### PR TITLE
Fix issue of recreating logTerminal on every render of output modal

### DIFF
--- a/src/renderer/components/Experiment/Eval/ViewOutputModalStreaming.tsx
+++ b/src/renderer/components/Experiment/Eval/ViewOutputModalStreaming.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSWRWithAuth as useSWR } from 'renderer/lib/authContext';
 
 import {
@@ -28,17 +29,23 @@ export default function ViewOutputModalStreaming({
 }: ViewOutputModalStreamingProps) {
   const { experimentInfo } = useExperimentInfo();
   if (!experimentInfo) return null;
-  const logEndpoint =
-    fileName !== ''
-      ? chatAPI.Endpoints.Experiment.StreamDetailedJSONReportFromJob(
-          experimentInfo.id,
-          jobId,
-          fileName,
-        )
-      : chatAPI.Endpoints.Experiment.StreamOutputFromJob(
-          experimentInfo.id,
-          jobId,
-        );
+
+  // Memoize the logEndpoint to prevent OutputTerminal from reinitializing on every render
+  const logEndpoint = useMemo(
+    () =>
+      fileName !== ''
+        ? chatAPI.Endpoints.Experiment.StreamDetailedJSONReportFromJob(
+            experimentInfo.id,
+            jobId,
+            fileName,
+          )
+        : chatAPI.Endpoints.Experiment.StreamOutputFromJob(
+            experimentInfo.id,
+            jobId,
+          ),
+    [experimentInfo.id, jobId, fileName],
+  );
+
   const titleSentence =
     fileName !== '' ? 'Detailed Report for Job' : 'Output from Job';
 

--- a/src/renderer/components/Experiment/Export/ViewOutputModalStreaming.tsx
+++ b/src/renderer/components/Experiment/Export/ViewOutputModalStreaming.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSWRWithAuth as useSWR } from 'renderer/lib/authContext';
 
 import { Box, Modal, ModalClose, ModalDialog, Typography } from '@mui/joy';
@@ -41,10 +41,17 @@ export default function ViewOutputModalStreaming({
     refreshInterval: 2000,
   });
 
-  // // Create a custom endpoint for export job output
-  const outputEndpoint = experimentInfo
-    ? chatAPI.Endpoints.Experiment.StreamOutputFromJob(experimentInfo.id, jobId)
-    : null;
+  // Memoize the outputEndpoint to prevent OutputTerminal from reinitializing on every render
+  const outputEndpoint = useMemo(
+    () =>
+      experimentInfo
+        ? chatAPI.Endpoints.Experiment.StreamOutputFromJob(
+            experimentInfo.id,
+            jobId,
+          )
+        : null,
+    [experimentInfo?.id, jobId],
+  );
 
   if (!experimentInfo) return null;
 

--- a/src/renderer/components/Experiment/Generate/ViewOutputModalStreaming.tsx
+++ b/src/renderer/components/Experiment/Generate/ViewOutputModalStreaming.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSWRWithAuth as useSWR } from 'renderer/lib/authContext';
 
 import { Box, Modal, ModalClose, ModalDialog, Typography } from '@mui/joy';
@@ -10,6 +11,17 @@ import { fetcher } from 'renderer/lib/transformerlab-api-sdk';
 export default function ViewOutputModalStreaming({ jobId, setJobId }) {
   const { experimentInfo } = useExperimentInfo();
   if (!experimentInfo) return null;
+
+  // Memoize the logEndpoint to prevent OutputTerminal from reinitializing on every render
+  const logEndpoint = useMemo(
+    () =>
+      chatAPI.Endpoints.Experiment.StreamOutputFromJob(
+        experimentInfo.id,
+        jobId,
+      ),
+    [experimentInfo.id, jobId],
+  );
+
   return (
     <Modal open={jobId != -1} onClose={() => setJobId(-1)}>
       <ModalDialog sx={{ width: '80vw', height: '80vh' }}>
@@ -25,13 +37,7 @@ export default function ViewOutputModalStreaming({ jobId, setJobId }) {
             width: '100%',
           }}
         >
-          <OutputTerminal
-            logEndpoint={chatAPI.Endpoints.Experiment.StreamOutputFromJob(
-              experimentInfo.id,
-              jobId,
-            )}
-            lineAnimationDelay={5}
-          />
+          <OutputTerminal logEndpoint={logEndpoint} lineAnimationDelay={5} />
         </Box>
       </ModalDialog>
     </Modal>

--- a/src/renderer/components/Experiment/Train/ViewOutputModalStreaming.tsx
+++ b/src/renderer/components/Experiment/Train/ViewOutputModalStreaming.tsx
@@ -12,7 +12,7 @@ import {
   TabPanel,
 } from '@mui/joy';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 
 import * as chatAPI from 'renderer/lib/transformerlab-api-sdk';
 import OutputTerminal from 'renderer/components/OutputTerminal';
@@ -52,6 +52,17 @@ export default function ViewOutputModalStreaming({
       setTab(0);
     }
   }, [sweeps, tab]);
+
+  // Memoize the logEndpoint to prevent OutputTerminal from reinitializing on every render
+  const logEndpoint = useMemo(
+    () =>
+      chatAPI.Endpoints.Experiment.StreamOutputFromJob(
+        experimentInfo.id,
+        jobId,
+        sweeps,
+      ),
+    [experimentInfo.id, jobId, sweeps],
+  );
 
   const renderResults = (results) => {
     if (!results || typeof results !== 'object') {
@@ -140,11 +151,7 @@ export default function ViewOutputModalStreaming({
               }}
             >
               <OutputTerminal
-                logEndpoint={chatAPI.Endpoints.Experiment.StreamOutputFromJob(
-                  experimentInfo.id,
-                  jobId,
-                  sweeps,
-                )}
+                logEndpoint={logEndpoint}
                 lineAnimationDelay={5}
               />
             </Box>

--- a/src/renderer/components/OutputTerminal/index.tsx
+++ b/src/renderer/components/OutputTerminal/index.tsx
@@ -55,9 +55,6 @@ const OutputTerminal = ({
     isProcessing.current = true;
     const line = lineQueue.current.shift()!;
     termRef.current.write(line.replace(/\n$/, '\r\n'));
-    if (terminalRef.current) {
-      terminalRef.current.scrollIntoView({ behavior: 'smooth' });
-    }
 
     timeoutRef.current = setTimeout(() => {
       processQueue();


### PR DESCRIPTION
- Currently output modal for everything in single user mode just keeps re-streaming all outputs from start on a new update. This fixes that