### PR TITLE
Fixed dropdown dark mode background

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -223,7 +223,7 @@ textarea {
   border-radius: 3px;
   line-height: 1.5rem;
   height: 2rem;
-  background: #fff;
+  background: var(--joy-palette-background-level1);
   min-width: 200px;
   margin: 0 5px 5px 0;
   font-size: 14px;


### PR DESCRIPTION
Under 'Export Settings' while in dark mode, dropdown menu text was not visible since background stayed white.