### PR TITLE
Store the default .env in ~/.transformerlab and make run.sh read from there as well

### DIFF
--- a/api/install.sh
+++ b/api/install.sh
@@ -524,10 +524,6 @@ print_success_message() {
   echo
 }
 
-# Load .env configuration (base config first, then local override)
-load_env_from_file "${TLAB_DIR}/.env"
-load_env_from_file "${RUN_DIR}/.env"
-
 # Check if there are positional arguments; if not, perform full install
 if [[ "$#" -eq 0 ]]; then
   title "Performing a full installation of Transformer Lab."

--- a/api/run.sh
+++ b/api/run.sh
@@ -23,7 +23,6 @@ load_env_files() {
     # Then: local .env files (higher priority, can override base)
     local env_files=(
         "${TLAB_DIR}/.env"
-        ".env"
         "../.env"
     )
 


### PR DESCRIPTION
This simplifies .env files usage. You can either have a .env in your app folder which gets the highest priority and if you dont have it then the .env file created in ~/.transformerlab/,env will be used for jwt secrets