### PR TITLE
Fix Artifacts dropdown to show options conditionally

### DIFF
--- a/src/renderer/components/Experiment/Tasks/JobsList.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsList.tsx
@@ -306,7 +306,8 @@ const JobsList: React.FC<JobsListProps> = ({
                     )}
                   {(job?.job_data?.artifacts ||
                     job?.job_data?.artifacts_dir ||
-                    job?.job_data?.generated_datasets) && (
+                    job?.job_data?.generated_datasets ||
+                    job?.job_data?.models) && (
                     <Dropdown>
                       <MenuButton
                         size="sm"
@@ -332,12 +333,18 @@ const JobsList: React.FC<JobsListProps> = ({
                             View Artifacts
                           </MenuItem>
                         )}
-                        <MenuItem onClick={() => onViewJobDatasets?.(job?.id)}>
-                          View Datasets
-                        </MenuItem>
-                        <MenuItem onClick={() => onViewJobModels?.(job?.id)}>
-                          View Models
-                        </MenuItem>
+                        {job?.job_data?.generated_datasets && (
+                          <MenuItem
+                            onClick={() => onViewJobDatasets?.(job?.id)}
+                          >
+                            View Datasets
+                          </MenuItem>
+                        )}
+                        {job?.job_data?.models && (
+                          <MenuItem onClick={() => onViewJobModels?.(job?.id)}>
+                            View Models
+                          </MenuItem>
+                        )}
                       </Menu>
                     </Dropdown>
                   )}


### PR DESCRIPTION
- Also fixes the artifacts button not appearing when there's no artifacts but there are saved models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu item visibility logic to conditionally display dataset and model viewing options only when the corresponding data is available, providing a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->