### PR TITLE
Improve AGENTS.md: add format:check, env prereqs, condense curl docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 - **Frontend dev**: `npm start` (Node v22, not v23+)
 - **Frontend test**: `npm test` (Jest); single test: `npm test -- --testPathPattern="<pattern>"`
-- **Frontend lint**: `npm run format`. **Always run `npm run format` on changed frontend files before committing.**
+- **Frontend lint**: `npm run format` (auto-fix) or `npm run format:check` (dry-run). **Always run `npm run format` on changed frontend files before committing.**
 - **Python env (run once per shell)**: `source ~/.transformerlab/miniforge3/bin/activate && conda activate ~/.transformerlab/envs/transformerlab`
 - **API install**: `cd api && ./install.sh` or `npm run api:install`
 - **API start**: `cd api && ./run.sh` or `npm run api:start`
@@ -26,6 +26,12 @@
 - **Dev (no Docker)**: `python scripts/dev.py` — runs both frontend and API side by side with hot reload. Requires the API conda env and Node v22. Checks ports 8338 (API) and 1212 (frontend) on startup and reports conflicts.
   - `dev.py` calls `api/run.sh` which automatically activates the conda env at `~/.transformerlab/envs/transformerlab`, so you do **not** need to activate conda yourself.
   - The conda env and dependencies must already be installed via `cd api && ./install.sh`. If Python dependencies change, the user needs to re-run `./install.sh` manually.
+
+## Environment Prerequisites
+
+- **Node v22** (v23+ is not supported)
+- **Python**: Managed via conda (`~/.transformerlab/envs/transformerlab`). Install with `cd api && ./install.sh`.
+- **npm deps**: `npm install` (includes `dotenv-cli`, `cross-env`, `concurrently` used by scripts)
 
 ## Architecture
 
@@ -121,45 +127,24 @@ When requested, verify the result with the following steps:
 
 ## Using curl to Access the API (Authentication)
 
-The API uses `fastapi-users` with JWT cookies and API keys. Most endpoints require authentication **and** a team context. When debugging or inspecting API responses with curl, follow this pattern:
-
-### Quick Start (cookie auth)
+The API uses `fastapi-users` with JWT cookies and API keys. Most endpoints require auth **and** an `X-Team-Id` header.
 
 ```bash
-# 1. Login — saves JWT cookies to cookies.txt
-curl -c cookies.txt -X POST http://localhost:8338/auth/cookie/login \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=admin@example.com&password=admin123"
-
-# 2. Get your team ID (required for most endpoints)
-curl -b cookies.txt http://localhost:8338/users/me/teams
-# Returns JSON array of teams — grab the "id" field from the first one
-
-# 3. Make authenticated requests — pass cookies + X-Team-Id header
-curl -b cookies.txt -H "X-Team-Id: <team-id>" http://localhost:8338/server/announcements
-```
-
-### Bearer token auth (no cookie file)
-
-```bash
-# Login via JWT endpoint — returns tokens in response body
+# Login and get a token
 TOKEN=$(curl -s -X POST http://localhost:8338/auth/jwt/login \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "username=admin@example.com&password=admin123" | jq -r .access_token)
 
-# Use the token (expires in 1 hour)
-curl -H "Authorization: Bearer $TOKEN" \
-  -H "X-Team-Id: <team-id>" \
-  http://localhost:8338/server/announcements
+# Get your team ID
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8338/users/me/teams
+
+# Make authenticated requests
+curl -H "Authorization: Bearer $TOKEN" -H "X-Team-Id: <team-id>" http://localhost:8338/server/announcements
 ```
 
-### Key details
-
-- **Login format**: Must be `application/x-www-form-urlencoded` with `username` and `password` fields (OAuth2 password flow).
-- **Default credentials**: `admin@example.com` / `admin123` (seeded on first startup).
-- **X-Team-Id header**: Required on all protected endpoints. Get it from `GET /users/me/teams`. Without it, requests return 400.
-- **Token lifetime**: Access tokens expire after 1 hour. Re-login to get a new one.
-- **Unprotected endpoints**: `auth`, `api_keys`, `quota`, `compute_provider`, and the OpenAI-compatible API do not require auth.
+- **Credentials**: `admin@example.com` / `admin123` (seeded on first startup). Tokens expire after 1 hour.
+- **X-Team-Id**: Required on all protected endpoints. Get it from `GET /users/me/teams`.
+- **Unprotected endpoints**: `auth`, `api_keys`, `quota`, `compute_provider`, and the OpenAI-compatible API.
 
 ## Agentic Performance Optimization
 


### PR DESCRIPTION
## Summary
- Document `npm run format:check` dry-run option alongside `npm run format`
- Add Environment Prerequisites section listing Node v22, conda env, and npm dependency requirements
- Condense the curl authentication section from ~40 lines to ~15 lines, keeping a single bearer-token example flow

## Test plan
- [ ] Verify all documented commands still work
- [ ] Confirm AGENTS.md and CLAUDE.md remain in sync