### PR TITLE
Dont install a plugin if no experiment is selected

### DIFF
--- a/src/renderer/components/Plugins/PluginCard.tsx
+++ b/src/renderer/components/Plugins/PluginCard.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 
 import { colorArray, mixColorWithBackground } from 'renderer/lib/utils';
 import ShowArchitectures from '../Shared/ListArchitectures';
+import { useNotification } from '../Shared/NotificationSystem';
 
 const fetcher = (url) => fetch(url).then((res) => res.json());
 
@@ -56,6 +57,7 @@ export default function PluginCard({
   isExperimental = false,
 }) {
   const [installing, setInstalling] = useState(null);
+  const { addNotification } = useNotification();
 
   // eslint-disable-next-line react/no-unstable-nested-components
   function WillThisPluginWorkOnMyMachine({ pluginArchitectures, machineType }) {
@@ -264,9 +266,11 @@ export default function PluginCard({
                   experimentInfo?.id === '' ||
                   experimentInfo?.id === 'undefined'
                 ) {
-                  alert(
-                    'Error: No experiment selected. Please select an experiment before installing plugins.',
-                  );
+                  addNotification({
+                    type: 'danger',
+                    message:
+                      'Error: No experiment selected. Please select an experiment before installing plugins.',
+                  });
                   return;
                 }
 
@@ -289,9 +293,11 @@ export default function PluginCard({
                       }
                     }
                   } else {
-                    alert(
-                      'Error: The API did not return a response. Plugin installation failed.',
-                    );
+                    addNotification({
+                      type: 'danger',
+                      message:
+                        'Error: The API did not return a response. Plugin installation failed.',
+                    });
                   }
                 });
                 setInstalling(null);

--- a/src/renderer/components/Plugins/PluginCard.tsx
+++ b/src/renderer/components/Plugins/PluginCard.tsx
@@ -258,6 +258,18 @@ export default function PluginCard({
                 )
               }
               onClick={async () => {
+                if (
+                  experimentInfo?.id === null ||
+                  experimentInfo?.id === undefined ||
+                  experimentInfo?.id === '' ||
+                  experimentInfo?.id === 'undefined'
+                ) {
+                  alert(
+                    'Error: No experiment selected. Please select an experiment before installing plugins.',
+                  );
+                  return;
+                }
+
                 setInstalling(plugin.uniqueId);
                 await fetch(
                   chatAPI.Endpoints.Experiment.InstallPlugin(


### PR DESCRIPTION
- Currently we allow a user to go to plugins and click on install and then it throws an error saying "Check your API connection" which is wrong. 
- Change two alerts to notifications instead