### PR TITLE
Allow setting a fixed folder from outside the Documents component.

### DIFF
--- a/src/renderer/components/Experiment/Rag/Documents.tsx
+++ b/src/renderer/components/Experiment/Rag/Documents.tsx
@@ -471,8 +471,9 @@ export default function Documents({
             <>
               <Link
                 onClick={() => {
-                  additionalMessage? setCurrentFolder('') :
-                  setCurrentFolder('rag');
+                  additionalMessage
+                    ? setCurrentFolder('')
+                    : setCurrentFolder('rag');
                 }}
               >
                 Documents /
@@ -712,6 +713,11 @@ export default function Documents({
                   </tr>
                 </thead>
                 <tbody>
+                  {rows?.status == 'error' && (
+                    <tr>
+                      <td colSpan={2}>{rows?.message}</td>
+                    </tr>
+                  )}
                   {rows?.length == 0 && (
                     <tr>
                       <td colSpan={2} style={{ padding: '2rem' }}>
@@ -745,7 +751,8 @@ export default function Documents({
       </Stack>
       {additionalMessage && (
         <Typography level="body-xs" mt={1}>
-          Documents for RAG should be uploaded in a folder called "rag" and only those will be indexed for RAG.
+          Documents for RAG should be uploaded in a folder called "rag" and only
+          those will be indexed for RAG.
         </Typography>
       )}
     </>

--- a/src/renderer/components/Experiment/Rag/Documents.tsx
+++ b/src/renderer/components/Experiment/Rag/Documents.tsx
@@ -140,6 +140,7 @@ export default function Documents({
   experimentInfo,
   fullPage = false,
   additionalMessage = false,
+  fixedFolder = '',
 }) {
   const [doc, setDoc] = React.useState<Doc>('desc');
   const [selected, setSelected] = React.useState<readonly string[]>([]);
@@ -154,13 +155,7 @@ export default function Documents({
 
   const [loading, setLoading] = React.useState(false);
 
-  const [currentFolder, setCurrentFolder] = React.useState('');
-
-  React.useEffect(() => {
-    if (!additionalMessage) {
-      setCurrentFolder('rag');
-    }
-  }, [additionalMessage]);
+  const [currentFolder, setCurrentFolder] = React.useState(fixedFolder);
 
   const {
     data: rows,
@@ -474,10 +469,9 @@ export default function Documents({
           ) : (
             <>
               <Link
+                disabled={fixedFolder !== ''}
                 onClick={() => {
-                  additionalMessage
-                    ? setCurrentFolder('')
-                    : setCurrentFolder('rag');
+                  setCurrentFolder('');
                 }}
               >
                 Documents /

--- a/src/renderer/components/Experiment/Rag/Documents.tsx
+++ b/src/renderer/components/Experiment/Rag/Documents.tsx
@@ -713,7 +713,7 @@ export default function Documents({
                 <tbody>
                   {rows?.status == 'error' && (
                     <tr>
-                      <td colSpan={2}>{rows?.message}</td>
+                      <td colSpan={2}>{/*rows?.message*/}</td>
                     </tr>
                   )}
                   {rows?.length == 0 && (

--- a/src/renderer/components/Experiment/Rag/Documents.tsx
+++ b/src/renderer/components/Experiment/Rag/Documents.tsx
@@ -405,6 +405,10 @@ export default function Documents({
       </FormControl>
     </React.Fragment>
   );
+
+  /****
+   * Main Documents Component is Here
+   */
   return (
     <>
       <Modal

--- a/src/renderer/components/Experiment/Rag/index.tsx
+++ b/src/renderer/components/Experiment/Rag/index.tsx
@@ -117,7 +117,7 @@ export default function DocumentSearch({ experimentInfo, setRagEngine }) {
             flexDirection: 'column',
           }}
         >
-          <Documents experimentInfo={experimentInfo} />
+          <Documents experimentInfo={experimentInfo} setFolder="rag" />
         </Box>
         <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <Query experimentInfo={experimentInfo} />

--- a/src/renderer/components/Experiment/Rag/index.tsx
+++ b/src/renderer/components/Experiment/Rag/index.tsx
@@ -117,7 +117,7 @@ export default function DocumentSearch({ experimentInfo, setRagEngine }) {
             flexDirection: 'column',
           }}
         >
-          <Documents experimentInfo={experimentInfo} setFolder="rag" />
+          <Documents experimentInfo={experimentInfo} fixedFolder="rag" />
         </Box>
         <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <Query experimentInfo={experimentInfo} />


### PR DESCRIPTION
Previously, we were doing magic to figure out if we should stay inside a specific folder. But the Documents component should not know about RAG -- it should be a generic documents explorer. So here we switch it so the fixing of a directory happens outside the documents component