### PR TITLE
Add Claude Code skill for the Transformer Lab CLI

### DIFF
--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -1,35 +1,145 @@
 ---
 name: transformerlab-cli
-description: Use the Transformer Lab CLI to check job status, stream logs, download artifacts, list tasks, manage providers, and query backend state. Use when you need structured data from the Transformer Lab API without going through the browser UI.
+description: Transformer Lab CLI for managing ML training tasks, jobs, and compute providers. Use when the user needs to check job status, stream logs, download artifacts, queue training tasks, manage compute providers, or interact with Transformer Lab programmatically. Triggers include "check job status", "download results", "queue a task", "list providers", "stream logs", "what's running", "monitor training", "add a task", "check provider health".
+allowed-tools: Bash(lab *)
 ---
 
 # Transformer Lab CLI
 
-Use the Transformer Lab CLI to interact with the backend programmatically. This complements the `agent-browser` skill — use the browser for UI interactions (creating experiments, configuring tasks, visual verification) and the CLI for structured data queries (job status, logs, artifacts, task lists).
+Use the `lab` CLI to interact with Transformer Lab programmatically — managing tasks, jobs, compute providers, and server configuration from the terminal.
 
-## Invocation
-
-All commands run from the repo root:
+## Installation
 
 ```bash
-uv run cli/src/transformerlab_cli/main.py <command> [subcommand] [options]
+uv tool install transformerlab-cli
+# or
+pip install transformerlab-cli
 ```
 
-Global option: `--format json` produces machine-readable JSON output. Default is `pretty` with Rich-formatted tables and panels.
+Verify: `lab version`
 
-## Prerequisites
+## First-Time Setup
 
-- `uv` must be installed
-- A running Transformer Lab server (default: `http://localhost:8338`)
-- **Required for most commands:** `server`, `team_id`, and `user_email` must be configured. Run `login` to set all three automatically.
-- **Required for `task` and `job` commands:** a current experiment must also be set
-
-Quick setup:
 ```bash
-uv run cli/src/transformerlab_cli/main.py status
-uv run cli/src/transformerlab_cli/main.py login
-uv run cli/src/transformerlab_cli/main.py config set current_experiment <experiment_id>
+lab login --server https://your-server:8338 --api-key YOUR_KEY
+lab config set current_experiment your_experiment_name
+lab status   # verify connectivity
 ```
+
+`login` automatically configures `server`, `team_id`, `user_email`, and `team_name`.
+
+## Critical: `--format` Flag Placement
+
+The `--format` flag is a **root-level option** and MUST come immediately after `lab`, before any subcommand:
+
+```bash
+# CORRECT
+lab --format json job list
+lab --format json task info 42
+
+# WRONG — will be ignored or cause an error
+lab job list --format json
+```
+
+**Always use `--format json` when you need to parse output.** The default `pretty` format uses Rich tables that are not machine-parseable.
+
+## Core Workflow
+
+The standard pattern for working with Transformer Lab:
+
+```bash
+# 1. Check server is up
+lab status
+
+# 2. List available tasks
+lab --format json task list
+
+# 3. Queue a task on a compute provider
+lab --format json task queue TASK_ID --no-interactive
+
+# 4. Monitor the job
+lab --format json job list --running
+lab job logs JOB_ID --follow
+
+# 5. Download results
+lab --format json job artifacts JOB_ID
+lab job download JOB_ID --file "*.csv" -o ./results
+```
+
+## Agent-Specific Rules
+
+1. **Always use `--format json`** for any command whose output you need to parse
+2. **Use `--no-interactive`** on `task queue` and `provider add` to avoid blocking prompts
+3. **Use `--yes` / `-y`** on destructive commands (`provider delete`) to skip confirmation
+4. **Never use `job monitor`** — it launches a TUI that blocks; use `job list` + `job logs` instead
+5. **Never use `task interactive`** unless the user specifically requests an interactive session
+6. **`job logs --follow`** streams continuously and blocks until the job finishes — use when the user wants real-time monitoring
+
+## Command Overview
+
+| Command | Description | Requires Experiment |
+|---|---|---|
+| `lab status` | Check server connectivity | No |
+| `lab config` | View/set CLI configuration | No |
+| `lab login` | Authenticate (sets server, team, user) | No |
+| `lab logout` | Remove stored API key | No |
+| `lab whoami` | Show current user and team | No |
+| `lab version` | Show CLI version | No |
+| `lab task list` | List tasks in current experiment | Yes |
+| `lab task info <id>` | Get task details | Yes |
+| `lab task add [dir]` | Add task from directory or `--from-git` URL | Yes |
+| `lab task delete <id>` | Delete a task | Yes |
+| `lab task queue <id>` | Queue task on compute provider | Yes |
+| `lab task gallery` | Browse/import from task gallery | Yes |
+| `lab job list` | List jobs (`--running` for active only) | Yes |
+| `lab job info <id>` | Get detailed job information | Yes |
+| `lab job logs <id>` | Fetch logs (`--follow` to stream) | Yes |
+| `lab job artifacts <id>` | List job artifacts | Yes |
+| `lab job download <id>` | Download artifacts (`--file` for glob) | Yes |
+| `lab job stop <id>` | Stop a running job | Yes |
+| `lab provider list` | List compute providers | No |
+| `lab provider info <id>` | Show provider details | No |
+| `lab provider add` | Add a new provider | No |
+| `lab provider update <id>` | Update provider config | No |
+| `lab provider delete <id>` | Delete a provider (`--yes` to skip prompt) | No |
+| `lab provider check <id>` | Check provider health | No |
+| `lab provider enable <id>` | Enable a provider | No |
+| `lab provider disable <id>` | Disable a provider | No |
+| `lab server install` | Interactive server setup wizard | No |
+| `lab server version` | Show installed server version | No |
+| `lab server update` | Update server to latest | No |
+
+## JSON Output Shapes
+
+**`lab --format json job list`** returns an array:
+```json
+[{"id": 1, "status": "COMPLETE", "progress": 100, "job_data": {...}, "created_at": "..."}]
+```
+
+**`lab --format json task list`** returns an array:
+```json
+[{"id": 1, "name": "my-task", "type": "TRAINING", ...}]
+```
+
+**`lab --format json task queue <id>`** returns the created job:
+```json
+{"id": 42, "status": "WAITING", ...}
+```
+
+**Errors** return:
+```json
+{"error": "error message here"}
+```
+
+With non-zero exit code.
+
+## Error Handling
+
+- Commands exit with non-zero status on failure
+- With `--format json`, errors return `{"error": "<message>"}`
+- "config not set" errors → run `lab login` first
+- "current_experiment not set" → run `lab config set current_experiment <id>`
+- Connection refused → check server URL with `lab config`, verify server is running
 
 ## When to Use CLI vs Browser
 
@@ -38,103 +148,19 @@ uv run cli/src/transformerlab_cli/main.py config set current_experiment <experim
 | Checking job/task status | Creating experiments |
 | Streaming job logs | Configuring tasks via forms |
 | Downloading artifacts | Visual UI verification |
-| Listing providers | Navigating the app |
+| Listing/managing providers | Navigating the app |
 | Querying structured data | Anything requiring UI interaction |
 
-Typical flow: use `agent-browser` to create and configure a task in the UI, then switch to CLI to queue it, monitor the job, and download results.
+Typical flow: use the browser to create and configure a task in the UI, then switch to CLI to queue it, monitor the job, and download results.
 
-## Common Workflow Patterns
+## Deep-Dive References
 
-**Monitor a running job:**
-```bash
-uv run cli/src/transformerlab_cli/main.py job list --format json
-uv run cli/src/transformerlab_cli/main.py job logs <job_id> --follow
-```
+- `references/commands.md` — Full command reference with all options
+- `references/workflows.md` — End-to-end workflow patterns
+- `references/troubleshooting.md` — Error patterns and recovery
 
-**Queue a task and track it:**
-```bash
-uv run cli/src/transformerlab_cli/main.py task list --format json
-uv run cli/src/transformerlab_cli/main.py task queue <task_id> --no-interactive
-uv run cli/src/transformerlab_cli/main.py job list --running --format json
-uv run cli/src/transformerlab_cli/main.py job logs <job_id> --follow
-```
+## Ready-to-Use Templates
 
-**Check system state:**
-```bash
-uv run cli/src/transformerlab_cli/main.py status
-uv run cli/src/transformerlab_cli/main.py provider list
-uv run cli/src/transformerlab_cli/main.py job list
-```
-
-**Download job results:**
-```bash
-uv run cli/src/transformerlab_cli/main.py job artifacts <job_id>
-uv run cli/src/transformerlab_cli/main.py job download <job_id> --file "*.csv" -o ./results
-uv run cli/src/transformerlab_cli/main.py job download <job_id> -o ./results
-```
-
-**Complement browser testing:**
-```bash
-# After creating a job via the browser UI...
-uv run cli/src/transformerlab_cli/main.py job list --running --format json
-uv run cli/src/transformerlab_cli/main.py job info <job_id>
-uv run cli/src/transformerlab_cli/main.py job logs <job_id>
-```
-
-## Command Overview
-
-See `references/commands.md` for full details on every option.
-
-| Command | Description |
-|---|---|
-| `status` | Check server connectivity |
-| `config` | View/set CLI configuration |
-| `login` | Authenticate (also sets server, team_id, user_email, team_name) |
-| `logout` | Remove stored API key |
-| `whoami` | Show current user and team |
-| `version` | Show CLI version |
-| `task list` | List tasks in current experiment |
-| `task info <id>` | Get task details |
-| `task add [dir]` | Add task from local directory or `--from-git` URL |
-| `task delete <id>` | Delete a task |
-| `task queue <id>` | Queue task on a compute provider |
-| `task gallery` | Browse and import from task gallery |
-| `task interactive` | Launch interactive task (Jupyter, vLLM, etc.) |
-| `job list` | List jobs (optionally `--running` only) |
-| `job info <id>` | Get detailed job information |
-| `job logs <id>` | Fetch logs (`--follow` to stream) |
-| `job artifacts <id>` | List job artifacts |
-| `job download <id>` | Download artifacts (`--file` for specific files) |
-| `job stop <id>` | Stop a running job |
-| `job monitor` | Launch interactive TUI monitor |
-| `provider list` | List compute providers |
-| `provider info <id>` | Show provider details |
-| `provider add` | Add a new compute provider |
-| `provider update <id>` | Update provider config |
-| `provider delete <id>` | Delete a provider |
-| `provider check <id>` | Check provider health |
-| `provider enable <id>` | Enable a provider |
-| `provider disable <id>` | Disable a provider |
-
-## Tips
-
-- **`--format` must come before the subcommand.** It is a root-level Typer callback option, not a per-command option. Place it immediately after the script path:
-  ```bash
-  # Correct
-  uv run cli/src/transformerlab_cli/main.py --format json task add /path/to/dir
-
-  # Wrong — will be ignored or cause an error
-  uv run cli/src/transformerlab_cli/main.py task add /path/to/dir --format json
-  ```
-- Use `--format json` when you need to parse output (e.g., extracting a job ID from `job list`)
-- `job logs --follow` streams continuously until the job exits an active state (RUNNING, LAUNCHING, INTERACTIVE, WAITING)
-- `task queue --no-interactive` skips all prompts and uses defaults — ideal for automated workflows
-- `job monitor` launches a full TUI — avoid in non-interactive contexts
-- Config keys: `server`, `current_experiment`, `user_email`, `team_id`, `team_name`
-
-## Error Handling
-
-- Commands exit with a non-zero status code on failure
-- With `--format json`, errors return `{"error": "<message>"}`
-- With `--format pretty`, errors print with `[error]Error:[/error]` styling
-- If you get "config not set" errors, run `login` first to configure `server`, `team_id`, and `user_email`
+- `templates/setup-and-login.sh` — First-time setup
+- `templates/queue-and-monitor.sh` — Queue a task and monitor until completion
+- `templates/provider-health-check.sh` — Check health of all providers

--- a/.agents/skills/transformerlab-cli/references/commands.md
+++ b/.agents/skills/transformerlab-cli/references/commands.md
@@ -3,11 +3,19 @@
 Full reference for every CLI command. All commands are invoked via:
 
 ```bash
-uv run cli/src/transformerlab_cli/main.py <command> [subcommand] [options]
+lab <command> [subcommand] [options]
 ```
 
 Global option available on all commands:
-- `--format pretty|json` — Output format (default: `pretty`)
+- `--format pretty|json` — Output format (default: `pretty`). **Must come before the subcommand.**
+
+```bash
+# Correct
+lab --format json task list
+
+# Wrong — flag will be ignored
+lab task list --format json
+```
 
 ---
 
@@ -15,21 +23,31 @@ Global option available on all commands:
 
 ### `version`
 
-Display CLI version.
+Display CLI version and check for updates.
+
+**JSON output:**
+```json
+{"version": "0.0.6", "update_available": false}
+```
 
 ### `status`
 
-Check server connectivity.
+Check server connectivity and configuration status.
+
+**JSON output:**
+```json
+{"server": "http://localhost:8338", "connected": true, "server_version": "0.33.0"}
+```
 
 ### `config [args...]`
 
 View, get, and set configuration values.
 
 ```bash
-config                        # List all config values
-config <key>                  # Get a specific value
-config get <key>              # Get a specific value (explicit)
-config set <key> <value>      # Set a value
+lab config                        # List all config values
+lab config <key>                  # Get a specific value
+lab config get <key>              # Get a specific value (explicit)
+lab config set <key> <value>      # Set a value
 ```
 
 Valid keys: `server`, `current_experiment`, `user_email`, `team_id`, `team_name`
@@ -51,17 +69,34 @@ Remove stored API key.
 
 Show current user, team, and server.
 
+**JSON output:**
+```json
+{"email": "user@example.com", "team_id": "...", "team_name": "...", "server": "http://localhost:8338"}
+```
+
 ---
 
 ## Task Commands
+
+**All task commands require `current_experiment` to be set.**
 
 ### `task list`
 
 List all remote tasks in the current experiment.
 
+**JSON output:**
+```json
+[{"id": 1, "name": "my-task", "type": "TRAINING", "status": "READY", ...}]
+```
+
 ### `task info <task_id>`
 
 Get details for a specific task.
+
+**JSON output:**
+```json
+{"id": 1, "name": "my-task", "type": "TRAINING", "config": {...}, ...}
+```
 
 ### `task add [directory]`
 
@@ -71,6 +106,8 @@ Add a new task from a local directory containing `task.yaml`, or from a Git repo
 |---|---|
 | `--from-git <url>` | Import from a Git repository instead of local directory |
 | `--dry-run` | Preview the task without creating it |
+
+**JSON output:** Returns the created task object.
 
 ### `task delete <task_id>`
 
@@ -82,16 +119,20 @@ Queue a task on a compute provider.
 
 | Option | Description |
 |---|---|
-| `--no-interactive` | Skip prompts. Uses the task's configured provider if set, otherwise the first available provider. Parameters use their default values. |
+| `--no-interactive` | Skip prompts. Uses the task's configured provider or first available. Parameters use defaults. **Always use this in automated workflows.** |
+
+**JSON output:** Returns the created job object with `id` and `status`.
 
 ### `task gallery`
 
-Browse the task gallery. Optionally import a task directly.
+Browse the task gallery. Use `--import` to non-interactively import a specific task.
 
 | Option | Description |
 |---|---|
 | `--type all\|interactive` | Filter gallery type (default: `all`) |
-| `--import <gallery_id>` | Import a gallery task directly |
+| `--import <gallery_id>` | Import a gallery task directly (non-interactive) |
+
+**Note:** Without `--import`, this command is interactive. Avoid in automated contexts.
 
 ### `task interactive`
 
@@ -101,9 +142,13 @@ Launch an interactive task (Jupyter, vLLM, Ollama, etc.).
 |---|---|
 | `--timeout <seconds>` | Timeout waiting for service readiness (default: 300) |
 
+**Warning:** This is inherently interactive and blocks. Only use when the user specifically requests it.
+
 ---
 
 ## Job Commands
+
+**All job commands require `current_experiment` to be set.**
 
 ### `job list`
 
@@ -113,9 +158,21 @@ List all jobs in the current experiment.
 |---|---|
 | `--running` | Show only active jobs (WAITING, LAUNCHING, RUNNING, INTERACTIVE) |
 
+**JSON output:**
+```json
+[{"id": 1, "status": "COMPLETE", "progress": 100, "job_data": {...}, "created_at": "...", ...}]
+```
+
+Job statuses: `WAITING`, `LAUNCHING`, `RUNNING`, `INTERACTIVE`, `COMPLETE`, `FAILED`, `STOPPED`
+
 ### `job info <job_id>`
 
 Get detailed job information including status, progress, config, resources, provider, artifacts, errors, and scores.
+
+**JSON output:**
+```json
+{"id": 1, "status": "RUNNING", "progress": 45, "config": {...}, "artifacts": [...], "errors": [...], ...}
+```
 
 ### `job logs <job_id>`
 
@@ -123,11 +180,18 @@ Fetch provider logs for a job.
 
 | Option | Description |
 |---|---|
-| `--follow` / `-f` | Stream new lines continuously. Polls every 2 seconds. Stops automatically when the job exits an active state (RUNNING, LAUNCHING, INTERACTIVE, WAITING). |
+| `--follow` / `-f` | Stream new lines continuously. Polls every 2 seconds. Stops automatically when the job exits an active state. |
+
+**Note:** `--follow` blocks until the job finishes. Use it for real-time monitoring.
 
 ### `job artifacts <job_id>`
 
 List job artifacts with filename, path, and size.
+
+**JSON output:**
+```json
+[{"filename": "model.bin", "path": "/path/to/file", "size": 1024000}]
+```
 
 ### `job download <job_id>`
 
@@ -144,11 +208,15 @@ Stop a running job.
 
 ### `job monitor`
 
-Launch the interactive job monitor TUI (Textual app). Not suitable for non-interactive or automated use.
+Launch the interactive job monitor TUI (Textual app).
+
+**Warning:** This launches a full terminal UI. **Never use in automated or agent contexts.** Use `job list` + `job logs` instead.
 
 ---
 
 ## Provider Commands
+
+**Provider commands do NOT require `current_experiment`.**
 
 ### `provider list`
 
@@ -157,6 +225,11 @@ List all compute providers.
 | Option | Description |
 |---|---|
 | `--include-disabled` | Include disabled providers in the list |
+
+**JSON output:**
+```json
+[{"id": 1, "name": "local", "type": "local", "disabled": false, "healthy": true, ...}]
+```
 
 ### `provider info <provider_id>`
 
@@ -169,9 +242,11 @@ Add a new compute provider. Interactive prompts by default.
 | Option | Description |
 |---|---|
 | `--name <name>` | Provider name |
-| `--type <type>` | Provider type: `slurm`, `skypilot`, `runpod`, `local`. Note: `local` has no config fields. |
+| `--type <type>` | Provider type: `slurm`, `skypilot`, `runpod`, `local` |
 | `--config <json>` | Config as JSON string |
-| `--interactive` / `--no-interactive` | Toggle interactive prompts (default: interactive). Non-interactive requires `--name` and `--type`; `--config` is also required unless `--type local` (which has no config fields). |
+| `--interactive` / `--no-interactive` | Toggle prompts. Non-interactive requires `--name` and `--type`; `--config` also required unless `--type local`. |
+
+**Always use `--no-interactive` with `--name`, `--type`, and `--config` in automated workflows.**
 
 ### `provider update <provider_id>`
 
@@ -189,7 +264,7 @@ Delete a compute provider.
 
 | Option | Description |
 |---|---|
-| `--yes` / `-y` | Skip confirmation prompt |
+| `--yes` / `-y` | Skip confirmation prompt. **Always use in automated workflows.** |
 
 ### `provider check <provider_id>`
 
@@ -202,3 +277,24 @@ Enable a disabled provider.
 ### `provider disable <provider_id>`
 
 Disable a provider.
+
+---
+
+## Server Commands
+
+### `server install`
+
+Interactive setup wizard for Transformer Lab server. Configures frontend URL, storage backend, admin account, compute provider, email, and auth.
+
+| Option | Description |
+|---|---|
+| `--dry-run` | Preview configuration without installing |
+| `--config <path>` | Path to a config file |
+
+### `server version`
+
+Show installed server version.
+
+### `server update`
+
+Update to latest server version.

--- a/.agents/skills/transformerlab-cli/references/troubleshooting.md
+++ b/.agents/skills/transformerlab-cli/references/troubleshooting.md
@@ -1,0 +1,166 @@
+# Transformer Lab CLI — Troubleshooting
+
+Common errors and how to resolve them.
+
+---
+
+## "config not set" or Missing Configuration
+
+**Symptom:** Commands fail with errors about missing `server`, `team_id`, or `user_email`.
+
+**Fix:** Run `lab login` to configure all required settings at once:
+```bash
+lab login --server https://your-server:8338 --api-key YOUR_KEY
+```
+
+To check current config:
+```bash
+lab config
+```
+
+---
+
+## "current_experiment not set"
+
+**Symptom:** Task and job commands fail because no experiment is selected.
+
+**Fix:**
+```bash
+# Find available experiments via the API or ask the user
+lab config set current_experiment EXPERIMENT_NAME
+```
+
+---
+
+## Connection Refused / Cannot Connect
+
+**Symptom:** `lab status` fails or commands time out.
+
+**Possible causes:**
+1. Server is not running
+2. Wrong server URL configured
+3. Network/firewall issue
+
+**Fix:**
+```bash
+# Check configured server URL
+lab config server
+
+# Update if wrong
+lab config set server http://correct-host:8338
+
+# Verify
+lab status
+```
+
+---
+
+## Authentication Errors (401/403)
+
+**Symptom:** Commands return authentication or permission errors.
+
+**Fix:**
+```bash
+# Re-authenticate
+lab logout
+lab login --server https://your-server:8338 --api-key YOUR_NEW_KEY
+
+# Verify
+lab whoami
+```
+
+API keys may have expired or been revoked. Get a new one from the Transformer Lab UI.
+
+---
+
+## "No Compute Providers Available"
+
+**Symptom:** `task queue` fails because no providers are configured or enabled.
+
+**Fix:**
+```bash
+# Check existing providers
+lab --format json provider list --include-disabled
+
+# If none exist, add one
+lab --format json provider add --name local --type local --no-interactive
+
+# If disabled, enable it
+lab provider enable PROVIDER_ID
+
+# Verify health
+lab --format json provider check PROVIDER_ID
+```
+
+---
+
+## Command Hangs / Blocks
+
+**Symptom:** A command seems to hang and waits for input.
+
+**Cause:** Interactive commands block when they need user input.
+
+**Fix:** Use non-interactive flags:
+- `task queue` → add `--no-interactive`
+- `provider add` → add `--no-interactive` with `--name`, `--type`, `--config`
+- `provider delete` → add `--yes`
+- `task gallery` → use `--import GALLERY_ID` instead of browsing
+
+**Never use these commands in automated contexts:**
+- `job monitor` (launches TUI)
+- `task interactive` (blocks for interactive session)
+
+---
+
+## `--format json` Not Working
+
+**Symptom:** Output is still pretty-printed despite using `--format json`.
+
+**Cause:** The `--format` flag must come before the subcommand.
+
+**Fix:**
+```bash
+# WRONG
+lab task list --format json
+
+# CORRECT
+lab --format json task list
+```
+
+---
+
+## Job Stuck in WAITING or LAUNCHING
+
+**Symptom:** Job status doesn't progress past WAITING or LAUNCHING.
+
+**Diagnosis:**
+```bash
+# Check job details
+lab --format json job info JOB_ID
+
+# Check provider health
+lab --format json provider check PROVIDER_ID
+
+# Check provider logs
+lab job logs JOB_ID
+```
+
+**Common causes:**
+- Provider is offline or unhealthy
+- Provider queue is full
+- Resource requirements exceed provider capacity
+
+---
+
+## Exit Codes
+
+| Exit Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | General error (check stderr or JSON `{"error": "..."}`) |
+| 2 | Invalid arguments or missing required options |
+
+With `--format json`, errors always return:
+```json
+{"error": "descriptive error message"}
+```

--- a/.agents/skills/transformerlab-cli/references/workflows.md
+++ b/.agents/skills/transformerlab-cli/references/workflows.md
@@ -1,0 +1,200 @@
+# Transformer Lab CLI — Workflow Patterns
+
+End-to-end workflows with complete command sequences. All examples use `--format json` for machine-parseable output.
+
+---
+
+## 1. First-Time Setup
+
+Install the CLI, authenticate, and configure for use.
+
+```bash
+# Install the CLI
+uv tool install transformerlab-cli
+
+# Verify installation
+lab version
+
+# Login to the server (interactive — prompts for server URL and API key)
+lab login --server https://your-server:8338 --api-key YOUR_API_KEY
+
+# Verify authentication
+lab --format json whoami
+
+# List experiments to find one to work with
+lab --format json config
+
+# Set the current experiment
+lab config set current_experiment my_experiment
+
+# Verify everything works
+lab status
+lab --format json task list
+```
+
+---
+
+## 2. Task Lifecycle: Gallery → Import → Queue → Monitor → Download
+
+The most common workflow: find a task in the gallery, import it, run it, and get results.
+
+```bash
+# Browse the task gallery
+lab --format json task gallery --type all
+
+# Import a specific task from the gallery
+lab --format json task gallery --import GALLERY_ID
+
+# List tasks to get the imported task's ID
+lab --format json task list
+
+# Queue the task (non-interactive — uses defaults)
+lab --format json task queue TASK_ID --no-interactive
+# Returns: {"id": JOB_ID, "status": "WAITING", ...}
+
+# Monitor the job — poll until complete
+lab --format json job list --running
+# Repeat until the job no longer appears in the running list
+
+# Or stream logs in real-time (blocks until job finishes)
+lab job logs JOB_ID --follow
+
+# Check final status
+lab --format json job info JOB_ID
+
+# List and download artifacts
+lab --format json job artifacts JOB_ID
+lab job download JOB_ID -o ./results
+# Or download specific files
+lab job download JOB_ID --file "*.csv" --file "*.json" -o ./results
+```
+
+---
+
+## 3. Task from Git Repository
+
+Add a task directly from a GitHub repo.
+
+```bash
+# Add task from Git URL
+lab --format json task add --from-git https://github.com/user/repo
+
+# Verify it was added
+lab --format json task list
+
+# Queue it
+lab --format json task queue TASK_ID --no-interactive
+```
+
+---
+
+## 4. Task from Local Directory
+
+Add a task from a local directory containing `task.yaml`.
+
+```bash
+# Preview first (dry run)
+lab --format json task add ./my-task --dry-run
+
+# Add the task
+lab --format json task add ./my-task
+
+# Queue it
+lab --format json task queue TASK_ID --no-interactive
+```
+
+---
+
+## 5. Provider Management
+
+Add, configure, and monitor compute providers.
+
+```bash
+# List current providers
+lab --format json provider list
+
+# Add a new provider (non-interactive)
+lab --format json provider add --name my-slurm --type slurm --config '{"host": "cluster.example.com", "user": "admin"}' --no-interactive
+
+# Check provider health
+lab --format json provider check PROVIDER_ID
+
+# Disable a provider temporarily
+lab provider disable PROVIDER_ID
+
+# Re-enable it
+lab provider enable PROVIDER_ID
+
+# Update provider config (merges with existing)
+lab --format json provider update PROVIDER_ID --config '{"partition": "gpu"}'
+
+# Delete a provider
+lab provider delete PROVIDER_ID --yes
+```
+
+---
+
+## 6. Job Monitoring Pattern
+
+Poll for job status and stream logs.
+
+```bash
+# List only running jobs
+lab --format json job list --running
+
+# Get detailed info on a specific job
+lab --format json job info JOB_ID
+
+# Stream logs (blocks until job finishes or is stopped)
+lab job logs JOB_ID --follow
+
+# Stop a job if needed
+lab job stop JOB_ID
+
+# After completion, check for errors
+lab --format json job info JOB_ID
+# Look at the "status" field: COMPLETE, FAILED, or STOPPED
+# Look at the "errors" field for failure details
+```
+
+### Polling Pattern for Agents
+
+When monitoring a job programmatically, use this pattern:
+
+```bash
+# 1. Queue and capture job ID
+JOB_JSON=$(lab --format json task queue TASK_ID --no-interactive)
+JOB_ID=$(echo "$JOB_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+# 2. Poll until not running
+while true; do
+  STATUS=$(lab --format json job info "$JOB_ID" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
+  case "$STATUS" in
+    COMPLETE) echo "Done!"; break ;;
+    FAILED|STOPPED) echo "Job $STATUS"; break ;;
+    *) sleep 10 ;;
+  esac
+done
+
+# 3. Download results
+lab job download "$JOB_ID" -o ./results
+```
+
+---
+
+## 7. System Health Check
+
+Quick check of server and all providers.
+
+```bash
+# Check server
+lab status
+
+# Check all providers
+lab --format json provider list
+# For each provider ID, run:
+lab --format json provider check PROVIDER_ID
+
+# List any running jobs
+lab --format json job list --running
+```

--- a/.agents/skills/transformerlab-cli/templates/provider-health-check.sh
+++ b/.agents/skills/transformerlab-cli/templates/provider-health-check.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Template: Check health of all compute providers
+# Lists all providers and checks each one's connectivity.
+#
+# Usage: ./provider-health-check.sh [--include-disabled]
+
+set -euo pipefail
+
+INCLUDE_DISABLED=""
+if [ "${1:-}" = "--include-disabled" ]; then
+    INCLUDE_DISABLED="--include-disabled"
+fi
+
+echo "Checking compute provider health..."
+echo ""
+
+# 1. Get provider list as JSON
+PROVIDERS=$(lab --format json provider list $INCLUDE_DISABLED)
+
+# 2. Extract provider IDs and names
+PROVIDER_COUNT=$(echo "$PROVIDERS" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
+
+if [ "$PROVIDER_COUNT" -eq 0 ]; then
+    echo "No compute providers configured."
+    echo "Add one with: lab provider add --name <name> --type <type> --no-interactive"
+    exit 0
+fi
+
+echo "Found $PROVIDER_COUNT provider(s):"
+echo ""
+
+# 3. Check each provider
+echo "$PROVIDERS" | python3 -c "
+import sys, json
+providers = json.load(sys.stdin)
+for p in providers:
+    print(f\"{p['id']}|{p['name']}|{p.get('type', '?')}|{'disabled' if p.get('disabled') else 'enabled'}\")
+" | while IFS='|' read -r id name type status; do
+    printf "  %-4s %-20s %-10s %-10s " "$id" "$name" "$type" "$status"
+
+    if [ "$status" = "disabled" ]; then
+        echo "[SKIPPED]"
+        continue
+    fi
+
+    # Run health check
+    if lab --format json provider check "$id" > /dev/null 2>&1; then
+        echo "[HEALTHY]"
+    else
+        echo "[UNHEALTHY]"
+    fi
+done
+
+echo ""
+echo "Done."

--- a/.agents/skills/transformerlab-cli/templates/queue-and-monitor.sh
+++ b/.agents/skills/transformerlab-cli/templates/queue-and-monitor.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Template: Queue a task and monitor until completion
+# Queues a task non-interactively, polls for job completion, and downloads results.
+#
+# Usage: ./queue-and-monitor.sh <task_id> [output_dir]
+#
+# Arguments:
+#   task_id    — The ID of the task to queue
+#   output_dir — Directory to download results to (default: ./results)
+
+set -euo pipefail
+
+TASK_ID="${1:?Usage: $0 <task_id> [output_dir]}"
+OUTPUT_DIR="${2:-./results}"
+POLL_INTERVAL=10
+
+echo "Queuing task $TASK_ID..."
+
+# 1. Queue the task and capture the job ID
+JOB_JSON=$(lab --format json task queue "$TASK_ID" --no-interactive)
+JOB_ID=$(echo "$JOB_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+echo "Job created: $JOB_ID"
+
+# 2. Poll until the job finishes
+echo "Monitoring job $JOB_ID..."
+while true; do
+    STATUS=$(lab --format json job info "$JOB_ID" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
+    PROGRESS=$(lab --format json job info "$JOB_ID" | python3 -c "import sys,json; print(json.load(sys.stdin).get('progress', 0))" 2>/dev/null || echo "?")
+
+    echo "  Status: $STATUS  Progress: $PROGRESS%"
+
+    case "$STATUS" in
+        COMPLETE)
+            echo "Job completed successfully!"
+            break
+            ;;
+        FAILED)
+            echo "Job failed. Check logs:"
+            echo "  lab job logs $JOB_ID"
+            exit 1
+            ;;
+        STOPPED)
+            echo "Job was stopped."
+            exit 1
+            ;;
+        *)
+            sleep "$POLL_INTERVAL"
+            ;;
+    esac
+done
+
+# 3. List artifacts
+echo ""
+echo "Artifacts:"
+lab --format json job artifacts "$JOB_ID"
+
+# 4. Download results
+echo ""
+echo "Downloading results to $OUTPUT_DIR..."
+mkdir -p "$OUTPUT_DIR"
+lab job download "$JOB_ID" -o "$OUTPUT_DIR"
+
+echo "Done! Results saved to $OUTPUT_DIR"

--- a/.agents/skills/transformerlab-cli/templates/setup-and-login.sh
+++ b/.agents/skills/transformerlab-cli/templates/setup-and-login.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Template: First-time Transformer Lab CLI setup
+# Checks if lab is installed, logs in, sets experiment, and verifies connectivity.
+#
+# Usage: ./setup-and-login.sh
+#
+# Set these environment variables before running:
+#   TL_SERVER   — Server URL (e.g. https://your-server:8338)
+#   TL_API_KEY  — Your API key
+#   TL_EXPERIMENT — Experiment name to set as current
+
+set -euo pipefail
+
+# 1. Check if lab CLI is installed
+if ! command -v lab &> /dev/null; then
+    echo "lab CLI not found. Installing..."
+    uv tool install transformerlab-cli
+fi
+
+echo "CLI version: $(lab version)"
+
+# 2. Login
+SERVER="${TL_SERVER:-http://localhost:8338}"
+API_KEY="${TL_API_KEY:?Set TL_API_KEY environment variable}"
+
+lab login --server "$SERVER" --api-key "$API_KEY"
+
+# 3. Verify authentication
+echo "Logged in as:"
+lab whoami
+
+# 4. Set current experiment (if provided)
+EXPERIMENT="${TL_EXPERIMENT:-}"
+if [ -n "$EXPERIMENT" ]; then
+    lab config set current_experiment "$EXPERIMENT"
+    echo "Current experiment set to: $EXPERIMENT"
+fi
+
+# 5. Verify connectivity
+echo ""
+echo "Server status:"
+lab status
+
+echo ""
+echo "Setup complete!"

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,6 +36,16 @@ uv tool install transformerlab-cli
 
 For a full list of all commands with detailed options and example usage, see [COMMANDS.md](https://github.com/transformerlab/transformerlab-app/blob/main/cli/COMMANDS.md).
 
+## Claude Code Skill
+
+Want Claude Code (or other AI coding agents) to manage Transformer Lab for you? Install the skill:
+
+```bash
+npx skills add transformerlab/transformerlab-app
+```
+
+This teaches your AI agent how to use the `lab` CLI to check job status, stream logs, download artifacts, queue tasks, manage providers, and more. See [.agents/skills/transformerlab-cli/](https://github.com/transformerlab/transformerlab-app/tree/main/.agents/skills/transformerlab-cli) for the full skill definition.
+
 ## Development
 
 ### Run (DEV)


### PR DESCRIPTION
## Summary

- Polishes the existing draft skill at `.agents/skills/transformerlab-cli/` into a complete, installable Claude Code skill
- External users can install with: `npx skills add transformerlab/transformerlab-app`
- Rewrites SKILL.md with proper `allowed-tools` frontmatter and `lab` binary invocations (replacing dev-mode `uv run` paths)
- Adds reference docs (workflows, troubleshooting), shell templates, and JSON output shape examples
- Adds skill install instructions to `cli/README.md`

## Test plan

- [ ] Install the skill in a fresh project: `npx skills add transformerlab/transformerlab-app`
- [ ] Verify `.claude/skills/transformerlab-cli/SKILL.md` appears with correct frontmatter
- [ ] Start a Claude Code session and ask "check my job status" — skill should activate and use `lab --format json`
- [ ] Verify `allowed-tools: Bash(lab *)` grants permission for `lab` commands