### PR TITLE
fix: compute 'new' model badge using parsed dates

### DIFF
--- a/api/test/api/test_model.py
+++ b/api/test/api/test_model.py
@@ -42,8 +42,10 @@ def test_model_gallery_new_badge_uses_dates(client):
 
     with (
         patch("transformerlab.routers.model.galleries.get_models_gallery", return_value=mock_gallery),
-        patch("transformerlab.routers.model.model_helper.list_installed_models", new_callable=AsyncMock, return_value=[]),
-        patch("transformerlab.routers.model.datetime.date.today", return_value=date(2025, 1, 31)),
+        patch(
+            "transformerlab.routers.model.model_helper.list_installed_models", new_callable=AsyncMock, return_value=[]
+        ),
+        patch("transformerlab.routers.model._today", return_value=date(2025, 1, 31)),
     ):
         resp = client.get("/model/gallery")
         assert resp.status_code == 200
@@ -70,8 +72,10 @@ def test_model_group_gallery_new_badge_uses_dates(client):
 
     with (
         patch("transformerlab.routers.model.galleries.get_model_groups_gallery", return_value=mock_groups),
-        patch("transformerlab.routers.model.model_helper.list_installed_models", new_callable=AsyncMock, return_value=[]),
-        patch("transformerlab.routers.model.datetime.date.today", return_value=date(2025, 1, 31)),
+        patch(
+            "transformerlab.routers.model.model_helper.list_installed_models", new_callable=AsyncMock, return_value=[]
+        ),
+        patch("transformerlab.routers.model._today", return_value=date(2025, 1, 31)),
     ):
         resp = client.get("/model/model_groups_list")
         assert resp.status_code == 200

--- a/api/transformerlab/routers/model.py
+++ b/api/transformerlab/routers/model.py
@@ -35,6 +35,10 @@ from werkzeug.utils import secure_filename
 router = APIRouter(tags=["model"])
 
 
+def _today() -> date:
+    return datetime.date.today()
+
+
 def _parse_gallery_added_date(value) -> date:
     if isinstance(value, date):
         return value
@@ -99,7 +103,7 @@ async def model_gallery_list_all():
     local_model_names = set(model["model_id"] for model in local_models)
 
     # Set a date one month in the past to identify "new" models
-    one_month_ago = datetime.date.today() + dateutil.relativedelta.relativedelta(months=-1)
+    one_month_ago = _today() + dateutil.relativedelta.relativedelta(months=-1)
     new_model_cutoff_date = one_month_ago
 
     # Iterate through models and add any values needed in result
@@ -131,7 +135,7 @@ async def model_groups_list_all():
     local_model_names = set(model["model_id"] for model in local_models)
 
     # Define what counts as a “new” model
-    one_month_ago = datetime.date.today() + dateutil.relativedelta.relativedelta(months=-1)
+    one_month_ago = _today() + dateutil.relativedelta.relativedelta(months=-1)
     new_model_cutoff_date = one_month_ago
 
     for group in gallery:


### PR DESCRIPTION
### Summary
This PR fixes the `"new"` badge logic in the model gallery endpoints by comparing real dates instead of doing string comparisons on `"added"`.

### Problem
`/model/gallery` and `/model/model_groups_list` previously computed `"new"` using `model["added"] > cutoff` where both values were strings (e.g. `"2024-12-01"`). This is fragile and can produce incorrect results depending on formatting (and it’s explicitly marked with a TODO in the code).

### Changes
- Parse `"added"` into a `datetime.date` safely (with fallback when missing/invalid).
- Compute `"new"` using date comparison.
- Added tests covering:
   - valid ISO dates
   - invalid "added" values
   - missing "added"
   
### Endpoints affected
- `GET /model/gallery`
- `GET /model/model_groups_list`

### Testing
Added/updated pytest coverage in api/test/api/test_model.py.