### PR TITLE
Suppress excessive botocore info logging

### DIFF
--- a/api/transformerlab/shared/remote_workspace.py
+++ b/api/transformerlab/shared/remote_workspace.py
@@ -5,6 +5,7 @@ This module provides functions to create buckets for teams when
 TFL_API_STORAGE_URI is enabled. Supports both S3 and GCS.
 """
 
+import logging
 import os
 import re
 import sys


### PR DESCRIPTION
This log appears every 1s or so on certain pages:

INFO:aiobotocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials

This PR reduces the log level to only log on error.