### PR TITLE
Added option to update Hugging Face credentials in UI

### DIFF
--- a/src/renderer/components/Settings/TransformerLabSettings.tsx
+++ b/src/renderer/components/Settings/TransformerLabSettings.tsx
@@ -37,6 +37,8 @@ export default function TransformerLabSettings() {
   const [doNotTrack, setDoNotTrack] = React.useState(false);
   const [showExperimentalPlugins, setShowExperimentalPlugins] =
     React.useState(false);
+  const [hfTokenModified, setHfTokenModified] = React.useState(false);
+  const [hfTokenValue, setHfTokenValue] = React.useState('');
 
   React.useEffect(() => {
     const fetchDoNotTrack = async () => {
@@ -54,6 +56,22 @@ export default function TransformerLabSettings() {
     fetchShowExperimental();
   }, []);
 
+  const {
+    data: hftoken,
+    error: hftokenerror,
+    isLoading: hftokenisloading,
+    mutate: hftokenmutate,
+  } = useAPI('config', ['get'], {
+    key: 'HuggingfaceUserAccessToken',
+  });
+
+  // Initialize HF token value when loaded
+  React.useEffect(() => {
+    if (hftoken && !hfTokenModified) {
+      setHfTokenValue(hftoken);
+    }
+  }, [hftoken, hfTokenModified]);
+
   const handleDoNotTrackChange = (event) => {
     const checked = event.target.checked;
     setDoNotTrack(checked);
@@ -66,14 +84,11 @@ export default function TransformerLabSettings() {
     window.storage.set('SHOW_EXPERIMENTAL_PLUGINS', checked.toString());
   };
 
-  const {
-    data: hftoken,
-    error: hftokenerror,
-    isLoading: hftokenisloading,
-    mutate: hftokenmutate,
-  } = useAPI('config', ['get'], {
-    key: 'HuggingfaceUserAccessToken',
-  });
+  const handleHfTokenChange = (event) => {
+    const newValue = event.target.value;
+    setHfTokenValue(newValue);
+    setHfTokenModified(newValue !== hftoken);
+  };
   const [showJobsOfType, setShowJobsOfType] = React.useState('NONE');
   const [showProvidersPage, setShowProvidersPage] = React.useState(false);
 
@@ -148,70 +163,72 @@ export default function TransformerLabSettings() {
               Huggingface Credentials:
             </Typography>
             {canLogInToHuggingFace?.message === 'OK' ? (
-              <Alert color="success">Login to Huggingface Successful</Alert>
+              <Alert color="success" sx={{ mb: 1 }}>
+                Login to Huggingface Successful
+              </Alert>
             ) : (
-              <>
-                <Alert color="danger" sx={{ mb: 1 }}>
-                  Login to Huggingface Failed. Please set credentials below.
-                </Alert>
-                <FormControl sx={{ maxWidth: '500px' }}>
-                  <FormLabel>User Access Token</FormLabel>
-                  {hftokenisloading ? (
-                    <CircularProgress />
-                  ) : (
-                    <Input
-                      name="hftoken"
-                      defaultValue={hftoken}
-                      type="password"
-                      endDecorator={
-                        <IconButton
-                          onClick={() => {
-                            const x = document.getElementsByName('hftoken')[0];
-                            x.type = x.type === 'text' ? 'password' : 'text';
-                            setShowPassword(!showPassword);
-                          }}
-                        >
-                          {showPassword ? <EyeOffIcon /> : <EyeIcon />}
-                        </IconButton>
-                      }
-                    />
-                  )}
-                  <Button
-                    onClick={async () => {
-                      const token =
-                        document.getElementsByName('hftoken')[0].value;
-                      await fetch(
-                        getAPIFullPath('config', ['set'], {
-                          key: 'HuggingfaceUserAccessToken',
-                          value: token,
-                        }),
-                      );
-                      // Now manually log in to Huggingface
-                      await fetch(chatAPI.Endpoints.Models.HuggingFaceLogin());
-                      hftokenmutate(token);
-                      canLogInToHuggingFaceMutate();
-                    }}
-                    sx={{ marginTop: 1, width: '100px', alignSelf: 'flex-end' }}
-                  >
-                    Save
-                  </Button>
-                  <FormHelperText>
-                    A Huggingface access token is required in order to access
-                    certain models and datasets (those marked as "Gated").
-                  </FormHelperText>
-                  <FormHelperText>
-                    Documentation here:{' '}
-                    <a
-                      href="https://huggingface.co/docs/hub/security-tokens"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      https://huggingface.co/docs/hub/security-tokens
-                    </a>
-                  </FormHelperText>
-                </FormControl>
-              </>
+              <Alert color="danger" sx={{ mb: 1 }}>
+                Login to Huggingface Failed. Please set credentials below.
+              </Alert>
             )}
+            <FormControl sx={{ maxWidth: '500px' }}>
+              <FormLabel>User Access Token</FormLabel>
+              {hftokenisloading ? (
+                <CircularProgress />
+              ) : (
+                <Input
+                  name="hftoken"
+                  value={hfTokenValue}
+                  onChange={handleHfTokenChange}
+                  type={showPassword ? 'text' : 'password'}
+                  endDecorator={
+                    <IconButton
+                      onClick={() => {
+                        setShowPassword(!showPassword);
+                      }}
+                    >
+                      {showPassword ? <EyeOffIcon /> : <EyeIcon />}
+                    </IconButton>
+                  }
+                />
+              )}
+              <Button
+                onClick={async () => {
+                  const token = hfTokenValue;
+                  await fetch(chatAPI.Endpoints.Models.HuggingFaceLogout());
+
+                  await fetch(
+                    getAPIFullPath('config', ['set'], {
+                      key: 'HuggingfaceUserAccessToken',
+                      value: token,
+                    }),
+                  );
+                  // Now manually log in to Huggingface
+                  await fetch(chatAPI.Endpoints.Models.HuggingFaceLogin());
+                  hftokenmutate(token);
+                  canLogInToHuggingFaceMutate();
+                  setHfTokenModified(false);
+                }}
+                disabled={!hfTokenModified}
+                sx={{ marginTop: 1, width: '100px', alignSelf: 'flex-end' }}
+              >
+                Save
+              </Button>
+              <FormHelperText>
+                A Huggingface access token is required in order to access
+                certain models and datasets (those marked as "Gated").
+              </FormHelperText>
+              <FormHelperText>
+                Documentation here:{' '}
+                <a
+                  href="https://huggingface.co/docs/hub/security-tokens"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  https://huggingface.co/docs/hub/security-tokens
+                </a>
+              </FormHelperText>
+            </FormControl>
             {wandbLoginStatus?.message === 'OK' ? (
               <Alert color="success">
                 Login to Weights &amp; Biases Successful

--- a/src/renderer/lib/api-client/endpoints.ts
+++ b/src/renderer/lib/api-client/endpoints.ts
@@ -160,6 +160,7 @@ Endpoints.Models = {
   ImportFromLocalPath: (modelPath: string) =>
     `${API_URL()}model/import_from_local_path?model_path=${modelPath}`,
   HuggingFaceLogin: () => `${API_URL()}model/login_to_huggingface`,
+  HuggingFaceLogout: () => `${API_URL()}model/logout_from_huggingface`,
   Delete: (modelId: string, deleteCache: boolean = false) =>
     `${API_URL()}model/delete?model_id=${modelId}&delete_from_cache=${
       deleteCache


### PR DESCRIPTION
Added UI option for updating Hugging Face credentials (Issue #703)
When the user provides a new token, we send it to the backend.
The backend clears the cached Hugging Face token (/model/logout_from_huggingface) before saving the new one.
