### PR TITLE
Dataset Download Config Name

### DIFF
--- a/src/renderer/components/Data/LocalDatasets.tsx
+++ b/src/renderer/components/Data/LocalDatasets.tsx
@@ -43,6 +43,7 @@ export default function LocalDatasets() {
   const [searchText, setSearchText] = useState('');
   const [newDatasetModalOpen, setNewDatasetModalOpen] = useState(false);
   const [downloadingDataset, setDownloadingDataset] = useState(null);
+  const [showConfig, setShowConfig] = useState(false);
 
   const { data, error, isLoading, mutate } = useSWR(
     chatAPI.Endpoints.Dataset.LocalList(false),
@@ -153,16 +154,18 @@ export default function LocalDatasets() {
                 // Setting model_id text field to 70% of the width, as they are longer
                 sx={{ flex: 7 }}
               />
-              <Input
-                placeholder="Config name"
-                name="download-config-name"
-                // Setting config name text field to 30% of the width, as they are folder names
-                sx={{ flex: 3 }}
-              />
+              {showConfig && (
+                <Input
+                  placeholder="folder_name"
+                  name="download-config-name"
+                  // Setting config name text field to 30% of the width, as they are folder names
+                  sx={{ flex: 3 }}
+                />
+              )}
               <Button
                 onClick={async (e) => {
                   const dataset = document.getElementsByName('download-dataset-name')[0].value;
-                  const configName = document.getElementsByName('download-config-name')[0]?.value;
+                  const configName = showConfig? document.getElementsByName('download-config-name')[0]?.value : undefined;
                   // only download if valid model is entered
                   if (dataset) {
                     // this triggers UI changes while download is in progress
@@ -185,6 +188,10 @@ export default function LocalDatasets() {
                       })
                       .catch((error) => {
                         setDownloadingDataset(null);
+                        // Check if the error message asks for folder_name and automatically show the config field
+                        if (error.message.includes("folder_name")) {
+                          setShowConfig(true);
+                          }
                         alert('Download failed:\n' + error);
                       });
                   }

--- a/src/renderer/components/Data/LocalDatasets.tsx
+++ b/src/renderer/components/Data/LocalDatasets.tsx
@@ -150,19 +150,24 @@ export default function LocalDatasets() {
               <Input
                 placeholder="Open-Orca/OpenOrca"
                 name="download-dataset-name"
+                // Setting model_id text field to 70% of the width, as they are longer
                 sx={{ flex: 7 }}
               />
               <Input
                 placeholder="Config name"
                 name="download-config-name"
+                // Setting config name text field to 30% of the width, as they are folder names
                 sx={{ flex: 3 }}
               />
               <Button
                 onClick={async (e) => {
                   const dataset = document.getElementsByName('download-dataset-name')[0].value;
                   const configName = document.getElementsByName('download-config-name')[0]?.value;
+                  // only download if valid model is entered
                   if (dataset) {
+                    // this triggers UI changes while download is in progress
                     setDownloadingDataset(dataset);
+                    // Datasets can be very large so do this asynchronously
                     fetch(chatAPI.Endpoints.Dataset.Download(dataset, configName))
                       .then((response) => {
                         if (!response.ok) {

--- a/src/renderer/components/Data/LocalDatasets.tsx
+++ b/src/renderer/components/Data/LocalDatasets.tsx
@@ -175,6 +175,7 @@ export default function LocalDatasets() {
                       .then((response) => {
                         if (!response.ok) {
                           console.log(response);
+                          setShowConfig(false);
                           throw new Error(`HTTP Status: ${response.status}`);
                         }
                         return response.json();

--- a/src/renderer/components/Data/LocalDatasets.tsx
+++ b/src/renderer/components/Data/LocalDatasets.tsx
@@ -43,7 +43,7 @@ export default function LocalDatasets() {
   const [searchText, setSearchText] = useState('');
   const [newDatasetModalOpen, setNewDatasetModalOpen] = useState(false);
   const [downloadingDataset, setDownloadingDataset] = useState(null);
-  const [showConfig, setShowConfig] = useState(false);
+  const [showConfigNameField, setShowConfigNameField] = useState(false);
 
   const { data, error, isLoading, mutate } = useSWR(
     chatAPI.Endpoints.Dataset.LocalList(false),
@@ -154,10 +154,10 @@ export default function LocalDatasets() {
                 // Setting model_id text field to 70% of the width, as they are longer
                 sx={{ flex: 7 }}
               />
-              {showConfig && (
+              {showConfigNameField && (
                 <Input
                   placeholder="folder_name"
-                  name="download-config-name"
+                  name="dataset-config-name"
                   // Setting config name text field to 30% of the width, as they are folder names
                   sx={{ flex: 3 }}
                 />
@@ -165,7 +165,7 @@ export default function LocalDatasets() {
               <Button
                 onClick={async (e) => {
                   const dataset = document.getElementsByName('download-dataset-name')[0].value;
-                  const configName = showConfig? document.getElementsByName('download-config-name')[0]?.value : undefined;
+                  const configName = showConfigNameField? document.getElementsByName('dataset-config-name')[0]?.value : undefined;
                   // only download if valid model is entered
                   if (dataset) {
                     // this triggers UI changes while download is in progress
@@ -175,7 +175,7 @@ export default function LocalDatasets() {
                       .then((response) => {
                         if (!response.ok) {
                           console.log(response);
-                          setShowConfig(false);
+                          setshowConfigNameField(false);
                           throw new Error(`HTTP Status: ${response.status}`);
                         }
                         return response.json();
@@ -191,7 +191,7 @@ export default function LocalDatasets() {
                         setDownloadingDataset(null);
                         // Check if the error message asks for folder_name and automatically show the config field
                         if (error.message.includes("folder_name")) {
-                          setShowConfig(true);
+                          setshowConfigNameField(true);
                           }
                         alert('Download failed:\n' + error);
                       });

--- a/src/renderer/components/Data/LocalDatasets.tsx
+++ b/src/renderer/components/Data/LocalDatasets.tsx
@@ -145,57 +145,50 @@ export default function LocalDatasets() {
         }}
       >
         <>
-          <FormControl>
-            <Input
-              placeholder="Open-Orca/OpenOrca"
-              name="download-dataset-name"
-              endDecorator={
-                <Button
-                  onClick={async (e) => {
-                    const dataset = document.getElementsByName(
-                      'download-dataset-name'
-                    )[0].value;
-                    // only download if valid model is entered
-                    if (dataset) {
-                      // this triggers UI changes while download is in progress
-                      setDownloadingDataset(dataset);
-
-                      // Datasets can be very large so do this asynchronously
-                      fetch(chatAPI.Endpoints.Dataset.Download(dataset))
-                        .then((response) => {
-                          if (!response.ok) {
-                            console.log(response);
-                            throw new Error(`HTTP Status: ${response.status}`);
-                          }
-                          return response.json();
-                        })
-                        .then((response_json) => {
-                          if (response_json?.status == 'error') {
-                            throw new Error(response_json.message);
-                          }
-                          // now mutate:
-                          mutate();
-                          setDownloadingDataset(null);
-                        })
-                        .catch((error) => {
-                          setDownloadingDataset(null);
-                          alert('Download failed:\n' + error);
-                        });
-                    }
-                  }}
-                  startDecorator={
-                    downloadingDataset ? (
-                      <CircularProgress size="sm" thickness={2} />
-                    ) : (
-                      ''
-                    )
+        <FormControl>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+              <Input
+                placeholder="Open-Orca/OpenOrca"
+                name="download-dataset-name"
+                sx={{ flex: 7 }}
+              />
+              <Input
+                placeholder="Config name"
+                name="download-config-name"
+                sx={{ flex: 3 }}
+              />
+              <Button
+                onClick={async (e) => {
+                  const dataset = document.getElementsByName('download-dataset-name')[0].value;
+                  const configName = document.getElementsByName('download-config-name')[0]?.value;
+                  if (dataset) {
+                    setDownloadingDataset(dataset);
+                    fetch(chatAPI.Endpoints.Dataset.Download(dataset, configName))
+                      .then((response) => {
+                        if (!response.ok) {
+                          console.log(response);
+                          throw new Error(`HTTP Status: ${response.status}`);
+                        }
+                        return response.json();
+                      })
+                      .then((response_json) => {
+                        if (response_json?.status == 'error') {
+                          throw new Error(response_json.message);
+                        }
+                        mutate();
+                        setDownloadingDataset(null);
+                      })
+                      .catch((error) => {
+                        setDownloadingDataset(null);
+                        alert('Download failed:\n' + error);
+                      });
                   }
-                >
-                  {downloadingDataset ? 'Downloading' : 'Download 🤗 Dataset'}
-                </Button>
-              }
-              sx={{ width: '500px' }}
-            />
+                }}
+                startDecorator={downloadingDataset ? <CircularProgress size="sm" thickness={2} /> : ''}
+              >
+                {downloadingDataset ? 'Downloading' : 'Download 🤗 Dataset'}
+              </Button>
+            </Box>
           </FormControl>
           <>
             <Button

--- a/src/renderer/components/Data/LocalDatasets.tsx
+++ b/src/renderer/components/Data/LocalDatasets.tsx
@@ -175,7 +175,7 @@ export default function LocalDatasets() {
                       .then((response) => {
                         if (!response.ok) {
                           console.log(response);
-                          setshowConfigNameField(false);
+                          setShowConfigNameField(false);
                           throw new Error(`HTTP Status: ${response.status}`);
                         }
                         return response.json();
@@ -191,7 +191,7 @@ export default function LocalDatasets() {
                         setDownloadingDataset(null);
                         // Check if the error message asks for folder_name and automatically show the config field
                         if (error.message.includes("folder_name")) {
-                          setshowConfigNameField(true);
+                          setShowConfigNameField(true);
                           }
                         alert('Download failed:\n' + error);
                       });

--- a/src/renderer/lib/transformerlab-api-sdk.ts
+++ b/src/renderer/lib/transformerlab-api-sdk.ts
@@ -1048,8 +1048,8 @@ Endpoints.Dataset = {
   Delete: (datasetId: string) =>
     API_URL() + 'data/delete?dataset_id=' + datasetId,
   Create: (datasetId: string) => API_URL() + 'data/new?dataset_id=' + datasetId,
-  Download: (datasetId: string) =>
-    API_URL() + 'data/download?dataset_id=' + datasetId,
+  Download: (datasetId: string, configName?: string) =>
+    API_URL() + 'data/download?dataset_id=' + datasetId + (configName ? '&config_name=' + configName : ''),
   LocalList: (generated: boolean = true) => API_URL() + 'data/list?generated=' + generated,
   GeneratedList: () => API_URL() + 'data/generated_datasets_list',
   FileUpload: (datasetId: string) =>


### PR DESCRIPTION
#### Add:
- Dataset Config Name

#### Affecting:
- Download dataset, Retrieve Info about Dataset, Dataset json data saving to DB

#### Changes:
- Added an additional text field in the download dataset component to support dataset downloads for embedding model fine tuning.

#### Steps to test:

- Checkout the branch and start the application
- The latest model provenance API server should also be active
- Navigate to Datasets --> Local Datasets --> Try downloading any Embedding model fine tuning dataset using the name and config name (folder name under 'Files and version' section on Huggingface)   