### PR TITLE
fix: Import from folder says "Select File" and doesn't make it clear that you should select a directory.

### DIFF
--- a/src/renderer/components/ModelZoo/ImportModelsModal.tsx
+++ b/src/renderer/components/ModelZoo/ImportModelsModal.tsx
@@ -176,9 +176,20 @@ export default function ImportModelsModal({ open, setOpen }) {
                 }
               </div>
               <div>
+                <label htmlFor="modelFolderSelector">
+                  <Button
+                    component="span"
+                    size="sm"
+                    sx={{ height: '30px' }}
+                    variant="outlined"
+                  >
+                    Select Folder
+                  </Button>
+                </label>
                 <input
                   directory=""
                   webkitdirectory=""
+                  style={{display:'none'}}
                   type="file"
                   id="modelFolderSelector"
                   onChange={async (event: FormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
 fix #253
- Changed "Choose File" to "Select Folder" to more clearly indicate that users should select a directory, not a single file.

![image](https://github.com/user-attachments/assets/147f6b44-4def-4e5f-98fe-7697aa7f2d12)

- The file selection dialog still displays "Upload", which might be confusing. This seems to be controlled by the browser and not easily customizable. Open to suggestions if there's a better way to handle it.