### PR TITLE
Fix diffusion calls to also include experiment id

### DIFF
--- a/src/renderer/components/Experiment/Diffusion/ControlNetModal.tsx
+++ b/src/renderer/components/Experiment/Diffusion/ControlNetModal.tsx
@@ -14,6 +14,7 @@ import {
 import { DownloadIcon, TrashIcon, X } from 'lucide-react';
 import * as chatAPI from 'renderer/lib/transformerlab-api-sdk';
 import { getAPIFullPath } from 'renderer/lib/transformerlab-api-sdk';
+import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
 
 export default function ControlNetModal({
   open,
@@ -22,11 +23,12 @@ export default function ControlNetModal({
   onSelect,
 }) {
   const [controlNets, setControlNets] = useState<string[]>([]);
+  const { experimentId } = useExperimentInfo();
 
   const refresh = async () => {
     try {
       const response = await fetch(
-        getAPIFullPath('diffusion', ['listControlnets'], {}),
+        getAPIFullPath('diffusion', ['listControlnets'], { experimentId }),
       );
       const models = await response.json();
       const names = (models.controlnets || []).map(

--- a/src/renderer/components/Experiment/Diffusion/Diffusion.tsx
+++ b/src/renderer/components/Experiment/Diffusion/Diffusion.tsx
@@ -56,6 +56,7 @@ type DiffusionProps = {
   experimentInfo: any;
 };
 import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
+import { useNotification } from 'renderer/components/Shared/NotificationSystem';
 
 // Helper component for labels with tooltips
 const LabelWithTooltip = ({
@@ -111,6 +112,7 @@ const samplePrompts = [
 
 export default function Diffusion() {
   const { experimentInfo } = useExperimentInfo();
+  const { addNotification } = useNotification();
   const analytics = useAnalytics();
   const { data: diffusionJobs } = useAPI(
     'jobs',

--- a/src/renderer/components/Experiment/Diffusion/History.tsx
+++ b/src/renderer/components/Experiment/Diffusion/History.tsx
@@ -31,6 +31,7 @@ import {
   ChevronRightIcon,
 } from 'lucide-react';
 import { getAPIFullPath, useAPI } from 'renderer/lib/transformerlab-api-sdk';
+import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
 import HistoryCard from './HistoryCard';
 import HistoryImageViewModal from './HistoryImageViewModal';
 import { HistoryImage } from './types';
@@ -42,12 +43,17 @@ const History: React.FC<HistoryProps> = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 12; // Number of items per page
   const offset = (currentPage - 1) * pageSize;
+  const { experimentId } = useExperimentInfo();
 
   const {
     data: historyData,
     isLoading: historyLoading,
     mutate: refreshHistory,
-  } = useAPI('diffusion', ['getHistory'], { limit: pageSize, offset });
+  } = useAPI('diffusion', ['getHistory'], {
+    experimentId,
+    limit: pageSize,
+    offset,
+  });
 
   // Calculate pagination info
   const totalPages = historyData?.total
@@ -91,7 +97,10 @@ const History: React.FC<HistoryProps> = () => {
   const viewImage = async (imageId: string) => {
     try {
       const response = await fetch(
-        getAPIFullPath('diffusion', ['getImageInfo'], { imageId }),
+        getAPIFullPath('diffusion', ['getImageInfo'], {
+          imageId,
+          experimentId,
+        }),
       );
       const data = await response.json();
       setSelectedImage(data);
@@ -104,9 +113,15 @@ const History: React.FC<HistoryProps> = () => {
   // Delete single image
   const deleteImage = async (imageId: string) => {
     try {
-      await fetch(getAPIFullPath('diffusion', ['deleteImage'], { imageId }), {
-        method: 'DELETE',
-      });
+      await fetch(
+        getAPIFullPath('diffusion', ['deleteImage'], {
+          imageId,
+          experimentId,
+        }),
+        {
+          method: 'DELETE',
+        },
+      );
       refreshHistory(); // Reload history
       setDeleteConfirmOpen(false);
       setImageToDelete(null);
@@ -128,9 +143,15 @@ const History: React.FC<HistoryProps> = () => {
       // Delete all selected images
       await Promise.all(
         Array.from(selectedImages).map((imageId) =>
-          fetch(getAPIFullPath('diffusion', ['deleteImage'], { imageId }), {
-            method: 'DELETE',
-          }),
+          fetch(
+            getAPIFullPath('diffusion', ['deleteImage'], {
+              imageId,
+              experimentId,
+            }),
+            {
+              method: 'DELETE',
+            },
+          ),
         ),
       );
       refreshHistory(); // Reload history
@@ -152,9 +173,14 @@ const History: React.FC<HistoryProps> = () => {
   // Clear all history
   const clearAllHistory = async () => {
     try {
-      await fetch(getAPIFullPath('diffusion', ['clearHistory'], {}), {
-        method: 'DELETE',
-      });
+      await fetch(
+        getAPIFullPath('diffusion', ['clearHistory'], {
+          experimentId,
+        }),
+        {
+          method: 'DELETE',
+        },
+      );
       refreshHistory(); // Reload history
     } catch (e) {
       // Error clearing history
@@ -199,7 +225,9 @@ const History: React.FC<HistoryProps> = () => {
 
     try {
       const response = await fetch(
-        getAPIFullPath('diffusion', ['createDataset'], {}),
+        getAPIFullPath('diffusion', ['createDataset'], {
+          experimentId,
+        }),
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/renderer/components/Experiment/Diffusion/HistoryCard.tsx
+++ b/src/renderer/components/Experiment/Diffusion/HistoryCard.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/joy';
 import { Trash2Icon } from 'lucide-react';
 import { getAPIFullPath } from 'renderer/lib/transformerlab-api-sdk';
+import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
 import { HistoryImage } from './types';
 
 interface HistoryCardProps {
@@ -34,6 +35,7 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
 }) => {
   const numImages = item.num_images || item.metadata?.num_images || 1;
   const hasMultipleImages = numImages > 1;
+  const { experimentId } = useExperimentInfo();
 
   // Function to render multiple images in a grid
   const renderImages = () => {
@@ -58,6 +60,7 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
               src={getAPIFullPath('diffusion', ['getImage'], {
                 imageId: item.id,
                 index,
+                experimentId,
               })}
               alt={`Generated image ${index + 1}`}
               style={{
@@ -96,6 +99,7 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
           src={getAPIFullPath('diffusion', ['getImage'], {
             imageId: item.id,
             index: 0,
+            experimentId,
           })}
           alt="generated"
           style={{

--- a/src/renderer/components/Experiment/Diffusion/HistoryImageSelector.tsx
+++ b/src/renderer/components/Experiment/Diffusion/HistoryImageSelector.tsx
@@ -16,6 +16,7 @@ import {
   CardOverflow,
   AspectRatio,
 } from '@mui/joy';
+import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
 import { ChevronLeftIcon, ChevronRightIcon, CheckIcon } from 'lucide-react';
 import { getAPIFullPath, useAPI } from 'renderer/lib/transformerlab-api-sdk';
 import { HistoryImage } from './types';
@@ -36,11 +37,12 @@ const HistoryImageSelector: React.FC<HistoryImageSelectorProps> = ({
   const [selectedImageIndex, setSelectedImageIndex] = useState<number>(0);
   const pageSize = 12;
   const offset = (currentPage - 1) * pageSize;
+  const { experimentId } = useExperimentInfo();
 
   const { data: historyData, isLoading: historyLoading } = useAPI(
     'diffusion',
     ['getHistory'],
-    { limit: pageSize, offset },
+    { experimentId, limit: pageSize, offset },
   );
 
   // Reset selection when changing pages
@@ -63,6 +65,7 @@ const HistoryImageSelector: React.FC<HistoryImageSelectorProps> = ({
         getAPIFullPath('diffusion', ['getImage'], {
           imageId: selectedImageId,
           index: selectedImageIndex,
+          experimentId,
         }),
       );
 
@@ -112,6 +115,7 @@ const HistoryImageSelector: React.FC<HistoryImageSelectorProps> = ({
               src={getAPIFullPath('diffusion', ['getImage'], {
                 imageId: item.id,
                 index: displayIndex,
+                experimentId,
               })}
               alt={item.prompt}
               style={{ objectFit: 'cover' }}

--- a/src/renderer/components/Experiment/Diffusion/HistoryImageViewModal.tsx
+++ b/src/renderer/components/Experiment/Diffusion/HistoryImageViewModal.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 import React, { useState, useEffect } from 'react';
 import { getAPIFullPath } from 'renderer/lib/transformerlab-api-sdk';
+import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
 import { HistoryImage } from './types';
 
 export default function HistoryImageViewModal({
@@ -37,6 +38,7 @@ export default function HistoryImageViewModal({
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [imageUrls, setImageUrls] = useState<string[]>([]);
   const [numImages, setNumImages] = useState(1);
+  const { experimentId } = useExperimentInfo();
   // const [hoveringMainImage, setHoveringMainImage] = useState(false);
 
   // Load all images for the selected item when modal opens
@@ -52,6 +54,7 @@ export default function HistoryImageViewModal({
         getAPIFullPath('diffusion', ['getImage'], {
           imageId: selectedImage.id,
           index,
+          experimentId,
         }),
       );
 
@@ -61,6 +64,7 @@ export default function HistoryImageViewModal({
           urls.push(
             getAPIFullPath('diffusion', ['getInputImage'], {
               imageId: selectedImage.id,
+              experimentId,
             }),
           );
         }
@@ -70,6 +74,7 @@ export default function HistoryImageViewModal({
             getAPIFullPath('diffusion', ['getProcessedImage'], {
               imageId: selectedImage.id,
               processed: true,
+              experimentId,
             }),
           );
         }
@@ -95,6 +100,7 @@ export default function HistoryImageViewModal({
       const link = document.createElement('a');
       link.href = getAPIFullPath('diffusion', ['getAllImages'], {
         imageId: selectedImage.id,
+        experimentId,
       });
 
       // Generate filename with timestamp
@@ -208,6 +214,7 @@ export default function HistoryImageViewModal({
                       getAPIFullPath('diffusion', ['getImage'], {
                         imageId: selectedImage?.id,
                         index: currentImageIndex,
+                        experimentId,
                       })
                     }
                     alt="Generated"
@@ -231,6 +238,7 @@ export default function HistoryImageViewModal({
                         <img
                           src={getAPIFullPath('diffusion', ['getInputImage'], {
                             imageId: selectedImage?.id,
+                            experimentId,
                           })}
                           alt="Input"
                           style={{
@@ -341,6 +349,7 @@ export default function HistoryImageViewModal({
                               ['getInputImage'],
                               {
                                 imageId: selectedImage?.id,
+                                experimentId,
                               },
                             )}
                             alt="Input"
@@ -379,6 +388,7 @@ export default function HistoryImageViewModal({
                               ['getInputImage'],
                               {
                                 imageId: selectedImage?.id,
+                                experimentId,
                               },
                             )}
                             alt="Input"
@@ -414,6 +424,7 @@ export default function HistoryImageViewModal({
                           <img
                             src={getAPIFullPath('diffusion', ['getMaskImage'], {
                               imageId: selectedImage?.id,
+                              experimentId,
                             })}
                             alt="Mask"
                             style={{
@@ -443,6 +454,7 @@ export default function HistoryImageViewModal({
                         <img
                           src={getAPIFullPath('diffusion', ['getInputImage'], {
                             imageId: selectedImage?.id,
+                            experimentId,
                           })}
                           alt="ControlNet Input"
                           style={{
@@ -485,6 +497,7 @@ export default function HistoryImageViewModal({
                             {
                               imageId: selectedImage?.id,
                               processed: true,
+                              experimentId,
                             },
                           )}
                           alt="Preprocessed"


### PR DESCRIPTION
Right now the calls for diffusion just send the "experimentId" instead of actual_id