### PR TITLE
Fix: Prevent TypeError when plugin.model_architectures is undefined in TrainLoRA component

### DIFF
--- a/src/renderer/components/Experiment/Train/TrainLoRA.tsx
+++ b/src/renderer/components/Experiment/Train/TrainLoRA.tsx
@@ -268,10 +268,10 @@ export default function TrainLoRA({}) {
                       key={plugin.uniqueId}
                       disabled={
                         plugin.train_type !== 'embedding'
-                          ? !plugin.model_architectures.includes(
+                          ? !plugin.model_architectures?.includes(
                               modelArchitecture,
                             ) &&
-                            !plugin.model_architectures.includes(
+                            !plugin.model_architectures?.includes(
                               embeddingModelArchitecture,
                             )
                           : false


### PR DESCRIPTION
Use optional chaining (?.) in the disabled prop to safely check array inclusion.

I got this error when accessing the train page via web app locally:
<img width="1902" height="907" alt="image" src="https://github.com/user-attachments/assets/c5cd32ed-c53e-4332-af26-6912b3122604" />

This PR uses optional chaining to fix this