### PR TITLE
Fix errors showing up in console from Import Models modal

### DIFF
--- a/src/renderer/components/ModelZoo/ImportModelsModal.tsx
+++ b/src/renderer/components/ModelZoo/ImportModelsModal.tsx
@@ -158,20 +158,13 @@ export default function ImportModelsModal({ open, setOpen }) {
                   value={modelFolder ? modelFolder.toString() : "(none)"}
                 />
                 {modelFolder
-                  ? <Button
+                  && <Button
                     size="sm"
                     sx={{ height: '30px' }}
                     variant="plain"
                     disabled={modelFolder == ""}
                     startDecorator={<FolderXIcon />}
                     onClick={() => setModelFolder("")}
-                  />
-                  : <Button
-                    size="sm"
-                    sx={{ height: '30px' }}
-                    variant="plain"
-                    disabled={modelFolder}
-                    startDecorator={<FolderPlusIcon />}
                   />
                 }
               </div>

--- a/src/renderer/components/ModelZoo/ImportModelsModal.tsx
+++ b/src/renderer/components/ModelZoo/ImportModelsModal.tsx
@@ -331,7 +331,7 @@ export default function ImportModelsModal({ open, setOpen }) {
             <Button
               variant="soft"
               type="submit"
-              disabled={models?.length == 0 && importing}
+              disabled={importing || isLoading || models?.length == 0}
               startDecorator={
                 importing
                   ? <CircularProgress />


### PR DESCRIPTION
This isn't fixing the problem where it spins forever if you have a lot in your cache.

The bug was that we were getting an error in the sidebar complaining about the disabled property being a string.  Also the import button was enabled while the modal was loading.