### PR TITLE
Fix things broken by Tasks

### DIFF
--- a/src/renderer/components/Experiment/Eval/EvalModal.tsx
+++ b/src/renderer/components/Experiment/Eval/EvalModal.tsx
@@ -318,7 +318,7 @@ export default function EvalModal({
         formJson.run_name = formJson.template_name;
       }
       if (!formJson.predefined_tasks) {
-        formJson.predefined_tasks = formJson.tasks;
+        formJson.predefined_tasks = '';
       }
       formJson.script_parameters = JSON.parse(JSON.stringify(formJson));
 

--- a/src/renderer/components/Experiment/Train/TrainingModalLoRA.tsx
+++ b/src/renderer/components/Experiment/Train/TrainingModalLoRA.tsx
@@ -316,12 +316,32 @@ export default function TrainingModalLoRA({
             formJson.type = trainingType;
             if (templateData && task_id) {
               //Only update if we are currently editing a template
+              // For all keys in templateData.inputs that are in formJson, set the value from formJson
+              const templateDataInputs = JSON.parse(templateData.inputs);
+              const templateDataOutputs = JSON.parse(templateData.outputs);
+              for (const key in templateDataInputs) {
+                if (key in formJson && templateDataInputs[key] != formJson[key]) {
+                  console.log(key, formJson[key]);
+                  templateDataInputs[key] = formJson[key];
+                }
+              }
+              // For all keys in templateData.outputs that are in formJson, set the value from formJson
+              for (const key in templateDataOutputs) {
+                if (key in formJson && templateDataOutputs[key] != formJson[key]) {
+                  console.log(key, formJson[key]);
+                  templateDataOutputs[key] = formJson[key];
+                }
+              }
               updateTask(
                 task_id,
-                templateData.inputs,
+                JSON.stringify(templateDataInputs),
                 JSON.stringify(formJson),
-                templateData.outputs,
+                JSON.stringify(templateDataOutputs),
               );
+              console.log("Updated task with parameters", task_id);
+              console.log("Updated task with parameters", formJson);
+              console.log("Updated task with parameters", typeof templateData.inputs);
+              console.log("Updated task with parameters", typeof templateData.outputs);
               templateMutate(); //Need to mutate template data after updating
             } else {
               createNewTask(


### PR DESCRIPTION
- Fix importing recipes, so now using recipes would work with the new task format
- Fix Training Edit Task (Earlier we were not able to edit training tasks for models/datasets as it always used the old configs)
- Fix Eval Tasks Menu to not have weird commas or repeated names