### PR TITLE
Add autocomplete attributes to enable Chrome password generator

### DIFF
--- a/src/renderer/components/Login/LoginForm.tsx
+++ b/src/renderer/components/Login/LoginForm.tsx
@@ -281,6 +281,7 @@ export default function LoginForm() {
                   autoFocus
                   disabled={loadingState !== null}
                   variant="outlined"
+                  slotProps={{ input: { autoComplete: 'username' } }}
                 />
               </FormControl>
               <FormControl required>
@@ -291,6 +292,7 @@ export default function LoginForm() {
                   onChange={(e) => setPassword(e.target.value)}
                   disabled={loadingState !== null}
                   variant="outlined"
+                  slotProps={{ input: { autoComplete: 'current-password' } }}
                 />
               </FormControl>
 

--- a/src/renderer/components/Login/RegisterUser.tsx
+++ b/src/renderer/components/Login/RegisterUser.tsx
@@ -222,6 +222,7 @@ export default function RegisterForm({ onClose }: { onClose: () => void }) {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               disabled={loadingState !== null}
+              slotProps={{ input: { autoComplete: 'new-password' } }}
             />
           </FormControl>
 
@@ -232,6 +233,7 @@ export default function RegisterForm({ onClose }: { onClose: () => void }) {
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               disabled={loadingState !== null}
+              slotProps={{ input: { autoComplete: 'new-password' } }}
             />
           </FormControl>
 

--- a/src/renderer/components/User/UserSettings.tsx
+++ b/src/renderer/components/User/UserSettings.tsx
@@ -84,6 +84,7 @@ function PasswordChangeForm({ open, onClose }) {
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
               fullWidth
+              slotProps={{ input: { autoComplete: 'new-password' } }}
             />
           </FormControl>
           <FormControl sx={{ mt: 1 }}>
@@ -93,6 +94,7 @@ function PasswordChangeForm({ open, onClose }) {
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               fullWidth
+              slotProps={{ input: { autoComplete: 'new-password' } }}
             />
           </FormControl>
         </DialogContent>


### PR DESCRIPTION
## Summary
- Added `autocomplete="new-password"` to password inputs in the **Change Password** modal (`UserSettings.tsx`) and **Registration** form (`RegisterUser.tsx`) so Chrome offers its "Suggest Strong Password" feature.
- Added `autocomplete="current-password"` and `autocomplete="username"` to the **Login** form (`LoginForm.tsx`) to improve credential autofill and help Chrome distinguish sign-in from password-creation forms.

## Test plan
- [ ] Open the Change Password modal in User Settings — Chrome should offer "Suggest Strong Password" on the new password field.
- [ ] Open the Registration form — Chrome should offer "Suggest Strong Password" on the password field.
- [ ] Open the Login form — Chrome should autofill saved credentials correctly.