### PR TITLE
Added runs reload when switching experiments

### DIFF
--- a/src/renderer/components/Experiment/Workflows/WorkflowRuns/WorkflowRuns.tsx
+++ b/src/renderer/components/Experiment/Workflows/WorkflowRuns/WorkflowRuns.tsx
@@ -126,7 +126,7 @@ export default function WorkflowRuns({ experimentInfo }) {
           setSelectedWorkflowRun={setSelectedWorkflowRun}
         />
       </Box>
-      <Box flex="3">
+      <Box flex="3" sx={{}}>
         <ShowSelectedWorkflowRun selectedWorkflowRun={selectedWorkflowRun} experimentInfo={experimentInfo} />
       </Box>
     </Sheet>


### PR DESCRIPTION
Response to https://github.com/transformerlab/transformerlab-app/issues/547

Whenever you would switch experiments from the Workflow Runs tab, the frontend would crash because it would attempt to retrieve the previous experiment's workflow runs from the API, which do not belong to the current experiment. My fix is if it is not the initial load, it reloads the runs for the current experiment.