### PR TITLE
Exclude api/test/tmp from git and VS Code file watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ api/db.sqlite3
 api/db.sqlite3-journal
 api/workspace/
 api/temp/
+api/test/tmp/
 api/experiments/
 api/logs/
 api/*.log
@@ -219,3 +220,5 @@ cli/dist/*
 # Playwright
 playwright-report/
 test-results/
+
+.secrets

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,11 @@
     "npm-debug.log.*": true,
     "test/**/__snapshots__": true,
     "package-lock.json": true,
-    "*.{css,sass,scss}.d.ts": true
+    "*.{css,sass,scss}.d.ts": true,
+    "api/test/tmp": true
+  },
+  "files.watcherExclude": {
+    "api/test/tmp/**": true
   },
   "editor.formatOnSave": true,
   "prettier.enable": true,


### PR DESCRIPTION
api/test/tmp/ accumulates ~1.4M files from pytest runs and was not
gitignored or excluded from VS Code's watcher/search, causing ripgrep
to consume 100% CPU.
