### PR TITLE
Make all job get json calls uncached

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "soundfile==0.13.1",
   "tensorboardX==2.6.2.2",
   "timm==1.0.15",
-  "transformerlab==0.0.51",
+  "transformerlab==0.0.53",
   "transformerlab-inference==0.2.51",
   "transformers==4.57.1",
   "wandb==0.19.10",

--- a/api/transformerlab/services/job_service.py
+++ b/api/transformerlab/services/job_service.py
@@ -67,16 +67,9 @@ def jobs_get_by_experiment(experiment_id):
 def job_get(job_id):
     try:
         job = Job.get(job_id)
-        return job.get_json_data()
+        return job.get_json_data(uncached=True)
     except Exception as e:
         print("Error getting job data", e)
-        if "Etag" in str(e):
-            try:
-                job = Job.get(job_id)
-                return job.get_json_data(uncached=True)
-            except Exception as e:
-                print("Error getting job data (uncached)", e)
-                return None
         return None
 
 
@@ -211,7 +204,7 @@ def jobs_get_next_queued_job_across_all_orgs() -> Tuple[Optional[dict], Optional
                                     try:
                                         job_id = int(job_id_str) if job_id_str.isdigit() else 0
                                         job = Job.get(job_id_str)
-                                        job_data = job.get_json_data()
+                                        job_data = job.get_json_data(uncached=True)
                                         if job_data.get("status") == "QUEUED":
                                             queued_jobs.append((job_id, job_data, org_id))
                                     except Exception:

--- a/lab-sdk/pyproject.toml
+++ b/lab-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab"
-version = "0.0.52"
+version = "0.0.53"
 description = "Python SDK for Transformer Lab"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/lab-sdk/src/lab/experiment.py
+++ b/lab-sdk/src/lab/experiment.py
@@ -7,7 +7,6 @@ from .labresource import BaseLabResource
 from .job import Job
 import json
 from . import storage
-import fsspec
 
 
 class Experiment(BaseLabResource):
@@ -99,7 +98,7 @@ class Experiment(BaseLabResource):
                     if storage.isdir(exp_path):
                         index_file = storage.join(exp_path, "index.json")
                         if storage.exists(index_file):
-                            with storage.open(index_file, "r") as f:
+                            with storage.open(index_file, "r", uncached=True) as f:
                                 data = json.load(f)
                             experiments.append(data)
                 except Exception:
@@ -269,13 +268,15 @@ class Experiment(BaseLabResource):
         results = {}
         cached_jobs = {}
 
-        # Create filesystem override if workspace_dir is an S3 URI (for background threads)
+        # Create uncached filesystem override if workspace_dir is provided (for background threads and fresh data)
         fs_override = None
-        if workspace_dir and workspace_dir.startswith(("s3://", "gs://", "abfs://", "gcs://")):
-            from .storage import _AWS_PROFILE
-
-            storage_options = {"profile": _AWS_PROFILE} if _AWS_PROFILE else None
-            fs_override, _token, _paths = fsspec.get_fs_token_paths(workspace_dir, storage_options=storage_options)
+        if workspace_dir:
+            # Use uncached filesystem to avoid stale directory listings and file reads
+            fs_override = storage._get_uncached_filesystem(workspace_dir)
+        else:
+            # For local workspace, also use uncached to ensure fresh data
+            jobs_dir = get_jobs_dir()
+            fs_override = storage._get_uncached_filesystem(jobs_dir)
 
         try:
             # Use provided jobs_dir or get current one

--- a/lab-sdk/src/lab/job.py
+++ b/lab-sdk/src/lab/job.py
@@ -135,8 +135,8 @@ class Job(BaseLabResource):
         """
         Updates a key-value pair in the job_data JSON object.
         """
-        # Fetch current job_data
-        json_data = self.get_json_data()
+        # Fetch current job_data (use uncached to avoid stale data)
+        json_data = self.get_json_data(uncached=True)
 
         # If there isn't a job_data property then make one
         if "job_data" not in json_data:
@@ -228,7 +228,7 @@ class Job(BaseLabResource):
                 entry = job_path.rstrip("/").split("/")[-1]
                 try:
                     job = cls.get(entry)
-                    job_data = job.get_json_data()
+                    job_data = job.get_json_data(uncached=True)
                     if job_data.get("status") == "RUNNING":
                         count += 1
                 except Exception:
@@ -252,7 +252,7 @@ class Job(BaseLabResource):
                 entry = job_path.rstrip("/").split("/")[-1]
                 try:
                     job = cls.get(entry)
-                    job_data = job.get_json_data()
+                    job_data = job.get_json_data(uncached=True)
                     if job_data.get("status") == "QUEUED":
                         # Without ctime in object stores, sort lexicographically by job id
                         queued_jobs.append((int(entry) if entry.isdigit() else 0, job_data))


### PR DESCRIPTION
- this avoids errors where a json for a new job is not fetched if etag error occurs once