### PR TITLE
Model architecture override

### DIFF
--- a/src/renderer/components/Experiment/Foundation/InferenceEngineModal.tsx
+++ b/src/renderer/components/Experiment/Foundation/InferenceEngineModal.tsx
@@ -1,6 +1,5 @@
 import {
   DialogTitle,
-  FormControl,
   FormLabel,
   Modal,
   ModalClose,
@@ -61,37 +60,40 @@ function EngineSelect({
         label="Show unsupported engines"
       />
 
-      <FormControl>
-        <FormLabel>Engine</FormLabel>
-        <Select
-          placeholder={isLoading ? 'Loading...' : 'Select Engine'}
-          variant="soft"
-          size="lg"
-          name="inferenceEngine"
-          onChange={(e, newValue) => {
-            setSelectedPlugin(newValue);
-          }}
-        >
-          {supported?.length > 0 &&
-            supported.map((row) => (
+      <Select
+        placeholder={isLoading ? 'Loading...' : 'Select Engine'}
+        variant="soft"
+        size="lg"
+        name="inferenceEngine"
+        defaultValue="Select Engine"
+        onChange={(e, newValue) => {
+          setSelectedPlugin(newValue);
+        }}
+      >
+        {supported?.length > 0 && (
+          <>
+            {supported.map((row) => (
               <Option value={row.uniqueId} key={row.uniqueId}>
                 {row.name}
               </Option>
             ))}
+          </>
+        )}
 
-          {showUnsupported &&
-            unsupported?.length > 0 &&
-            unsupported.map((row) => (
+        {showUnsupported && unsupported?.length > 0 && (
+          <>
+            <Option disabled>── Unsupported ──</Option>
+            {unsupported.map((row) => (
               <Option value={row.uniqueId} key={row.uniqueId}>
                 {row.name}
               </Option>
             ))}
-        </Select>
-      </FormControl>
+          </>
+        )}
+      </Select>
     </Stack>
   );
 }
-
 
 export default function InferenceEngineModal({
   showModal,
@@ -102,8 +104,6 @@ export default function InferenceEngineModal({
 }) {
   const [selectedPlugin, setSelectedPlugin] = useState(null);
 
-  // Call this on either cancel or save, but only after any changes are saved
-  // It resets the selected plugin to whatever the saved experiment settings are (overwriting whatever the user selected)
   function closeModal() {
     setShowModal(false);
     setSelectedPlugin(inferenceSettings?.inferenceEngine);
@@ -115,7 +115,6 @@ export default function InferenceEngineModal({
         <DialogTitle>Inference Engine Settings</DialogTitle>
         <ModalClose variant="plain" sx={{ m: 1 }} />
 
-        {/* <DialogContent>Fill in the information of the project.</DialogContent> */}
         <form
           onSubmit={async (event: React.FormEvent<HTMLFormElement>) => {
             event.preventDefault();
@@ -126,10 +125,9 @@ export default function InferenceEngineModal({
 
             if (!engine) {
               closeModal();
+              return;
             }
 
-            // We don't want to go to the server to get the friendly name of the server
-            // so we dig into the DOM to get it
             const engineFriendlyName = document.querySelector(
               `button[name='inferenceEngine']`,
             )?.innerHTML;
@@ -153,27 +151,27 @@ export default function InferenceEngineModal({
                 JSON.stringify(newInferenceSettings),
               ),
             );
+
             closeModal();
           }}
         >
-          <Stack spacing={0}>
-            {/* {JSON.stringify(inferenceSettings)} */}
-            <FormControl>
-              <FormLabel>Engine</FormLabel>
-              <EngineSelect
-                experimentInfo={experimentInfo}
-                inferenceSettings={inferenceSettings}
-                setSelectedPlugin={setSelectedPlugin}
-              />
-            </FormControl>
+          <Stack spacing={2}>
+            <FormLabel>Engine</FormLabel>
+            <EngineSelect
+              experimentInfo={experimentInfo}
+              inferenceSettings={inferenceSettings}
+              setSelectedPlugin={setSelectedPlugin}
+            />
 
             <Typography level="title-md" paddingTop={2}>
               Engine Configuration:
             </Typography>
+
             <DynamicPluginForm
               experimentInfo={experimentInfo}
               plugin={selectedPlugin}
             />
+
             <Button type="submit">Save</Button>
           </Stack>
         </form>

--- a/src/renderer/components/Experiment/Foundation/InferenceEngineModal.tsx
+++ b/src/renderer/components/Experiment/Foundation/InferenceEngineModal.tsx
@@ -1,5 +1,6 @@
 import {
   DialogTitle,
+  FormControl,
   FormLabel,
   Modal,
   ModalClose,
@@ -95,6 +96,8 @@ function EngineSelect({
   );
 }
 
+
+
 export default function InferenceEngineModal({
   showModal,
   setShowModal,
@@ -104,6 +107,8 @@ export default function InferenceEngineModal({
 }) {
   const [selectedPlugin, setSelectedPlugin] = useState(null);
 
+  // Call this on either cancel or save, but only after any changes are saved
+  // It resets the selected plugin to whatever the saved experiment settings are (overwriting whatever the user selected)
   function closeModal() {
     setShowModal(false);
     setSelectedPlugin(inferenceSettings?.inferenceEngine);
@@ -111,10 +116,14 @@ export default function InferenceEngineModal({
 
   return (
     <Modal open={showModal} onClose={closeModal}>
-      <ModalDialog>
+      <ModalDialog sx={{
+    minWidth: 300,   //set this to ensure all options are clickable despite CSS issues.
+    minHeight: 440,  
+  }}>
         <DialogTitle>Inference Engine Settings</DialogTitle>
         <ModalClose variant="plain" sx={{ m: 1 }} />
 
+        {/* <DialogContent>Fill in the information of the project.</DialogContent> */}
         <form
           onSubmit={async (event: React.FormEvent<HTMLFormElement>) => {
             event.preventDefault();
@@ -125,9 +134,10 @@ export default function InferenceEngineModal({
 
             if (!engine) {
               closeModal();
-              return;
             }
 
+            // We don't want to go to the server to get the friendly name of the server
+            // so we dig into the DOM to get it
             const engineFriendlyName = document.querySelector(
               `button[name='inferenceEngine']`,
             )?.innerHTML;
@@ -151,27 +161,27 @@ export default function InferenceEngineModal({
                 JSON.stringify(newInferenceSettings),
               ),
             );
-
             closeModal();
           }}
         >
-          <Stack spacing={2}>
-            <FormLabel>Engine</FormLabel>
-            <EngineSelect
-              experimentInfo={experimentInfo}
-              inferenceSettings={inferenceSettings}
-              setSelectedPlugin={setSelectedPlugin}
-            />
+          <Stack spacing={0}>
+            {/* {JSON.stringify(inferenceSettings)} */}
+            <FormControl>
+              <FormLabel>Engine</FormLabel>
+              <EngineSelect
+                experimentInfo={experimentInfo}
+                inferenceSettings={inferenceSettings}
+                setSelectedPlugin={setSelectedPlugin}
+              />
+            </FormControl>
 
             <Typography level="title-md" paddingTop={2}>
               Engine Configuration:
             </Typography>
-
             <DynamicPluginForm
               experimentInfo={experimentInfo}
               plugin={selectedPlugin}
             />
-
             <Button type="submit">Save</Button>
           </Stack>
         </form>

--- a/src/renderer/components/Experiment/Foundation/RunModelButton.tsx
+++ b/src/renderer/components/Experiment/Foundation/RunModelButton.tsx
@@ -49,7 +49,7 @@ export default function RunModelButton({
     return (
       experimentInfo != null &&
       experimentInfo?.config?.foundation !== '' &&
-      inferenceSettings?.inferenceEngine != null
+      // inferenceSettings?.inferenceEngine != null
     );
   }
 

--- a/src/renderer/components/Experiment/Foundation/RunModelButton.tsx
+++ b/src/renderer/components/Experiment/Foundation/RunModelButton.tsx
@@ -48,7 +48,7 @@ export default function RunModelButton({
     // console.log(inferenceSettings);
     return (
       experimentInfo != null &&
-      experimentInfo?.config?.foundation !== '' &&
+      experimentInfo?.config?.foundation !== ''
       // inferenceSettings?.inferenceEngine != null
     );
   }


### PR DESCRIPTION
I created this small PR now and will continue with the next steps afterward
Based on the Notion task this PR is related to:

- ~~STEP 1: Disable check for model architecture on Run button~~
- ~~STEP 2: Remove architecture for model you are testing with from server supported architecture~~
- ~~STEP 2’: show the unsupported server for that architecture~~
- ~~STEP 3: Test Debug trying to run that model, and make any fixes~~
- ~~STEP 4: Undo Steps 1 and 2~~
- I~~MPLEMENT!~~
    - ~~Add checkbox to server plugin select to allow showing Unsupported~~
        - ~~Updates list to include unsupported~~
        - 