### PR TITLE
Remove duplicate timestamp from below the eval name

### DIFF
--- a/src/renderer/components/Experiment/Eval/EvalJobsTable.tsx
+++ b/src/renderer/components/Experiment/Eval/EvalJobsTable.tsx
@@ -374,9 +374,6 @@ const EvalJobsTable = () => {
                   <Typography level="title-sm">
                     {job?.job_data?.plugin}
                   </Typography>
-                  <Typography level="body-sm">
-                    {getLocalTimeSinceEvent(job?.created_at)}
-                  </Typography>
                 </td>
                 <td>
                   <JobProgress job={job} />


### PR DESCRIPTION
- Making this change as all evals now add "start_time" and "end_time" and those are shown below the job progress in the middle column. 
- We should follow the start_time and end_time standard as that is how the Train tab does it as well.