### PR TITLE
One line: Print an error when datadog init fails.

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -36,6 +36,8 @@ def _enable_datadog_if_setup():
     try:
         from ddtrace import patch_all
         from ddtrace.contrib.asgi import TraceMiddleware
+
+        print("Datadog trace middleware enabled")
     except ImportError:
         print("Datadog Init Error: Failed to import library")
         return None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging around optional monitoring integration: now logs a clear success message when monitoring middleware is enabled and a specific error message if the monitoring library fails to import, making setup outcomes more visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->