### PR TITLE
Add 4 new task gallery entries with category icons and task.yaml stubs

### DIFF
--- a/api/transformerlab/galleries/task-gallery.json
+++ b/api/transformerlab/galleries/task-gallery.json
@@ -251,5 +251,49 @@
       "modality": "other",
       "framework": []
     }
+  },
+  {
+    "title": "DPO / ORPO / SimPO Alignment Training",
+    "description": "Preference optimization training using DPO, ORPO, or SimPO methods via Llama Factory. Requires a dataset with 'conversations', 'chosen', and 'rejected' columns.",
+    "github_repo_url": "https://github.com/transformerlab/transformerlab-examples",
+    "github_repo_dir": "dpo-alignment-train",
+    "metadata": {
+      "category": "rlhf",
+      "modality": "text",
+      "framework": ["llama-factory"]
+    }
+  },
+  {
+    "title": "Batch Text Generation",
+    "description": "Generate outputs from a dataset in batch using a local or commercial LLM. Supports configurable system prompts, temperature, and output dataset naming.",
+    "github_repo_url": "https://github.com/transformerlab/transformerlab-examples",
+    "github_repo_dir": "batch-text-generation",
+    "metadata": {
+      "category": "generation",
+      "modality": "text",
+      "framework": []
+    }
+  },
+  {
+    "title": "Synthetic Dataset Generation",
+    "description": "Generate QA pairs, chain-of-thought examples, or summaries from reference documents using Meta's synthetic-data-kit. Supports curation scoring and multiple output formats.",
+    "github_repo_url": "https://github.com/transformerlab/transformerlab-examples",
+    "github_repo_dir": "synthetic-dataset-generation",
+    "metadata": {
+      "category": "dataset-generation",
+      "modality": "text",
+      "framework": ["synthetic-data-kit"]
+    }
+  },
+  {
+    "title": "GGUF Model Export",
+    "description": "Export a model to GGUF format for efficient CPU inference. Supports q8_0, f16, and f32 quantization types for Llama, Mistral, Gemma, Qwen, and other architectures.",
+    "github_repo_url": "https://github.com/transformerlab/transformerlab-examples",
+    "github_repo_dir": "gguf-model-export",
+    "metadata": {
+      "category": "export",
+      "modality": "text",
+      "framework": ["gguf"]
+    }
   }
 ]

--- a/api/transformerlab/galleries/task-stubs/batch-text-generation/task.yaml
+++ b/api/transformerlab/galleries/task-stubs/batch-text-generation/task.yaml
@@ -1,0 +1,60 @@
+name: Batch Text Generation
+
+resources:
+  accelerators: GPU:1
+
+setup: |
+  pip install transformerlab-sdk
+
+run: |
+  python generate.py \
+    --generation_model {{generation_model}} \
+    --input_column {{input_column}} \
+    --output_column {{output_column}} \
+    --batch_size {{batch_size}} \
+    --temperature {{temperature}} \
+    --max_tokens {{max_tokens}} \
+    --dataset_split {{dataset_split}} \
+    --output_dataset_name {{output_dataset_name}}
+
+parameters:
+  generation_model:
+    title: Generation Model
+    type: string
+    required: true
+  system_prompt:
+    title: System Prompt
+    type: string
+    default: ""
+  input_column:
+    title: Input Column
+    type: string
+    default: input
+  output_column:
+    title: Output Column
+    type: string
+    default: output
+  batch_size:
+    title: Batch Size
+    type: integer
+    default: 128
+  temperature:
+    title: Temperature
+    type: number
+    default: 0.7
+    minimum: 0.0
+    maximum: 2.0
+  max_tokens:
+    title: Max Tokens
+    type: integer
+    default: 1024
+    minimum: 16
+    maximum: 8192
+  dataset_split:
+    title: Dataset Split
+    type: string
+    default: train
+  output_dataset_name:
+    title: Output Dataset Name
+    type: string
+    default: generated_dataset_batched

--- a/api/transformerlab/galleries/task-stubs/dpo-alignment-train/task.yaml
+++ b/api/transformerlab/galleries/task-stubs/dpo-alignment-train/task.yaml
@@ -1,0 +1,45 @@
+name: DPO / ORPO / SimPO Alignment Training
+
+resources:
+  accelerators: GPU:1
+
+envs:
+  HF_TOKEN:
+
+setup: |
+  pip install transformerlab-sdk llama-factory torch
+
+run: |
+  python train.py \
+    --pref_loss {{pref_loss}} \
+    --learning_rate {{learning_rate}} \
+    --num_train_epochs {{num_train_epochs}} \
+    --max_steps {{max_steps}} \
+    --adaptor_name {{adaptor_name}}
+
+parameters:
+  pref_loss:
+    title: Preference Loss Method
+    type: string
+    enum: [dpo, orpo, simpo]
+    default: dpo
+    required: true
+  learning_rate:
+    title: Learning Rate
+    type: number
+    default: 0.001
+    minimum: 0.000001
+  num_train_epochs:
+    title: Number of Training Epochs
+    type: integer
+    default: 1
+    minimum: 1
+  max_steps:
+    title: Max Steps (-1 means no limit)
+    type: integer
+    default: -1
+  adaptor_name:
+    title: Adaptor Name
+    type: string
+    default: dpo
+    required: true

--- a/api/transformerlab/galleries/task-stubs/gguf-model-export/task.yaml
+++ b/api/transformerlab/galleries/task-stubs/gguf-model-export/task.yaml
@@ -1,0 +1,17 @@
+name: GGUF Model Export
+
+resources:
+  CPUs: "4"
+
+setup: |
+  pip install transformerlab-sdk gguf
+
+run: |
+  python export.py --outtype {{outtype}}
+
+parameters:
+  outtype:
+    title: Output Quantization Type
+    type: string
+    enum: [q8_0, f16, f32]
+    default: q8_0

--- a/api/transformerlab/galleries/task-stubs/synthetic-dataset-generation/task.yaml
+++ b/api/transformerlab/galleries/task-stubs/synthetic-dataset-generation/task.yaml
@@ -1,0 +1,48 @@
+name: Synthetic Dataset Generation
+
+resources:
+  accelerators: GPU:1
+
+setup: |
+  pip install transformerlab-sdk synthetic-data-kit
+
+run: |
+  python generate.py \
+    --task_type {{task_type}} \
+    --num_pairs {{num_pairs}} \
+    --curation_threshold {{curation_threshold}} \
+    --output_format {{output_format}} \
+    --output_dataset_name {{output_dataset_name}}
+
+parameters:
+  task_type:
+    title: Generation Type
+    type: string
+    enum: [qa, cot, summary]
+    default: qa
+    required: true
+  num_pairs:
+    title: Number of Pairs to Generate
+    type: integer
+    default: 25
+    minimum: 1
+    maximum: 500
+  curation_threshold:
+    title: Curation Threshold (1-10)
+    type: number
+    default: 7.0
+    minimum: 1.0
+    maximum: 10.0
+  output_format:
+    title: Output Format
+    type: string
+    enum: [jsonl, alpaca, chatml]
+    default: jsonl
+  prompt_template:
+    title: Custom Prompt Template (optional)
+    type: string
+    default: ""
+  output_dataset_name:
+    title: Output Dataset Name
+    type: string
+    default: generated_dataset_synth_data_kit

--- a/src/renderer/components/TasksGallery/TasksGallery.tsx
+++ b/src/renderer/components/TasksGallery/TasksGallery.tsx
@@ -30,6 +30,9 @@ import {
   Trash2Icon,
   GraduationCapIcon,
   ChartColumnIncreasingIcon,
+  ScaleIcon,
+  SparklesIcon,
+  PackageIcon,
 } from 'lucide-react';
 
 import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
@@ -91,9 +94,25 @@ function TaskIcon({ category }: { category: string }) {
       icon = <GraduationCapIcon />;
       color = '#388e3c';
       break;
+    case 'finetuning':
+      icon = <GraduationCapIcon />;
+      color = '#388e3c';
+      break;
     case 'eval':
       icon = <ChartColumnIncreasingIcon />;
       color = '#d27d00';
+      break;
+    case 'rlhf':
+      icon = <ScaleIcon />;
+      color = '#7b1fa2';
+      break;
+    case 'generation':
+      icon = <SparklesIcon />;
+      color = '#00897b';
+      break;
+    case 'export':
+      icon = <PackageIcon />;
+      color = '#303f9f';
       break;
     default:
       icon = <ScanTextIcon />;


### PR DESCRIPTION
- Add DPO/ORPO/SimPO alignment, batch text generation, synthetic dataset
  generation, and GGUF model export entries to task-gallery.json
- Add distinct icons for finetuning, rlhf, generation, and export
  categories in TasksGallery TaskIcon component
- Create task.yaml stubs in galleries/task-stubs/ as reference
  implementations for the transformerlab-examples repo

https://claude.ai/code/session_01X7G6ZvkkLgRjNkmSssncSE