### PR TITLE
Show error message for diffusion when the image height and width is not divisible by 8

### DIFF
--- a/src/renderer/components/Experiment/Diffusion/Diffusion.tsx
+++ b/src/renderer/components/Experiment/Diffusion/Diffusion.tsx
@@ -506,15 +506,7 @@ export default function Diffusion({ experimentInfo }: DiffusionProps) {
       const data = await response.json();
 
       if (data.error_code !== 0) {
-        // Only show data.detail if data.detail has these words - `height` and `width` have to be divisible by
-        if (
-          data.detail &&
-          data.detail.includes('`height` and `width` have to be divisible by')
-        ) {
-          setError(data.detail);
-        } else {
-          setError('Error generating image');
-        }
+        setError(data.detail);
         // Stop polling on error
         if (pollingCleanupRef.current) pollingCleanupRef.current();
         pollingCleanupRef.current = null;
@@ -604,7 +596,7 @@ export default function Diffusion({ experimentInfo }: DiffusionProps) {
       });
       const data = await response.json();
       if (data.error_code !== 0) {
-        setError('Error generating image');
+        setError(data.detail || 'Error generating inpainting image');
       } else {
         // Fetch all generated images
         const imageUrls: string[] = [];


### PR DESCRIPTION
Fixes #616 
This is a known issue with SD models: https://forums.fast.ai/t/height-and-width-of-images-must-to-be-divisible-by-8/101069/3