### PR TITLE
Add --format=json support to CLI config command

### DIFF
--- a/cli/src/transformerlab_cli/commands/config.py
+++ b/cli/src/transformerlab_cli/commands/config.py
@@ -1,5 +1,8 @@
+import json
+
 import typer
 
+from transformerlab_cli.state import cli_state
 from transformerlab_cli.util.config import list_config, set_config
 from transformerlab_cli.util.ui import console
 
@@ -12,10 +15,14 @@ def config(
     value: str = typer.Argument(None, help="Config value to set"),
 ):
     """View or set configuration values."""
+    output_format = cli_state.output_format
     if key is None and value is None:
-        list_config()
+        list_config(output_format=output_format)
     elif key is not None and value is not None:
-        set_config(key, value)
+        set_config(key, value, output_format=output_format)
     else:
-        console.print("[error]Error:[/error] Both key and value are required to set a config")
+        if output_format == "json":
+            print(json.dumps({"error": "Both key and value are required to set a config"}))
+        else:
+            console.print("[error]Error:[/error] Both key and value are required to set a config")
         raise typer.Exit(1)

--- a/cli/src/transformerlab_cli/util/config.py
+++ b/cli/src/transformerlab_cli/util/config.py
@@ -48,19 +48,22 @@ def _save_config(config: dict[str, Any]) -> bool:
         return False
 
 
-def list_config() -> None:
+def list_config(output_format: str = "pretty") -> None:
     """Display all config values in a table."""
     config = load_config()
 
     if not config:
-        console.print("[warning]No configuration values set[/warning]")
+        if output_format == "json":
+            print(json.dumps([]))
+        else:
+            console.print("[warning]No configuration values set[/warning]")
         return
 
     json_with_key_value = [{"Key": k, "Value": str(v)} for k, v in sorted(config.items())]
 
     render_table(
         data=json_with_key_value,
-        format_type="pretty",
+        format_type=output_format,
         table_columns=["Key", "Value"],
         title=None,
     )
@@ -86,26 +89,38 @@ def _validate_url(url: str) -> str | None:
         return None
 
 
-def set_config(key: str, value: str) -> bool:
+def set_config(key: str, value: str, output_format: str = "pretty") -> bool:
     """Set a config value. Returns True on success."""
     if not key:
-        console.print("[error]Error:[/error] Key cannot be empty")
+        if output_format == "json":
+            print(json.dumps({"error": "Key cannot be empty"}))
+        else:
+            console.print("[error]Error:[/error] Key cannot be empty")
         return False
     if not value:
-        console.print("[error]Error:[/error] Value cannot be empty")
+        if output_format == "json":
+            print(json.dumps({"error": "Value cannot be empty"}))
+        else:
+            console.print("[error]Error:[/error] Value cannot be empty")
         return False
 
     if key not in VALID_CONFIG_KEYS:
         keys_list = ", ".join(VALID_CONFIG_KEYS)
-        console.print(f"[error]Error:[/error] Invalid config key '{key}'")
-        console.print(f"[warning]Valid keys:[/warning] {keys_list}")
+        if output_format == "json":
+            print(json.dumps({"error": f"Invalid config key '{key}'", "valid_keys": VALID_CONFIG_KEYS}))
+        else:
+            console.print(f"[error]Error:[/error] Invalid config key '{key}'")
+            console.print(f"[warning]Valid keys:[/warning] {keys_list}")
         return False
 
     if key == "server":
         normalized_url = _validate_url(value)
         if normalized_url is None:
-            console.print(f"[error]Error:[/error] Invalid URL '{value}'")
-            console.print("[warning]URL must start with http:// or https://[/warning]")
+            if output_format == "json":
+                print(json.dumps({"error": f"Invalid URL '{value}'"}))
+            else:
+                console.print(f"[error]Error:[/error] Invalid URL '{value}'")
+                console.print("[warning]URL must start with http:// or https://[/warning]")
             return False
         value = normalized_url
 
@@ -113,7 +128,10 @@ def set_config(key: str, value: str) -> bool:
     config[key] = value
 
     if _save_config(config):
-        console.print(f"[success]✓[/success] Set [label]{key}[/label] = [value]{value}[/value]")
+        if output_format == "json":
+            print(json.dumps({"key": key, "value": value}))
+        else:
+            console.print(f"[success]✓[/success] Set [label]{key}[/label] = [value]{value}[/value]")
         return True
     return False
 

--- a/cli/tests/commands/test_config.py
+++ b/cli/tests/commands/test_config.py
@@ -122,3 +122,65 @@ def test_load_config_with_data(tmp_config_dir):
     with _patch_config_paths(config_dir, config_file):
         config = load_config()
         assert config["server"] == "http://test:8338"
+
+
+# --- JSON format output ---
+
+
+def test_config_list_json_format(tmp_config_dir):
+    """Test that --format=json outputs all config keys as JSON."""
+    config_dir, config_file = tmp_config_dir
+    config_data = {
+        "server": "http://localhost:8338",
+        "team_id": "abc-123",
+        "user_email": "user@example.com",
+        "current_experiment": "alpha",
+        "team_name": "Test Team",
+    }
+    config_file.write_text(json.dumps(config_data))
+    with _patch_config_paths(config_dir, config_file):
+        result = runner.invoke(app, ["--format=json", "config"])
+        assert result.exit_code == 0
+        output = json.loads(result.output.strip())
+        assert len(output) == 5
+        keys = {item["Key"] for item in output}
+        assert keys == {"server", "team_id", "user_email", "current_experiment", "team_name"}
+
+
+def test_config_list_json_format_empty(tmp_config_dir):
+    """Test that --format=json outputs empty list when no config exists."""
+    config_dir, config_file = tmp_config_dir
+    with _patch_config_paths(config_dir, config_file):
+        result = runner.invoke(app, ["--format=json", "config"])
+        assert result.exit_code == 0
+        output = json.loads(result.output.strip())
+        assert output == []
+
+
+def test_config_set_json_format(tmp_config_dir):
+    """Test that setting a config key with --format=json outputs JSON."""
+    config_dir, config_file = tmp_config_dir
+    with _patch_config_paths(config_dir, config_file):
+        result = runner.invoke(app, ["--format=json", "config", "server", "http://localhost:8338"])
+        assert result.exit_code == 0
+        output = json.loads(result.output.strip())
+        assert output["key"] == "server"
+        assert output["value"] == "http://localhost:8338"
+
+
+def test_config_set_invalid_key_json_format(tmp_config_dir):
+    """Test that setting an invalid key with --format=json outputs JSON error."""
+    config_dir, config_file = tmp_config_dir
+    with _patch_config_paths(config_dir, config_file):
+        result = runner.invoke(app, ["--format=json", "config", "bad_key", "value"])
+        assert result.exit_code == 0
+        output = json.loads(result.output.strip())
+        assert "error" in output
+
+
+def test_config_key_without_value_json_format():
+    """Test that providing only a key with --format=json outputs JSON error."""
+    result = runner.invoke(app, ["--format=json", "config", "server"])
+    assert result.exit_code == 1
+    output = json.loads(result.output.strip())
+    assert "error" in output


### PR DESCRIPTION
## Summary
- The `config` command now respects the global `--format=json` flag for both list and set operations
- List outputs a JSON array of key/value objects; set outputs the key/value pair on success or a JSON error on failure
- Matches the existing pattern used by `task list`

## Test plan
- [x] All 19 config tests pass (`cd cli && python -m pytest tests/commands/test_config.py -v`)
- [x] All 47 CLI tests pass (`cd cli && python -m pytest tests/ -v`)
- [x] `ruff check` and `ruff format` clean