### PR TITLE
Add per-provider command hooks (pre_setup, post_setup, pre_run, post_run)

### DIFF
--- a/api/transformerlab/compute_providers/config.py
+++ b/api/transformerlab/compute_providers/config.py
@@ -39,6 +39,12 @@ class ComputeProviderConfig(BaseModel):
     # Accelerators supported by this provider
     supported_accelerators: Optional[list[str]] = Field(default=None)
 
+    # Command hooks - shell commands injected around job setup/run
+    pre_setup: Optional[str] = None  # Runs before all setup commands
+    post_setup: Optional[str] = None  # Runs after all setup commands
+    pre_run: Optional[str] = None  # Prepended to the run command
+    post_run: Optional[str] = None  # Appended to the run command
+
     # Additional provider-specific config
     extra_config: Dict[str, Any] = Field(default_factory=dict)
 

--- a/api/transformerlab/routers/compute_provider.py
+++ b/api/transformerlab/routers/compute_provider.py
@@ -1653,6 +1653,28 @@ async def launch_template_on_provider(
     # Build setup script - add cloud credential helpers first, then file_mounts and other setup.
     setup_commands: list[str] = []
 
+    # Extract command hooks from provider config
+    provider_config_raw = provider.config or {}
+    hook_pre_setup = (provider_config_raw.get("pre_setup") or "").strip()
+    hook_post_setup = (provider_config_raw.get("post_setup") or "").strip()
+    hook_pre_run = (provider_config_raw.get("pre_run") or "").strip()
+    hook_post_run = (provider_config_raw.get("post_run") or "").strip()
+
+    # Replace {{secret.<name>}} placeholders in hooks
+    if team_secrets:
+        if hook_pre_setup:
+            hook_pre_setup = replace_secret_placeholders(hook_pre_setup, team_secrets)
+        if hook_post_setup:
+            hook_post_setup = replace_secret_placeholders(hook_post_setup, team_secrets)
+        if hook_pre_run:
+            hook_pre_run = replace_secret_placeholders(hook_pre_run, team_secrets)
+        if hook_post_run:
+            hook_post_run = replace_secret_placeholders(hook_post_run, team_secrets)
+
+    # Inject pre_setup hook before all other setup commands
+    if hook_pre_setup:
+        setup_commands.append(hook_pre_setup)
+
     if os.getenv("TFL_REMOTE_STORAGE_ENABLED", "false").lower() == "true":
         if STORAGE_PROVIDER == "aws":
             # Get AWS credentials from stored credentials file (transformerlab-s3 profile)
@@ -1823,6 +1845,10 @@ async def launch_template_on_provider(
         setup_with_secrets = replace_secret_placeholders(request.setup, team_secrets) if team_secrets else request.setup
         setup_commands.append(setup_with_secrets)
 
+    # Inject post_setup hook after all other setup commands
+    if hook_post_setup:
+        setup_commands.append(hook_post_setup)
+
     # Join setup commands, stripping trailing semicolons to avoid double semicolons
     if setup_commands:
         cleaned_commands = [cmd.rstrip(";").rstrip() for cmd in setup_commands if cmd.strip()]
@@ -1831,10 +1857,23 @@ async def launch_template_on_provider(
         final_setup = None
 
     if setup_override_from_gallery is not None:
-        final_setup = setup_override_from_gallery
+        # Still wrap gallery override with provider hooks
+        parts: list[str] = []
+        if hook_pre_setup:
+            parts.append(hook_pre_setup)
+        parts.append(setup_override_from_gallery)
+        if hook_post_setup:
+            parts.append(hook_post_setup)
+        final_setup = ";".join(parts)
 
     # Replace secrets in command
     command_with_secrets = replace_secret_placeholders(base_command, team_secrets) if team_secrets else base_command
+
+    # Inject pre_run / post_run hooks around the run command
+    if hook_pre_run:
+        command_with_secrets = f"{hook_pre_run} && {command_with_secrets}"
+    if hook_post_run:
+        command_with_secrets = f"{command_with_secrets} ; {hook_post_run}"
 
     # Replace secrets in parameters if present
     # Merge parameters (defaults) with config (user's custom values for this run)

--- a/api/transformerlab/schemas/compute_providers.py
+++ b/api/transformerlab/schemas/compute_providers.py
@@ -34,6 +34,12 @@ class ProviderConfigBase(BaseModel):
     # Accelerators supported by this provider
     supported_accelerators: Optional[List[AcceleratorType]] = Field(default=None)
 
+    # Command hooks - shell commands injected around job setup/run
+    pre_setup: Optional[str] = None  # Runs before all setup commands
+    post_setup: Optional[str] = None  # Runs after all setup commands
+    pre_run: Optional[str] = None  # Prepended to the run command
+    post_run: Optional[str] = None  # Appended to the run command
+
     # Additional provider-specific config
     extra_config: Dict[str, Any] = Field(default_factory=dict)
 

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -85,6 +85,13 @@ export default function ProviderDetailsModal({
     [],
   );
 
+  // Command hooks
+  const [preSetup, setPreSetup] = useState('');
+  const [postSetup, setPostSetup] = useState('');
+  const [preRun, setPreRun] = useState('');
+  const [postRun, setPostRun] = useState('');
+  const [showHooks, setShowHooks] = useState(false);
+
   // SLURM-specific form fields
   const [slurmMode, setSlurmMode] = useState<'ssh' | 'rest'>('ssh');
   const [slurmSshHost, setSlurmSshHost] = useState('');
@@ -180,6 +187,24 @@ export default function ProviderDetailsModal({
         delete rawConfigObj.supported_accelerators;
       }
 
+      // Extract command hooks into dedicated state
+      setPreSetup(rawConfigObj.pre_setup || '');
+      setPostSetup(rawConfigObj.post_setup || '');
+      setPreRun(rawConfigObj.pre_run || '');
+      setPostRun(rawConfigObj.post_run || '');
+      if (
+        rawConfigObj.pre_setup ||
+        rawConfigObj.post_setup ||
+        rawConfigObj.pre_run ||
+        rawConfigObj.post_run
+      ) {
+        setShowHooks(true);
+      }
+      delete rawConfigObj.pre_setup;
+      delete rawConfigObj.post_setup;
+      delete rawConfigObj.pre_run;
+      delete rawConfigObj.post_run;
+
       // Parse SLURM-specific fields if this is a SLURM provider
       if (providerData.type === 'slurm') {
         parseSlurmConfig(rawConfigObj);
@@ -198,6 +223,11 @@ export default function ProviderDetailsModal({
       setSlurmSshKeyPath('');
       setSlurmRestUrl('');
       setSlurmApiToken('');
+      setPreSetup('');
+      setPostSetup('');
+      setPreRun('');
+      setPostRun('');
+      setShowHooks(false);
     }
   }, [providerId, providerData]);
 
@@ -215,6 +245,11 @@ export default function ProviderDetailsModal({
       setSlurmSshKeyPath('');
       setSlurmRestUrl('');
       setSlurmApiToken('');
+      setPreSetup('');
+      setPostSetup('');
+      setPreRun('');
+      setPostRun('');
+      setShowHooks(false);
     }
   }, [open]);
 
@@ -377,6 +412,12 @@ export default function ProviderDetailsModal({
         }
       }
 
+      // Add command hooks to config if set
+      if (preSetup.trim()) parsedConfig.pre_setup = preSetup.trim();
+      if (postSetup.trim()) parsedConfig.post_setup = postSetup.trim();
+      if (preRun.trim()) parsedConfig.pre_run = preRun.trim();
+      if (postRun.trim()) parsedConfig.post_run = postRun.trim();
+
       const response = providerId
         ? await updateProvider(providerId, name, parsedConfig)
         : await createProvider(name, type, parsedConfig);
@@ -507,6 +548,104 @@ export default function ProviderDetailsModal({
                   Select the types of hardware this provider supports.
                 </Typography>
               </FormControl>
+
+              {/* Command Hooks (collapsible, all provider types) */}
+              {type && (
+                <Box sx={{ mt: 2 }}>
+                  <Typography
+                    level="title-sm"
+                    sx={{ cursor: 'pointer', userSelect: 'none' }}
+                    onClick={() => setShowHooks(!showHooks)}
+                  >
+                    {showHooks ? '\u25BE' : '\u25B8'} Command Hooks (Advanced)
+                  </Typography>
+                  <Typography
+                    level="body-sm"
+                    sx={{ color: 'text.tertiary', mb: 1 }}
+                  >
+                    Optional shell commands injected before/after every
+                    job&apos;s setup and run phases.
+                  </Typography>
+                  {showHooks && (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 1,
+                        pl: 1,
+                      }}
+                    >
+                      <FormControl>
+                        <FormLabel>Pre-Setup</FormLabel>
+                        <Textarea
+                          value={preSetup}
+                          onChange={(e) => setPreSetup(e.currentTarget.value)}
+                          placeholder="e.g. module load cuda/12.0"
+                          minRows={2}
+                          maxRows={4}
+                        />
+                        <Typography
+                          level="body-xs"
+                          sx={{ color: 'text.tertiary' }}
+                        >
+                          Runs before all other setup (cloud creds, pip install,
+                          etc.)
+                        </Typography>
+                      </FormControl>
+                      <FormControl>
+                        <FormLabel>Post-Setup</FormLabel>
+                        <Textarea
+                          value={postSetup}
+                          onChange={(e) => setPostSetup(e.currentTarget.value)}
+                          placeholder="e.g. source /opt/env.sh"
+                          minRows={2}
+                          maxRows={4}
+                        />
+                        <Typography
+                          level="body-xs"
+                          sx={{ color: 'text.tertiary' }}
+                        >
+                          Runs after all setup commands complete
+                        </Typography>
+                      </FormControl>
+                      <FormControl>
+                        <FormLabel>Pre-Run</FormLabel>
+                        <Textarea
+                          value={preRun}
+                          onChange={(e) => setPreRun(e.currentTarget.value)}
+                          placeholder="e.g. nvidia-smi"
+                          minRows={2}
+                          maxRows={4}
+                        />
+                        <Typography
+                          level="body-xs"
+                          sx={{ color: 'text.tertiary' }}
+                        >
+                          Prepended to every job&apos;s run command (joined with
+                          &amp;&amp;)
+                        </Typography>
+                      </FormControl>
+                      <FormControl>
+                        <FormLabel>Post-Run</FormLabel>
+                        <Textarea
+                          value={postRun}
+                          onChange={(e) => setPostRun(e.currentTarget.value)}
+                          placeholder="e.g. cleanup.sh"
+                          minRows={2}
+                          maxRows={4}
+                        />
+                        <Typography
+                          level="body-xs"
+                          sx={{ color: 'text.tertiary' }}
+                        >
+                          Appended after the job&apos;s run command (always
+                          runs, even on failure)
+                        </Typography>
+                      </FormControl>
+                    </Box>
+                  )}
+                </Box>
+              )}
 
               {/* SLURM-specific form fields */}
               {type === 'slurm' && (


### PR DESCRIPTION
Allows team admins to configure optional shell commands that are injected
before/after the setup and run phases of every job on a given provider.
Hooks are stored in the provider's config JSON blob and edited via a
collapsible "Command Hooks (Advanced)" section in the provider modal.

- pre_setup: runs before all setup (cloud creds, pip install, etc.)
- post_setup: runs after all setup commands
- pre_run: prepended to run command (&&, skips main cmd on failure)
- post_run: appended to run command (;, always runs for cleanup)

Hooks support {{secret.<name>}} placeholder replacement and are
correctly wrapped by tfl-remote-trap for remote providers.

https://claude.ai/code/session_018CsKUeRYRaccL36Cu6ocdd