### PR TITLE
Fixes coloured evals

### DIFF
--- a/src/renderer/components/Experiment/Eval/EvalJobsTable.tsx
+++ b/src/renderer/components/Experiment/Eval/EvalJobsTable.tsx
@@ -193,10 +193,10 @@ const EvalJobsTable = () => {
             level="body-sm"
             startDecorator={<ChartColumnIncreasingIcon size="20px" />}
             // Uncomment this line to enable the combined reports feature
-            onClick={handleCombinedReports}
-            // onClick={() => {
-            //   alert('this feature coming soon');
-            // }}
+            // onClick={handleCombinedReports}
+            onClick={() => {
+              alert('this feature coming soon');
+            }}
             sx={{ cursor: 'pointer' }}
           >
             <>Compare Selected Evals</>

--- a/src/renderer/components/Experiment/Eval/ViewCSVModal.tsx
+++ b/src/renderer/components/Experiment/Eval/ViewCSVModal.tsx
@@ -119,7 +119,6 @@ function formatScore(score) {
             // If no JSON string was found and there's exactly one key,
             // assume legacy format: { metricName: [score, modifier] }
             if (!jsonParsed && Object.keys(item).length === 1) {
-              console.log("item", item);
               metricName = Object.keys(item)[0];
               let score = item[metricName];
               parsedItem = [metricName, score[0], 1];
@@ -176,23 +175,47 @@ function formatScore(score) {
     );
   } else {
     // Handle a single score value.
-    const parsed = parseFloat(score);
-    if (!isNaN(parsed)) {
-      return (
-        <Box
-          sx={{
-            backgroundColor: heatedColor(parsed),
-            padding: "0 5px",
-            fontWeight: "normal",
-            flex: "1 0 0",
-            overflow: "hidden",
-          }}
-        >
-          {parsed.toFixed(5)}
-        </Box>
-      );
-    }
-    return score;
+
+// Check legacy format: { metricName: score }
+if (typeof score === "object" && score !== null && Object.keys(score).length === 1) {
+  const metricName = Object.keys(score)[0];
+  const rawScore = score[metricName];
+  const parsed = parseFloat(rawScore);
+  if (!isNaN(parsed)) {
+    return (
+      <Box
+        sx={{
+          backgroundColor: heatedColor(parsed),
+          padding: "0 5px",
+          fontWeight: "normal",
+          flex: "1 0 0",
+          overflow: "hidden",
+        }}
+      >
+        {`${metricName}: ${parsed.toFixed(5)}`}
+      </Box>
+    );
+  }
+  return JSON.stringify(score);
+}
+
+const parsed = parseFloat(score);
+if (!isNaN(parsed)) {
+  return (
+    <Box
+      sx={{
+        backgroundColor: heatedColor(parsed),
+        padding: "0 5px",
+        fontWeight: "normal",
+        flex: "1 0 0",
+        overflow: "hidden",
+      }}
+    >
+      {parsed.toFixed(5)}
+    </Box>
+  );
+}
+return score;
   }
 }
 

--- a/src/renderer/components/Experiment/Eval/ViewCSVModal.tsx
+++ b/src/renderer/components/Experiment/Eval/ViewCSVModal.tsx
@@ -147,6 +147,13 @@ function formatScore(score) {
                   fontWeight: "normal",
                   flex: "1 0 0",
                   overflow: "hidden",
+                  width: "100%",
+                  height: "100%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  border: "1px solid #ccc"
+
                 }}
               >
                 {metricName ? `${metricName}: ${parsed.toFixed(4)}` : parsed.toFixed(4)}
@@ -164,6 +171,12 @@ function formatScore(score) {
                   fontWeight: "normal",
                   flex: "1 0 0",
                   overflow: "hidden",
+                  width: "100%",
+                  height: "100%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  border: "1px solid #ccc",
                 }}
               >
                 {parsed.toFixed(5)}
@@ -190,6 +203,12 @@ if (typeof score === "object" && score !== null && Object.keys(score).length ===
           fontWeight: "normal",
           flex: "1 0 0",
           overflow: "hidden",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          border: "1px solid #ccc"
         }}
       >
         {`${metricName}: ${parsed.toFixed(5)}`}
@@ -209,6 +228,7 @@ if (!isNaN(parsed)) {
         fontWeight: "normal",
         flex: "1 0 0",
         overflow: "hidden",
+        border: "1px solid #ccc"
       }}
     >
       {parsed.toFixed(5)}

--- a/src/renderer/components/Experiment/Eval/ViewCSVModal.tsx
+++ b/src/renderer/components/Experiment/Eval/ViewCSVModal.tsx
@@ -235,7 +235,12 @@ if (!isNaN(parsed)) {
         fontWeight: "normal",
         flex: "1 0 0",
         overflow: "hidden",
-        border: "1px solid #ccc"
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        border: "1px solid #ccc",
       }}
     >
       {parsed.toFixed(5)}


### PR DESCRIPTION
- Add states for scores in detailed reports:
//  - If state is 0, no background colour is applied.
//  - If state is -1, colour is computed in reverse
//  - Otherwise, the normal colour pattern is applied.

- Switch off compare evals temporarily and show the coming soon screen instead just to avoid it going out in a release