### PR TITLE
Fixed issue #137 Whitespace before or after the IP address

### DIFF
--- a/src/renderer/components/Connect/LoginModal.tsx
+++ b/src/renderer/components/Connect/LoginModal.tsx
@@ -160,7 +160,7 @@ export default function LoginModal({
               onSubmit={(event: React.FormEvent<HTMLFormElement>) => {
                 event.preventDefault();
 
-                const server = event.currentTarget.elements[0].value.replace(/[\s\/]+/g, '');
+                const server = event.currentTarget.elements[0].value.trim().replace(/\/+$/, '');
                 const port = event.currentTarget.elements[1].value.replace(/[\s]+/g, '');
 
                 // eslint-disable-next-line prefer-template

--- a/src/renderer/components/Connect/LoginModal.tsx
+++ b/src/renderer/components/Connect/LoginModal.tsx
@@ -160,8 +160,8 @@ export default function LoginModal({
               onSubmit={(event: React.FormEvent<HTMLFormElement>) => {
                 event.preventDefault();
 
-                const server = event.currentTarget.elements[0].value;
-                const port = event.currentTarget.elements[1].value;
+                const server = event.currentTarget.elements[0].value.replace(/[\s\/]+/g, '');
+                const port = event.currentTarget.elements[1].value.replace(/[\s]+/g, '');
 
                 // eslint-disable-next-line prefer-template
                 const fullServer = 'http://' + server + ':' + port + '/';
@@ -177,7 +177,7 @@ export default function LoginModal({
                   <FormLabel>Server URL</FormLabel>
                   <Input autoFocus required placeholder="192.168.1.100" />
                   <FormHelperText>
-                    Do not include http:// in the URL or a / at the end
+                    Do not include http:// in the URL.
                   </FormHelperText>
                 </FormControl>
                 <FormControl>


### PR DESCRIPTION
Fixed issue #137 by removing trailing white space from both "Server URL" and "Server Port" inputs as well as trailing slashes from "Server URL" input on the "Connect to Remote Engine" modal.