### PR TITLE
Removing Restricted Logic for LoRA Train Type

### DIFF
--- a/src/renderer/components/Experiment/Train/LoRATrainingRunButton.tsx
+++ b/src/renderer/components/Experiment/Train/LoRATrainingRunButton.tsx
@@ -49,11 +49,16 @@ export default function LoRATrainingRunButton({
           return false;
         });
         let modelInLocalList = false;
+        if (model === "unknown")
+        {
+          modelInLocalList = true;
+        } else {
         models_downloaded.forEach(modelData => {
           if (modelData.model_id == model || modelData.local_path === model) {
             modelInLocalList = true;
           }
         });
+      }
 
         const datasets_downloaded = await fetch(
           chatAPI.Endpoints.Dataset.LocalList()

--- a/src/renderer/components/Experiment/Train/TrainLoRA.tsx
+++ b/src/renderer/components/Experiment/Train/TrainLoRA.tsx
@@ -232,7 +232,9 @@ export default function TrainLoRA({ experimentInfo }) {
                   }}
                   key={plugin.uniqueId}
                   disabled={
-                    !plugin.model_architectures?.includes(modelArchitecture)
+                    plugin.model_architectures
+                      ? !plugin.model_architectures.includes(modelArchitecture)
+                      : false
                   }
                 >
                   <ListItemDecorator>
@@ -244,7 +246,7 @@ export default function TrainLoRA({ experimentInfo }) {
                       level="body-xs"
                       sx={{ color: 'var(--joy-palette-neutral-400)' }}
                     >
-                      {!plugin.model_architectures?.includes(modelArchitecture)
+                      {plugin.model_architectures && !plugin.model_architectures.includes(modelArchitecture)
                         ? '(Does not support this model architecture)'
                         : ''}
                     </Typography>

--- a/src/renderer/components/Experiment/Train/TrainLoRA.tsx
+++ b/src/renderer/components/Experiment/Train/TrainLoRA.tsx
@@ -63,7 +63,7 @@ function formatTemplateConfig(config): ReactElement {
 
   const r = (
     <>
-      <b>Model:</b> {short_model_name} <br />
+      {short_model_name && (<><b>Model:</b> {short_model_name} <br /></>)}
       <b>Dataset:</b> {c.dataset_name} <FileTextIcon size={14} />
       <br />
       {/* <b>Adaptor:</b> {c.adaptor_name} <br /> */}

--- a/src/renderer/components/Experiment/Train/TrainingModalLoRA.tsx
+++ b/src/renderer/components/Experiment/Train/TrainingModalLoRA.tsx
@@ -69,6 +69,25 @@ export default function TrainingModalLoRA({
   const [nameInput, setNameInput] = useState('');
   const [currentTab, setCurrentTab] = useState(0);
 
+
+  // Fetch training type with useSWR
+  const { data: trainingTypeData } = useSWR(
+    experimentInfo?.id
+      ? chatAPI.Endpoints.Experiment.ScriptGetFile(experimentInfo.id, pluginId, 'index.json')
+      : null,
+    fetcher
+  );
+
+  let trainingType = "LoRA";
+  if (trainingTypeData && trainingTypeData !== "undefined" && trainingTypeData.length > 0) {
+
+  trainingType = JSON.parse(trainingTypeData)?.train_type || "LoRA";
+
+  }
+
+
+
+
   // Fetch available datasets from the API
   const {
     data: datasets,
@@ -252,7 +271,7 @@ export default function TrainingModalLoRA({
                 template_id,
                 event.currentTarget.elements['template_name'].value,
                 'Description',
-                'LoRA',
+                trainingType,
                 JSON.stringify(formJson)
               );
               templateMutate(); //Need to mutate template data after updating
@@ -260,7 +279,7 @@ export default function TrainingModalLoRA({
               chatAPI.saveTrainingTemplate(
                 event.currentTarget.elements['template_name'].value,
                 'Description',
-                'LoRA',
+                trainingType,
                 JSON.stringify(formJson)
               );
             }

--- a/src/renderer/components/Nav/Sidebar.tsx
+++ b/src/renderer/components/Nav/Sidebar.tsx
@@ -164,9 +164,7 @@ export default function Sidebar({
           title="Train"
           path="/projects/training"
           icon={<GraduationCapIcon />}
-          disabled={
-            !experimentInfo?.name || !experimentInfo?.config?.foundation
-          }
+          disabled={!experimentInfo?.name}
         />
         <SubNavItem
           title="Export"


### PR DESCRIPTION
- Set a train_type within the index.json, if not specified "LoRA" will be used, use that train type when creating and editing templates
- Remove restrictions from Train to be run without a foundation model
