### PR TITLE
check-status stops cluster in a terminal state

### DIFF
--- a/api/transformerlab/routers/compute_provider.py
+++ b/api/transformerlab/routers/compute_provider.py
@@ -1665,9 +1665,7 @@ async def check_provider_job_status(
                 provider = await get_team_provider(session, team_id, provider_id)
                 if provider:
                     user_id_str = str(user_and_team["user"].id)
-                    provider_instance = await get_provider_instance(
-                        provider, user_id=user_id_str, team_id=team_id
-                    )
+                    provider_instance = await get_provider_instance(provider, user_id=user_id_str, team_id=team_id)
                     # Local provider needs workspace_dir from job_data for stop_cluster
                     if provider.type == ProviderType.LOCAL.value and job_data.get("workspace_dir"):
                         if hasattr(provider_instance, "extra_config"):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved resource cleanup for remote jobs. When remote jobs complete, stop, fail, or are deleted, associated computing resources are now automatically cleaned up to optimize resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->