### PR TITLE
UI fix - Moved Plugins

### DIFF
--- a/src/renderer/components/Nav/Sidebar.tsx
+++ b/src/renderer/components/Nav/Sidebar.tsx
@@ -193,13 +193,6 @@ export default function Sidebar({
           disabled={!experimentInfo?.name}
         />
         <SubNavItem
-          title="Plugins"
-          path="/projects/plugins"
-          icon={<PlugIcon />}
-          disabled={!experimentInfo?.name}
-          counter={outdatedPluginsCount}
-        />
-        <SubNavItem
           title="Settings"
           path="/projects/settings"
           icon={<SlidersIcon />}
@@ -214,6 +207,13 @@ export default function Sidebar({
           path="/zoo"
           icon={<BoxesIcon />}
           disabled={false}
+        />
+        <SubNavItem
+          title="Plugins"
+          path="/projects/plugins"
+          icon={<PlugIcon />}
+          disabled={!experimentInfo?.name}
+          counter={outdatedPluginsCount}
         />
         <SubNavItem
           title="Training Data"


### PR DESCRIPTION
Moved Plugins from top to bottom (under model zoo) in the left nav bar.