### PR TITLE
Fix Local Models Download bar, inference destructuring and experimental plugin card overflows

### DIFF
--- a/src/renderer/components/Experiment/Foundation/RunModelButton.tsx
+++ b/src/renderer/components/Experiment/Foundation/RunModelButton.tsx
@@ -73,13 +73,16 @@ export default function RunModelButton({
         'inferenceParams',
         JSON.stringify({
           ...inferenceSettings,
-          inferenceEngine: engine,
-          inferenceEngineFriendlyName: inferenceEngineFriendlyName,
+          inferenceEngine: engine || null,
+          inferenceEngineFriendlyName: inferenceEngineFriendlyName || null,
         }),
       ),
     );
 
-    return inferenceEnginesJSON?.[0]?.uniqueId;
+    return {
+      inferenceEngine: engine || null,
+      inferenceEngineFriendlyName: inferenceEngineFriendlyName || null,
+    };
   }
 
   // Set a default inference Engine if there is none
@@ -94,8 +97,8 @@ export default function RunModelButton({
         const { inferenceEngine, inferenceEngineFriendlyName } =
           await getDefaultinferenceEngines();
         setInferenceSettings({
-          inferenceEngine: inferenceEngine,
-          inferenceEngineFriendlyName: inferenceEngineFriendlyName,
+          inferenceEngine: inferenceEngine || null,
+          inferenceEngineFriendlyName: inferenceEngineFriendlyName || null,
         });
       })();
     } else {

--- a/src/renderer/components/ModelZoo/LocalModels.tsx
+++ b/src/renderer/components/ModelZoo/LocalModels.tsx
@@ -115,8 +115,6 @@ export default function LocalModels({
         setAdaptor={setAdaptor}
         showOnlyGeneratedModels={showOnlyGeneratedModels}
       />
-
-      <ImportModelsBar />
     </Sheet>
   );
 }

--- a/src/renderer/components/Plugins/PluginCard.tsx
+++ b/src/renderer/components/Plugins/PluginCard.tsx
@@ -172,6 +172,19 @@ export default function PluginCard({
                     mt: 1,
                     backgroundColor: 'warning.softBg',
                     color: 'warning.700',
+                    maxWidth: 160,
+                    whiteSpace: 'normal',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    wordBreak: 'break-word',
+                    fontSize: '0.75rem',
+                    lineHeight: 1.2,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    textAlign: 'center',
+                    minHeight: 32,
+                    px: 1.5,
                   }}
                 >
                   This is an experimental plugin


### PR DESCRIPTION
Fixes 3 minor bugs:
- The download bar at the bottom of the LocalModels tab in Model Zoo breaks every time we use it. Removed the bar as we have a link to Model Zoo on the same page.
- Whenever you create a new experiment and select a model without downloading an inference engine, it shows an error because of a function wrongly being called. This is an edge case
- Fixes experimental plugin card overflows