### PR TITLE
Fix: added reset system prompt button in "All Generation Settings"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ npm-debug.log.*
 *.css.d.ts
 *.sass.d.ts
 *.scss.d.ts
+
+# Developer tools
+.cursorignore
+.cursor

--- a/src/renderer/components/Experiment/Interact/SystemMessageBox.tsx
+++ b/src/renderer/components/Experiment/Interact/SystemMessageBox.tsx
@@ -6,8 +6,10 @@ import {
   FormLabel,
   Sheet,
   Textarea,
+  Box,
 } from '@mui/joy';
 import { useEffect, useState } from 'react';
+import { RotateCcwIcon } from 'lucide-react';
 
 import * as chatAPI from '../../../lib/transformerlab-api-sdk';
 import SafeJSONParse from '../../Shared/SafeJSONParse';
@@ -203,15 +205,23 @@ export default function SystemMessageBox({
 
   return (
     <div>
-      <FormLabel
-        sx={{
-          justifyContent: 'space-between',
-          width: '100%',
-          marginBottom: '3px',
-        }}
-      >
-        <span>System message</span>
-      </FormLabel>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '3px' }}>
+        <FormLabel>System message</FormLabel>
+        {isOverrideEnabled && (
+          <Button
+            variant="plain"
+            size="sm"
+            onClick={() => {
+              setCustomSystemMessage(defaultPromptConfigForModel?.system_message || '');
+              setHasEdited(true);
+            }}
+            startDecorator={<RotateCcwIcon size={14} />}
+            sx={{ '--Button-gap': '4px', fontSize: '0.75rem', padding: '2px 8px' }}
+          >
+            Reset to Default
+          </Button>
+        )}
+      </Box>
 
       <Sheet
         variant="outlined"


### PR DESCRIPTION
I added a reset button for the system prompt.
I also added .cursorignore and .cursor to .gitignore

This PR is related to Issue #690.
<img width="1422" height="887" alt="Screenshot 2025-07-22 at 3 13 41 PM" src="https://github.com/user-attachments/assets/90203475-a038-4cbb-a11b-a275d64d3e12" />
<img width="1422" height="887" alt="Screenshot 2025-07-22 at 3 14 12 PM" src="https://github.com/user-attachments/assets/211f2dd4-3099-4877-ab2d-b92bf74b43b8" />
