### PR TITLE
fix: apply trackio fixes for experiment ID and modal behavior

### DIFF
--- a/api/transformerlab/routers/trackio.py
+++ b/api/transformerlab/routers/trackio.py
@@ -12,7 +12,7 @@ router = APIRouter(tags=["train"])
 
 
 @router.get("/trackio/start")
-async def trackio_start(job_id: str, user_and_team=Depends(get_user_and_team)) -> dict:
+async def trackio_start(job_id: str, experiment_id: str, user_and_team=Depends(get_user_and_team)) -> dict:
     """
     Start a Trackio dashboard for the given job and return its local URL.
 
@@ -20,7 +20,6 @@ async def trackio_start(job_id: str, user_and_team=Depends(get_user_and_team)) -
     be scoped to the correct workspace and kept isolated per job.
     """
     org_id = str(user_and_team.get("team_id") or "")
-    experiment_id = user_and_team.get("experiment_id")
     return await start_trackio_for_job(job_id, org_id=org_id, experiment_id=experiment_id)
 
 

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -1421,6 +1421,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
       />
       <TrackioModal
         jobId={trackioJobIdForModal}
+        experimentId={experimentInfo?.id ?? null}
         onClose={() => setTrackioJobIdForModal(null)}
       />
       <DeleteTaskConfirmModal

--- a/src/renderer/components/Experiment/Tasks/TrackioModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/TrackioModal.tsx
@@ -15,10 +15,11 @@ import { fetcher } from 'renderer/lib/transformerlab-api-sdk';
 
 interface TrackioModalProps {
   jobId: string | null;
+  experimentId: string | number | null;
   onClose: () => void;
 }
 
-export default function TrackioModal({ jobId, onClose }: TrackioModalProps) {
+export default function TrackioModal({ jobId, experimentId, onClose }: TrackioModalProps) {
   const [iframeReady, setIframeReady] = useState(false);
   const [trackioUrl, setTrackioUrl] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
@@ -33,7 +34,7 @@ export default function TrackioModal({ jobId, onClose }: TrackioModalProps) {
 
       try {
         const response = await chatAPI.authenticatedFetch(
-          `${chatAPI.API_URL()}trackio/start?job_id=${jobId}`,
+          `${chatAPI.API_URL()}trackio/start?job_id=${jobId}&experiment_id=${experimentId}`,
         );
         if (!response.ok) {
           const txt = await response.text();
@@ -45,7 +46,14 @@ export default function TrackioModal({ jobId, onClose }: TrackioModalProps) {
         }
         const data = (await response.json()) as { url?: string };
         if (!cancelled && data.url) {
-          setTrackioUrl(data.url);
+          // Replace localhost/127.0.0.1 with the actual server hostname so the
+          // iframe loads correctly when the user's browser is remote from the server.
+          const serverHost = window.location.hostname;
+          const resolvedUrl = data.url.replace(
+            /localhost|127\.0\.0\.1/,
+            serverHost,
+          );
+          setTrackioUrl(resolvedUrl);
           setIframeReady(true);
         }
       } catch (e) {
@@ -75,7 +83,7 @@ export default function TrackioModal({ jobId, onClose }: TrackioModalProps) {
         );
       }
     };
-  }, [jobId]);
+  }, [jobId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleClose = () => {
     onClose();


### PR DESCRIPTION
<img width="1452" height="468" alt="Screenshot 2026-03-28 at 10 07 04 PM" src="https://github.com/user-attachments/assets/d6500d3c-27a0-4449-a30e-977160401b13" />

The endpoint was reading experiment_id from auth context (where it was
never set), always getting None and raising a 400 error.

- Backend: add `experiment_id` as an explicit query param to /trackio/start
- Frontend: pass experimentId prop to TrackioModal and include it in the
  fetch URL; also replace localhost/127.0.0.1 in the returned Trackio URL
  with the actual server hostname so the iframe loads correctly in remote
  browsers