### PR TITLE
Remove Save button from interactive task Configure modal

### DIFF
--- a/src/renderer/components/Experiment/Tasks/NewInteractiveTaskModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/NewInteractiveTaskModal.tsx
@@ -1035,32 +1035,19 @@ export default function NewInteractiveTaskModal({
                 </Button>
               )}
               {step === 'config' && (
-                <Stack direction="row" spacing={2}>
-                  <Button
-                    variant="outlined"
-                    loading={isSubmitting}
-                    disabled={isSubmitting || !canSubmit}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      handleSubmit(e, false);
-                    }}
-                  >
-                    Save
-                  </Button>
-                  <Button
-                    variant="solid"
-                    color="primary"
-                    loading={isSubmitting}
-                    disabled={isSubmitting || !canSubmit}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      handleSubmit(e, true);
-                    }}
-                    endDecorator={<ArrowRightIcon size={16} />}
-                  >
-                    Launch
-                  </Button>
-                </Stack>
+                <Button
+                  variant="solid"
+                  color="primary"
+                  loading={isSubmitting}
+                  disabled={isSubmitting || !canSubmit}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleSubmit(e, true);
+                  }}
+                  endDecorator={<ArrowRightIcon size={16} />}
+                >
+                  Launch
+                </Button>
               )}
             </Stack>
           </DialogActions>


### PR DESCRIPTION
## Summary

Removes the **Save** button from the Configure Task modal for interactive tasks, leaving only the **Launch** button.

Interactive tasks are meant to be launched immediately, so the separate Save option added unnecessary complexity to the UX.