### PR TITLE
Add queue status feedback for local provider jobs

### DIFF
--- a/api/transformerlab/services/job_service.py
+++ b/api/transformerlab/services/job_service.py
@@ -253,6 +253,21 @@ async def job_update_launch_progress(
         print(f"Error updating launch progress for job {job_id}: {e}")
 
 
+async def job_update_status_message(
+    job_id: str,
+    experiment_id: Optional[str],
+    message: str,
+) -> None:
+    """
+    Update the general-purpose 'status_message' field in job_data.
+
+    This field can be set for any job status to provide human-readable context
+    (e.g., queue position, current phase description). It is automatically
+    cleared on status transitions so stale messages don't persist.
+    """
+    await job_update_job_data_insert_key_value(job_id, "status_message", message, experiment_id)
+
+
 async def jobs_get_sweep_children(parent_job_id, experiment_id=None):
     """
     Get all child jobs that belong to a sweep parent job.
@@ -479,6 +494,8 @@ async def job_update_status(
         await job.update_status(status)
         if error_msg:
             await job.set_error_message(error_msg)
+        # Clear status_message on status transitions so stale messages don't persist.
+        await job.update_job_data_field("status_message", "")
     except Exception as e:
         print(f"Error updating job {job_id}: {e}")
         pass

--- a/api/transformerlab/services/local_provider_queue.py
+++ b/api/transformerlab/services/local_provider_queue.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Optional
+from typing import List, Optional, Tuple
 
 from pydantic import BaseModel
 
@@ -32,6 +32,31 @@ _worker_started = False
 _worker_started_lock = asyncio.Lock()
 _worker_lock = asyncio.Lock()
 
+# Track waiting job IDs so we can update queue positions when jobs are dequeued.
+# Each entry is (job_id, experiment_id).
+_waiting_jobs: List[Tuple[str, str]] = []
+_waiting_jobs_lock = asyncio.Lock()
+
+
+async def _update_waiting_job_positions() -> None:
+    """Update launch_progress and status_message for all waiting jobs with their queue position."""
+    async with _waiting_jobs_lock:
+        for idx, (jid, eid) in enumerate(_waiting_jobs):
+            position = idx + 1
+            total = len(_waiting_jobs)
+            if total == 1:
+                message = "Queued \u2014 waiting for the current job to finish"
+            else:
+                ahead = position - 1
+                if ahead == 0:
+                    message = "Queued \u2014 you're next"
+                elif ahead == 1:
+                    message = "Queued \u2014 1 job ahead"
+                else:
+                    message = f"Queued \u2014 {ahead} jobs ahead"
+            await job_service.job_update_launch_progress(jid, eid, phase="queued", percent=0, message=message)
+            await job_service.job_update_status_message(jid, eid, message)
+
 
 async def enqueue_local_launch(
     job_id: str,
@@ -57,6 +82,13 @@ async def enqueue_local_launch(
     await _local_launch_queue.put(item)
     print(f"[local_provider_queue] Enqueued job {job_id} (cluster={cluster_name}, status={initial_status})")
 
+    # Track this job for queue position updates.
+    async with _waiting_jobs_lock:
+        _waiting_jobs.append((str(job_id), str(experiment_id)))
+
+    # Set initial queue position feedback for all waiting jobs.
+    await _update_waiting_job_positions()
+
     global _worker_started
     async with _worker_started_lock:
         if not _worker_started:
@@ -69,6 +101,12 @@ async def _local_launch_worker() -> None:
     while True:
         item = await _local_launch_queue.get()
         print(f"[local_provider_queue] Picked up job {item.job_id} from queue (cluster={item.cluster_name})")
+
+        # Remove this job from the waiting list and refresh positions for remaining jobs.
+        async with _waiting_jobs_lock:
+            _waiting_jobs[:] = [(jid, eid) for jid, eid in _waiting_jobs if jid != item.job_id]
+        await _update_waiting_job_positions()
+
         try:
             # Delegate actual processing to helper to keep the worker loop simple.
             await _process_launch_item(item)
@@ -82,13 +120,15 @@ async def _process_launch_item(item: LocalLaunchWorkItem) -> None:
         lab_dirs.set_organization_id(item.team_id)
         try:
             # Initial progress update – make it clear we're preparing the local environment.
+            preparing_msg = "Preparing local environment (this may take a few minutes)..."
             await job_service.job_update_launch_progress(
                 item.job_id,
                 item.experiment_id,
                 phase="starting",
                 percent=5,
-                message="Preparing local environment (this may take a few minutes)...",
+                message=preparing_msg,
             )
+            await job_service.job_update_status_message(item.job_id, item.experiment_id, preparing_msg)
             provider = await get_provider_by_id(session, item.provider_id)
             if not provider:
                 print(f"[local_provider_queue] Provider {item.provider_id} not found, job {item.job_id} FAILED")
@@ -117,13 +157,15 @@ async def _process_launch_item(item: LocalLaunchWorkItem) -> None:
             await session.commit()
 
             # Indicate we're about to launch the local cluster
+            launching_msg = "Setting up local provider and starting cluster..."
             await job_service.job_update_launch_progress(
                 item.job_id,
                 item.experiment_id,
                 phase="launching_cluster",
                 percent=50,
-                message="Setting up local provider and starting cluster...",
+                message=launching_msg,
             )
+            await job_service.job_update_status_message(item.job_id, item.experiment_id, launching_msg)
 
             loop = asyncio.get_running_loop()
             try:
@@ -160,6 +202,8 @@ async def _process_launch_item(item: LocalLaunchWorkItem) -> None:
                 percent=100,
                 message="Local cluster started",
             )
+            # Clear status_message once the cluster is running — let the status chip speak for itself.
+            await job_service.job_update_status_message(item.job_id, item.experiment_id, "")
         except Exception as exc:  # noqa: BLE001
             print(f"[local_provider_queue] Job {item.job_id}: unexpected error while processing launch item: {exc}")
             if item.quota_hold_id:

--- a/lab-sdk/src/lab/job.py
+++ b/lab-sdk/src/lab/job.py
@@ -224,6 +224,16 @@ class Job(BaseLabResource):
         """
         await self.update_job_data_field("error_msg", str(error_msg))
 
+    async def update_status_message(self, message: str):
+        """
+        Update the general-purpose 'status_message' field in the job_data.
+
+        This can be used by plugins, harnesses, or any code that wants to
+        communicate a human-readable status detail to the frontend
+        (e.g., current phase, queue position, progress description).
+        """
+        await self.update_job_data_field("status_message", message)
+
     async def update_sweep_progress(self, value):
         """
         Update the 'sweep_progress' key in the job_data JSON object.

--- a/src/renderer/components/Experiment/Tasks/JobProgress.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobProgress.tsx
@@ -6,7 +6,7 @@ import {
   Typography,
   Tooltip,
 } from '@mui/joy';
-import { StopCircleIcon, Info } from 'lucide-react';
+import { StopCircleIcon, Info, Clock } from 'lucide-react';
 import Skeleton from '@mui/joy/Skeleton';
 import CircularProgress from '@mui/joy/CircularProgress';
 import dayjs from 'dayjs';
@@ -236,9 +236,46 @@ export default function JobProgress({
             </Typography>
           </Stack>
         </>
-      ) : job?.status === 'LAUNCHING' ||
-        job?.status === 'INTERACTIVE' ||
-        job?.status === 'WAITING' ? (
+      ) : job?.status === 'WAITING' ? (
+        <>
+          <Stack direction="row" alignItems="center" gap={1}>
+            <Chip
+              sx={{
+                backgroundColor: jobChipColor(job.status),
+                color: 'var(--joy-palette-neutral-800)',
+              }}
+            >
+              QUEUED
+            </Chip>
+            <Clock size={16} color="var(--joy-palette-warning-600)" />
+            <IconButton
+              color="danger"
+              onClick={handleStopJob}
+              disabled={stopping}
+            >
+              {stopping ? (
+                <CircularProgress size="sm" thickness={2} />
+              ) : (
+                <StopCircleIcon size="20px" />
+              )}
+            </IconButton>
+            {stopping && (
+              <Typography level="body-xs" color="warning">
+                Stopping&hellip;
+              </Typography>
+            )}
+          </Stack>
+          {(launchProgress?.message || job?.job_data?.status_message) && (
+            <Typography
+              level="body-sm"
+              textColor="neutral.600"
+              sx={{ mt: 0.5 }}
+            >
+              {launchProgress?.message || job?.job_data?.status_message}
+            </Typography>
+          )}
+        </>
+      ) : job?.status === 'LAUNCHING' || job?.status === 'INTERACTIVE' ? (
         <>
           <Stack direction="row" alignItems="center" gap={1}>
             <Chip
@@ -318,6 +355,15 @@ export default function JobProgress({
                 />
               )}
             </Stack>
+          )}
+          {!launchProgress?.message && job?.job_data?.status_message && (
+            <Typography
+              level="body-sm"
+              textColor="neutral.600"
+              sx={{ mt: 0.5 }}
+            >
+              {job.job_data.status_message}
+            </Typography>
           )}
           {job?.job_data?.start_time && (
             <>

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -205,6 +205,7 @@ export function useTraceUpdate(props) {
 export function jobChipColor(status: string): string {
   if (status === 'COMPLETE') return 'var(--joy-palette-success-200)';
   if (status === 'QUEUED') return 'var(--joy-palette-warning-200)';
+  if (status === 'WAITING') return 'var(--joy-palette-warning-200)';
   if (status === 'LAUNCHING') return 'var(--joy-palette-primary-200)';
   if (status === 'FAILED') return 'var(--joy-palette-danger-200)';
   if (status === 'STOPPING') return 'var(--joy-palette-warning-200)';


### PR DESCRIPTION
When multiple jobs are queued on the local provider, users now see a
distinct "QUEUED" chip (amber) with a clock icon instead of the same
"LAUNCHING" spinner. The backend sets queue position messages like
"Queued — 2 jobs ahead" via launch_progress, and positions update
automatically as jobs are picked up by the worker.

Also adds a general-purpose `status_message` field to job_data that any
provider or plugin can use to communicate human-readable status context.
The field is automatically cleared on status transitions.

https://claude.ai/code/session_012tqngj6Qdw3fNBXbFfD7qm