### PR TITLE
rename tabs for consistency: update 'Task Output' to 'Lab SDK Output'…

### DIFF
--- a/src/renderer/components/Experiment/Tasks/EmbeddableStreamingOutput.tsx
+++ b/src/renderer/components/Experiment/Tasks/EmbeddableStreamingOutput.tsx
@@ -97,8 +97,8 @@ const ProviderLogsTerminal: React.FC<ProviderLogsTerminalProps> = ({
 };
 
 const TAB_OPTIONS: { value: 'output' | 'provider'; label: string }[] = [
-  { value: 'output', label: 'Task Output' },
-  { value: 'provider', label: 'Provider Logs' },
+  { value: 'output', label: 'Lab SDK Output' },
+  { value: 'provider', label: 'Machine Logs' },
 ];
 
 export interface EmbeddableStreamingOutputProps {

--- a/src/renderer/components/Experiment/Tasks/ViewOutputModalStreaming.tsx
+++ b/src/renderer/components/Experiment/Tasks/ViewOutputModalStreaming.tsx
@@ -3,8 +3,8 @@ import { Modal, ModalClose, ModalDialog, Typography } from '@mui/joy';
 import EmbeddableStreamingOutput from './EmbeddableStreamingOutput';
 
 const TAB_LABELS: Record<string, string> = {
-  output: 'Task Output',
-  provider: 'Provider Logs',
+  output: 'Lab SDK Output',
+  provider: 'Machine Logs',
 };
 
 interface ViewOutputModalStreamingProps {


### PR DESCRIPTION
… and 'Provider Logs' to 'Machine Logs'