### PR TITLE
Remove datadog import

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -33,27 +33,6 @@ logging.getLogger("transformerlab").setLevel(
     getattr(logging, os.getenv("TLAB_LOG_LEVEL", "WARNING").upper(), logging.WARNING)
 )
 
-
-# Optional Datadog APM (does nothing unless enabled + installed)
-def _enable_datadog_if_setup():
-    if not os.getenv("DD_SERVICE"):
-        return
-
-    try:
-        from ddtrace import patch_all
-        from ddtrace.contrib.asgi import TraceMiddleware
-
-        print("Datadog trace middleware enabled")
-    except ImportError:
-        print("Datadog Init Error: Failed to import library")
-        return None
-
-    patch_all(fastapi=True, httpx=True)
-    return TraceMiddleware
-
-
-TRACE_MIDDLEWARE = _enable_datadog_if_setup()
-
 from fastchat.constants import (  # noqa: E402
     ErrorCode,
 )
@@ -239,10 +218,6 @@ app = fastapi.FastAPI(
     lifespan=lifespan,
     openapi_tags=tags_metadata,
 )
-
-# Add tracing middleware only if setup and enabled
-if TRACE_MIDDLEWARE is not None:
-    app.add_middleware(TRACE_MIDDLEWARE)
 
 # CORS configuration
 # When using cookies, allow_credentials must be True and allow_origins cannot be ["*"]


### PR DESCRIPTION
We don't need this anymore. We are running datadog agent from outside of hte code and it is getting the same level of tracing (for now). 

We might need to add this back in the future if we want to add detailed instrumentation to the product. But for now it's better to not have in the code.
