### PR TITLE
Add/s3 proxy remove node credentials

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -51,6 +51,7 @@ from transformerlab.routers import (  # noqa: E402
     ssh_keys,
     asset_versions,
     trackio,
+    storage_proxy,
 )
 from transformerlab.routers.auth import get_user_and_team  # noqa: E402
 
@@ -313,6 +314,7 @@ app.include_router(quota.router)
 app.include_router(ssh_keys.router, dependencies=[Depends(get_user_and_team)])
 app.include_router(asset_versions.router, dependencies=[Depends(get_user_and_team)])
 app.include_router(trackio.router, dependencies=[Depends(get_user_and_team)])
+app.include_router(storage_proxy.router, dependencies=[Depends(get_user_and_team)])
 
 
 async def install_all_plugins():

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "python-dotenv==1.1.0",
   "python-multipart==0.0.20",
   "sqlalchemy[asyncio]==2.0.40",
-  "transformerlab==0.1.17",
+  "transformerlab==0.1.18",
   "transformerlab-inference==0.2.52",
   "uvicorn==0.35.0",
   "watchfiles==1.0.5",

--- a/api/test/test_storage_service.py
+++ b/api/test/test_storage_service.py
@@ -1,0 +1,180 @@
+"""Tests for transformerlab.services.storage_service (cloud-agnostic storage proxy helpers).
+
+All ``lab.storage`` calls are mocked so the tests are fast and deterministic.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from transformerlab.services import storage_service
+
+
+# ---------------------------------------------------------------------------
+# get_object
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_object_happy_path():
+    """get_object returns a StreamingResponse whose body matches mocked storage data."""
+    file_data = b"hello-world"
+
+    mock_file = AsyncMock()
+    mock_file.read = AsyncMock(side_effect=[file_data, b""])
+    mock_file.__aenter__ = AsyncMock(return_value=mock_file)
+    mock_file.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("lab.storage.exists", new_callable=AsyncMock, return_value=True),
+        patch("lab.storage.open", new_callable=AsyncMock, return_value=mock_file),
+    ):
+        response = await storage_service.get_object("s3://my-bucket/some/key.txt")
+
+        assert response.media_type == "application/octet-stream"
+
+        # Collect streamed chunks — must happen inside the mock context because
+        # the _stream() generator calls storage.open lazily.
+        chunks: list[bytes] = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk)
+        assert b"".join(chunks) == file_data
+
+
+@pytest.mark.asyncio
+async def test_get_object_not_found():
+    """get_object raises FileNotFoundError when the path does not exist."""
+    with patch("lab.storage.exists", new_callable=AsyncMock, return_value=False):
+        with pytest.raises(FileNotFoundError, match="not found"):
+            await storage_service.get_object("s3://my-bucket/missing/key")
+
+
+# ---------------------------------------------------------------------------
+# put_object
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_put_object_happy_path():
+    """put_object writes data via lab.storage.open in write mode."""
+    mock_file = AsyncMock()
+    mock_file.write = AsyncMock()
+    mock_file.__aenter__ = AsyncMock(return_value=mock_file)
+    mock_file.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("lab.storage.open", new_callable=AsyncMock, return_value=mock_file):
+        await storage_service.put_object("s3://my-bucket/dst/key.bin", b"data-bytes")
+
+    mock_file.write.assert_called_once_with(b"data-bytes")
+
+
+@pytest.mark.asyncio
+async def test_put_object_storage_error():
+    """put_object raises RuntimeError when the underlying storage call fails."""
+    mock_file = AsyncMock()
+    mock_file.write = AsyncMock(side_effect=OSError("disk full"))
+    mock_file.__aenter__ = AsyncMock(return_value=mock_file)
+    mock_file.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("lab.storage.open", new_callable=AsyncMock, return_value=mock_file):
+        with pytest.raises(RuntimeError, match="Storage put failed"):
+            await storage_service.put_object("s3://b/k", b"x")
+
+
+# ---------------------------------------------------------------------------
+# list_objects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_objects_happy_path():
+    """list_objects returns child paths from lab.storage.ls."""
+    expected = ["s3://my-bucket/a/1.txt", "s3://my-bucket/a/2.txt"]
+
+    with patch("lab.storage.ls", new_callable=AsyncMock, return_value=expected):
+        paths = await storage_service.list_objects("s3://my-bucket/a/")
+
+    assert paths == expected
+
+
+@pytest.mark.asyncio
+async def test_list_objects_not_found_returns_empty():
+    """list_objects returns an empty list when the path does not exist."""
+    with patch("lab.storage.ls", new_callable=AsyncMock, side_effect=FileNotFoundError):
+        paths = await storage_service.list_objects("s3://my-bucket/empty/")
+
+    assert paths == []
+
+
+@pytest.mark.asyncio
+async def test_list_objects_storage_error():
+    """list_objects raises RuntimeError on unexpected storage errors."""
+    with patch("lab.storage.ls", new_callable=AsyncMock, side_effect=OSError("access denied")):
+        with pytest.raises(RuntimeError, match="Storage ls failed"):
+            await storage_service.list_objects("s3://locked-bucket")
+
+
+# ---------------------------------------------------------------------------
+# Filesystem metadata helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fs_exists():
+    """fs_exists delegates to lab.storage.exists."""
+    with patch("lab.storage.exists", new_callable=AsyncMock, return_value=True):
+        assert await storage_service.fs_exists("s3://b/k") is True
+
+
+@pytest.mark.asyncio
+async def test_fs_isdir():
+    """fs_isdir delegates to lab.storage.isdir."""
+    with patch("lab.storage.isdir", new_callable=AsyncMock, return_value=True):
+        assert await storage_service.fs_isdir("s3://b/dir/") is True
+
+
+@pytest.mark.asyncio
+async def test_fs_isfile():
+    """fs_isfile delegates to lab.storage.isfile."""
+    with patch("lab.storage.isfile", new_callable=AsyncMock, return_value=False):
+        assert await storage_service.fs_isfile("s3://b/missing") is False
+
+
+@pytest.mark.asyncio
+async def test_fs_makedirs():
+    """fs_makedirs delegates to lab.storage.makedirs."""
+    with patch("lab.storage.makedirs", new_callable=AsyncMock) as mock_mk:
+        await storage_service.fs_makedirs("s3://b/new/dir")
+    mock_mk.assert_called_once_with("s3://b/new/dir", exist_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_fs_rm_file():
+    """fs_rm (non-recursive) delegates to lab.storage.rm."""
+    with patch("lab.storage.rm", new_callable=AsyncMock) as mock_rm:
+        await storage_service.fs_rm("s3://b/file.txt", recursive=False)
+    mock_rm.assert_called_once_with("s3://b/file.txt")
+
+
+@pytest.mark.asyncio
+async def test_fs_rm_tree():
+    """fs_rm (recursive) delegates to lab.storage.rm_tree."""
+    with patch("lab.storage.rm_tree", new_callable=AsyncMock) as mock_rm:
+        await storage_service.fs_rm("s3://b/dir/", recursive=True)
+    mock_rm.assert_called_once_with("s3://b/dir/")
+
+
+@pytest.mark.asyncio
+async def test_fs_find():
+    """fs_find delegates to lab.storage.find."""
+    expected = ["s3://b/a/1.txt", "s3://b/a/2.txt"]
+    with patch("lab.storage.find", new_callable=AsyncMock, return_value=expected):
+        result = await storage_service.fs_find("s3://b/a")
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_fs_find_storage_error():
+    """fs_find raises RuntimeError on unexpected storage errors."""
+    with patch("lab.storage.find", new_callable=AsyncMock, side_effect=OSError("gone")):
+        with pytest.raises(RuntimeError, match="Storage find failed"):
+            await storage_service.fs_find("s3://b/a")

--- a/api/transformerlab/routers/storage_proxy.py
+++ b/api/transformerlab/routers/storage_proxy.py
@@ -1,20 +1,4 @@
 """Storage proxy router.
-
-Provides endpoints that let authenticated callers (remote GPU nodes, users)
-perform cloud-storage operations without ever receiving cloud credentials.
-The API server performs the real operations using its own credentials via
-the ``lab.storage`` abstraction (supports S3, GCS, Azure, local).
-
-Authentication follows the same ``Depends(get_user_and_team)`` pattern used
-on all other protected routes (see docs/Auth.md).
-
-Two groups of endpoints:
-
-1. **Object endpoints** — read / write / list objects by full cloud path
-   (e.g. ``s3://bucket/key``).
-2. **Filesystem metadata endpoints** — exists, isdir, isfile, makedirs, rm,
-   find — matching the operations that ``lab.storage`` exposes and that the
-   SDK calls from remote nodes.
 """
 
 import logging

--- a/api/transformerlab/routers/storage_proxy.py
+++ b/api/transformerlab/routers/storage_proxy.py
@@ -48,7 +48,7 @@ async def get_object(
         return JSONResponse(status_code=404, content={"detail": f"Not found: {body.path}"})
     except RuntimeError as exc:
         logger.error("Storage proxy GET failed: %s", exc)
-        return JSONResponse(status_code=502, content={"detail": str(exc)})
+        return JSONResponse(status_code=502, content={"detail": "Storage backend error"})
 
 
 @router.post("/proxy/put")
@@ -64,7 +64,7 @@ async def put_object(
         return JSONResponse(status_code=200, content={"status": "ok"})
     except RuntimeError as exc:
         logger.error("Storage proxy PUT failed: %s", exc)
-        return JSONResponse(status_code=502, content={"detail": str(exc)})
+        return JSONResponse(status_code=502, content={"detail": "Storage backend error"})
 
 
 @router.post("/proxy/ls")
@@ -78,7 +78,7 @@ async def list_objects(
         return JSONResponse(status_code=200, content={"paths": paths})
     except RuntimeError as exc:
         logger.error("Storage proxy LS failed: %s", exc)
-        return JSONResponse(status_code=502, content={"detail": str(exc)})
+        return JSONResponse(status_code=502, content={"detail": "Storage backend error"})
 
 
 # ---------------------------------------------------------------------------
@@ -147,4 +147,4 @@ async def fs_find(
         return JSONResponse(content={"paths": paths})
     except RuntimeError as exc:
         logger.error("Storage proxy FIND failed: %s", exc)
-        return JSONResponse(status_code=502, content={"detail": str(exc)})
+        return JSONResponse(status_code=502, content={"detail": "Storage backend error"})

--- a/api/transformerlab/routers/storage_proxy.py
+++ b/api/transformerlab/routers/storage_proxy.py
@@ -1,0 +1,167 @@
+"""Storage proxy router.
+
+Provides endpoints that let authenticated callers (remote GPU nodes, users)
+perform cloud-storage operations without ever receiving cloud credentials.
+The API server performs the real operations using its own credentials via
+the ``lab.storage`` abstraction (supports S3, GCS, Azure, local).
+
+Authentication follows the same ``Depends(get_user_and_team)`` pattern used
+on all other protected routes (see docs/Auth.md).
+
+Two groups of endpoints:
+
+1. **Object endpoints** — read / write / list objects by full cloud path
+   (e.g. ``s3://bucket/key``).
+2. **Filesystem metadata endpoints** — exists, isdir, isfile, makedirs, rm,
+   find — matching the operations that ``lab.storage`` exposes and that the
+   SDK calls from remote nodes.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from transformerlab.routers.auth import get_user_and_team
+from transformerlab.services import storage_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/storage", tags=["storage"])
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+class PathRequest(BaseModel):
+    path: str
+
+
+class MakedirsRequest(BaseModel):
+    path: str
+    exist_ok: bool = True
+
+
+class RmRequest(BaseModel):
+    path: str
+    recursive: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Object endpoints (read / write / list)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/proxy/get")
+async def get_object(
+    body: PathRequest,
+    _auth: dict = Depends(get_user_and_team),
+) -> Response:
+    """Stream a cloud object to the caller."""
+    try:
+        return await storage_service.get_object(body.path)
+    except FileNotFoundError:
+        return JSONResponse(status_code=404, content={"detail": f"Not found: {body.path}"})
+    except RuntimeError as exc:
+        logger.error("Storage proxy GET failed: %s", exc)
+        return JSONResponse(status_code=502, content={"detail": str(exc)})
+
+
+@router.post("/proxy/put")
+async def put_object(
+    request: Request,
+    path: str,
+    _auth: dict = Depends(get_user_and_team),
+) -> JSONResponse:
+    """Upload data to a cloud path.  The raw request body is written as-is."""
+    data = await request.body()
+    try:
+        await storage_service.put_object(path, data)
+        return JSONResponse(status_code=200, content={"status": "ok"})
+    except RuntimeError as exc:
+        logger.error("Storage proxy PUT failed: %s", exc)
+        return JSONResponse(status_code=502, content={"detail": str(exc)})
+
+
+@router.post("/proxy/ls")
+async def list_objects(
+    body: PathRequest,
+    _auth: dict = Depends(get_user_and_team),
+) -> JSONResponse:
+    """List child paths under a cloud directory."""
+    try:
+        paths = await storage_service.list_objects(body.path)
+        return JSONResponse(status_code=200, content={"paths": paths})
+    except RuntimeError as exc:
+        logger.error("Storage proxy LS failed: %s", exc)
+        return JSONResponse(status_code=502, content={"detail": str(exc)})
+
+
+# ---------------------------------------------------------------------------
+# Filesystem metadata endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/proxy/exists")
+async def fs_exists(
+    body: PathRequest,
+    _auth: dict = Depends(get_user_and_team),
+) -> JSONResponse:
+    """Check whether a path exists."""
+    result = await storage_service.fs_exists(body.path)
+    return JSONResponse(content={"result": result})
+
+
+@router.post("/proxy/isdir")
+async def fs_isdir(
+    body: PathRequest,
+    _auth: dict = Depends(get_user_and_team),
+) -> JSONResponse:
+    """Check whether a path is a directory."""
+    result = await storage_service.fs_isdir(body.path)
+    return JSONResponse(content={"result": result})
+
+
+@router.post("/proxy/isfile")
+async def fs_isfile(
+    body: PathRequest,
+    _auth: dict = Depends(get_user_and_team),
+) -> JSONResponse:
+    """Check whether a path is a file."""
+    result = await storage_service.fs_isfile(body.path)
+    return JSONResponse(content={"result": result})
+
+
+@router.post("/proxy/makedirs")
+async def fs_makedirs(
+    body: MakedirsRequest,
+    _auth: dict = Depends(get_user_and_team),
+) -> JSONResponse:
+    """Create a directory tree."""
+    await storage_service.fs_makedirs(body.path, exist_ok=body.exist_ok)
+    return JSONResponse(content={"status": "ok"})
+
+
+@router.post("/proxy/rm")
+async def fs_rm(
+    body: RmRequest,
+    _auth: dict = Depends(get_user_and_team),
+) -> JSONResponse:
+    """Remove a file or (recursively) a directory."""
+    await storage_service.fs_rm(body.path, recursive=body.recursive)
+    return JSONResponse(content={"status": "ok"})
+
+
+@router.post("/proxy/find")
+async def fs_find(
+    body: PathRequest,
+    _auth: dict = Depends(get_user_and_team),
+) -> JSONResponse:
+    """Recursively list all files under a path."""
+    try:
+        paths = await storage_service.fs_find(body.path)
+        return JSONResponse(content={"paths": paths})
+    except RuntimeError as exc:
+        logger.error("Storage proxy FIND failed: %s", exc)
+        return JSONResponse(status_code=502, content={"detail": str(exc)})

--- a/api/transformerlab/routers/storage_proxy.py
+++ b/api/transformerlab/routers/storage_proxy.py
@@ -1,5 +1,4 @@
-"""Storage proxy router.
-"""
+"""Storage proxy router."""
 
 import logging
 

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -14,10 +14,6 @@ from transformerlab.schemas.secrets import SPECIAL_SECRET_TYPES
 from transformerlab.services import job_service, quota_service
 from transformerlab.services.compute_provider.launch_credentials import (
     COPY_FILE_MOUNTS_SETUP,
-    RUNPOD_AWS_CREDENTIALS_DIR,
-    generate_aws_credentials_setup,
-    generate_azure_credentials_setup,
-    get_aws_credentials_from_file,
 )
 from transformerlab.services.compute_provider.launch_secrets import find_missing_secrets_for_template_launch
 from transformerlab.services.compute_provider.launch_sweep import create_sweep_parent_job, launch_sweep_jobs
@@ -212,39 +208,7 @@ async def launch_template_on_provider(
     # Build setup script - add cloud credential helpers first, then file_mounts and other setup.
     setup_commands: list[str] = []
 
-    if os.getenv("TFL_REMOTE_STORAGE_ENABLED", "false").lower() == "true":
-        if STORAGE_PROVIDER == "aws":
-            # Get AWS credentials from stored credentials file (transformerlab-s3 profile)
-            aws_profile = "transformerlab-s3"
-            aws_access_key_id, aws_secret_access_key = await asyncio.to_thread(
-                get_aws_credentials_from_file, aws_profile
-            )
-            if aws_access_key_id and aws_secret_access_key:
-                aws_credentials_dir = RUNPOD_AWS_CREDENTIALS_DIR if provider.type == ProviderType.RUNPOD.value else None
-                aws_setup = generate_aws_credentials_setup(
-                    aws_access_key_id, aws_secret_access_key, aws_profile, aws_credentials_dir=aws_credentials_dir
-                )
-                setup_commands.append(aws_setup)
-                if aws_credentials_dir:
-                    env_vars["AWS_SHARED_CREDENTIALS_FILE"] = f"{aws_credentials_dir}/credentials"
-        elif STORAGE_PROVIDER == "azure":
-            azure_connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
-            azure_account = os.getenv("AZURE_STORAGE_ACCOUNT")
-            azure_key = os.getenv("AZURE_STORAGE_KEY")
-            azure_sas = os.getenv("AZURE_STORAGE_SAS_TOKEN")
-            if azure_connection_string or azure_account:
-                azure_setup = generate_azure_credentials_setup(
-                    azure_connection_string, azure_account, azure_key, azure_sas
-                )
-                setup_commands.append(azure_setup)
-                if azure_connection_string:
-                    env_vars["AZURE_STORAGE_CONNECTION_STRING"] = azure_connection_string
-                if azure_account:
-                    env_vars["AZURE_STORAGE_ACCOUNT"] = azure_account
-                if azure_key:
-                    env_vars["AZURE_STORAGE_KEY"] = azure_key
-                if azure_sas:
-                    env_vars["AZURE_STORAGE_SAS_TOKEN"] = azure_sas
+
 
     if request.file_mounts is True and request.task_id:
         setup_commands.append(COPY_FILE_MOUNTS_SETUP)
@@ -338,6 +302,15 @@ async def launch_template_on_provider(
     env_vars["_TFL_JOB_ID"] = str(job_id)
     env_vars["_TFL_EXPERIMENT_ID"] = request.experiment_id
     env_vars["_TFL_USER_ID"] = user_id
+
+
+    tfl_api_url = os.getenv("TFL_API_URL", "")
+    if tfl_api_url:
+        env_vars["_TFL_API_URL"] = tfl_api_url
+    tfl_api_key = os.getenv("TFL_API_KEY", "")
+    if tfl_api_key:
+        env_vars["_TFL_API_KEY"] = tfl_api_key
+    env_vars["_TFL_TEAM_ID"] = str(team_id)
 
     # Enable Trackio auto-init for this job if requested. When set, the lab SDK
     # running inside the remote script can automatically initialize Trackio

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -208,8 +208,6 @@ async def launch_template_on_provider(
     # Build setup script - add cloud credential helpers first, then file_mounts and other setup.
     setup_commands: list[str] = []
 
-
-
     if request.file_mounts is True and request.task_id:
         setup_commands.append(COPY_FILE_MOUNTS_SETUP)
     # Ensure transformerlab SDK is available on remote machines for live_status tracking and other helpers.
@@ -302,7 +300,6 @@ async def launch_template_on_provider(
     env_vars["_TFL_JOB_ID"] = str(job_id)
     env_vars["_TFL_EXPERIMENT_ID"] = request.experiment_id
     env_vars["_TFL_USER_ID"] = user_id
-
 
     tfl_api_url = os.getenv("TFL_API_URL", "")
     if tfl_api_url:

--- a/api/transformerlab/services/storage_service.py
+++ b/api/transformerlab/services/storage_service.py
@@ -1,0 +1,105 @@
+"""Storage proxy service — filesystem operations on behalf of authenticated callers.
+"""
+
+import logging
+from typing import AsyncIterator
+
+from fastapi.responses import StreamingResponse
+
+from lab import storage
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# High-level object helpers (get / put / list)
+# ---------------------------------------------------------------------------
+
+
+async def get_object(path: str) -> StreamingResponse:
+    """Stream a remote object back to the caller.
+
+    Raises:
+        FileNotFoundError: if the path does not exist (404)
+        RuntimeError: on any other storage error (502)
+    """
+    if not await storage.exists(path):
+        raise FileNotFoundError(f"{path} not found")
+
+    async def _stream() -> AsyncIterator[bytes]:
+        async with await storage.open(path, "rb") as f:
+            while True:
+                chunk = await f.read(1024 * 1024)  # 1 MiB
+                if not chunk:
+                    break
+                yield chunk
+
+    return StreamingResponse(_stream(), media_type="application/octet-stream")
+
+
+async def put_object(path: str, data: bytes) -> None:
+    """Write *data* to *path*.
+
+    Raises:
+        RuntimeError: on storage error (502)
+    """
+    try:
+        async with await storage.open(path, "wb") as f:
+            await f.write(data)
+    except Exception as exc:
+        raise RuntimeError(f"Storage put failed for {path}: {exc}") from exc
+
+
+async def list_objects(path: str) -> list[str]:
+    """Return child paths under *path*.
+
+    Raises:
+        RuntimeError: on storage error (502)
+    """
+    try:
+        return await storage.ls(path, detail=False)
+    except FileNotFoundError:
+        return []
+    except Exception as exc:
+        raise RuntimeError(f"Storage ls failed for {path}: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Filesystem metadata helpers (exists / isdir / isfile / makedirs / rm)
+# ---------------------------------------------------------------------------
+
+
+async def fs_exists(path: str) -> bool:
+    """Check whether *path* exists."""
+    return await storage.exists(path)
+
+
+async def fs_isdir(path: str) -> bool:
+    """Check whether *path* is a directory."""
+    return await storage.isdir(path)
+
+
+async def fs_isfile(path: str) -> bool:
+    """Check whether *path* is a regular file."""
+    return await storage.isfile(path)
+
+
+async def fs_makedirs(path: str, exist_ok: bool = True) -> None:
+    """Create directory tree at *path*."""
+    await storage.makedirs(path, exist_ok=exist_ok)
+
+
+async def fs_rm(path: str, recursive: bool = False) -> None:
+    """Remove *path* (file or, when *recursive*, directory tree)."""
+    if recursive:
+        await storage.rm_tree(path)
+    else:
+        await storage.rm(path)
+
+
+async def fs_find(path: str) -> list[str]:
+    """Recursively list all files under *path*."""
+    try:
+        return await storage.find(path)
+    except Exception as exc:
+        raise RuntimeError(f"Storage find failed for {path}: {exc}") from exc

--- a/api/transformerlab/services/storage_service.py
+++ b/api/transformerlab/services/storage_service.py
@@ -1,5 +1,4 @@
-"""Storage proxy service — filesystem operations on behalf of authenticated callers.
-"""
+"""Storage proxy service — filesystem operations on behalf of authenticated callers."""
 
 import logging
 from typing import AsyncIterator

--- a/lab-sdk/pyproject.toml
+++ b/lab-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab"
-version = "0.1.17"
+version = "0.1.18"
 description = "Python SDK for Transformer Lab"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/lab-sdk/src/lab/storage.py
+++ b/lab-sdk/src/lab/storage.py
@@ -14,6 +14,21 @@ import logging
 logging.getLogger("aiobotocore").setLevel(logging.CRITICAL)
 logging.getLogger("s3fs").setLevel(logging.CRITICAL)
 
+# ---------------------------------------------------------------------------
+# Proxy-mode detection
+# ---------------------------------------------------------------------------
+# When _TFL_API_URL is set the SDK is running on a remote GPU node and must
+# NOT access cloud storage directly (it has no credentials).  All remote-path
+# operations are routed through the API server's storage proxy instead.
+# Import lazily to avoid circular import at module load time.
+
+
+def _use_proxy_for(path: str) -> bool:
+    """Return True when *path* should be served through the HTTP proxy."""
+    from . import storage_proxy
+
+    return storage_proxy.is_proxy_mode() and is_remote_path(path)
+
 
 class AsyncFileWrapper:
     """
@@ -298,6 +313,10 @@ async def root_join(*parts: str) -> str:
 
 
 async def exists(path: str) -> bool:
+    if _use_proxy_for(path):
+        from . import storage_proxy
+
+        return await asyncio.to_thread(storage_proxy.exists, path)
     fs = await filesystem()
     try:
         return await asyncio.to_thread(fs.exists, path)
@@ -307,6 +326,10 @@ async def exists(path: str) -> bool:
 
 
 async def isdir(path: str, fs=None) -> bool:
+    if _use_proxy_for(path):
+        from . import storage_proxy
+
+        return await asyncio.to_thread(storage_proxy.isdir, path)
     filesys = fs
     try:
         filesys = fs if fs is not None else await filesystem()
@@ -320,6 +343,10 @@ async def isdir(path: str, fs=None) -> bool:
 
 
 async def isfile(path: str) -> bool:
+    if _use_proxy_for(path):
+        from . import storage_proxy
+
+        return await asyncio.to_thread(storage_proxy.isfile, path)
     fs = None
     try:
         fs = await filesystem()
@@ -332,6 +359,11 @@ async def isfile(path: str) -> bool:
 
 
 async def makedirs(path: str, exist_ok: bool = True) -> None:
+    if _use_proxy_for(path):
+        from . import storage_proxy
+
+        await asyncio.to_thread(storage_proxy.makedirs, path, exist_ok)
+        return
     fs = await filesystem()
     try:
         await asyncio.to_thread(fs.makedirs, path, exist_ok=exist_ok)
@@ -345,6 +377,10 @@ async def makedirs(path: str, exist_ok: bool = True) -> None:
 
 
 async def ls(path: str, detail: bool = False, fs=None):
+    if _use_proxy_for(path):
+        from . import storage_proxy
+
+        return await asyncio.to_thread(storage_proxy.ls, path, detail)
     # Use provided filesystem or get default
     filesys = fs if fs is not None else await filesystem()
     try:
@@ -374,6 +410,10 @@ async def ls(path: str, detail: bool = False, fs=None):
 
 
 async def find(path: str) -> list[str]:
+    if _use_proxy_for(path):
+        from . import storage_proxy
+
+        return await asyncio.to_thread(storage_proxy.find, path)
     fs = await filesystem()
     try:
         return await asyncio.to_thread(fs.find, path)
@@ -386,6 +426,9 @@ async def walk(path: str, maxdepth=None, topdown=True, on_error="omit"):
     """
     Walk directory tree, returning a list of (root, dirs, files) tuples.
 
+    In proxy mode, ``walk`` is not directly supported by the HTTP proxy.
+    We approximate it by using ``find`` + ``ls`` to reconstruct the tree.
+
     Args:
         path: Root directory to start the walk
         maxdepth: Maximum recursion depth (None for no limit)
@@ -395,6 +438,38 @@ async def walk(path: str, maxdepth=None, topdown=True, on_error="omit"):
     Returns:
         List of (root, dirs, files) tuples similar to os.walk()
     """
+    if _use_proxy_for(path):
+        # Approximate walk via find (returns flat list of all files)
+        from . import storage_proxy
+
+        all_files = await asyncio.to_thread(storage_proxy.find, path)
+        # Build a dir→files mapping
+        dir_files: dict[str, list[str]] = {}
+        dir_subdirs: dict[str, set[str]] = {}
+        path_stripped = path.rstrip("/")
+        for f in all_files:
+            parent = posixpath.dirname(f)
+            fname = posixpath.basename(f)
+            dir_files.setdefault(parent, []).append(fname)
+            # Register all intermediate directories
+            rel = parent[len(path_stripped) :].lstrip("/")
+            parts = rel.split("/") if rel else []
+            cur = path_stripped
+            for part in parts:
+                dir_subdirs.setdefault(cur, set()).add(part)
+                cur = posixpath.join(cur, part)
+            dir_subdirs.setdefault(cur, set())
+        # Collect all directories
+        all_dirs = sorted(set(list(dir_files.keys()) + [path_stripped] + [k for k in dir_subdirs]))
+        result = []
+        for d in all_dirs:
+            subdirs = sorted(dir_subdirs.get(d, set()))
+            files = dir_files.get(d, [])
+            result.append((d, subdirs, files))
+        if not topdown:
+            result.reverse()
+        return result
+
     fs = await filesystem()
     try:
         # Materialise the generator in a thread so the blocking filesystem
@@ -408,6 +483,11 @@ async def walk(path: str, maxdepth=None, topdown=True, on_error="omit"):
 
 
 async def rm(path: str) -> None:
+    if _use_proxy_for(path):
+        from . import storage_proxy
+
+        await asyncio.to_thread(storage_proxy.rm, path)
+        return
     if await exists(path):
         fs = await filesystem()
         try:
@@ -418,6 +498,11 @@ async def rm(path: str) -> None:
 
 
 async def rm_tree(path: str) -> None:
+    if _use_proxy_for(path):
+        from . import storage_proxy
+
+        await asyncio.to_thread(storage_proxy.rm_tree, path)
+        return
     if await exists(path):
         fs = await filesystem()
         try:
@@ -437,6 +522,10 @@ async def open(path: str, mode: str = "r", fs=None, uncached: bool = False, **kw
     """
     Open a file for reading or writing.
 
+    When proxy mode is active and the path is remote, uses the HTTP storage
+    proxy (``storage_proxy.ProxyFile``) wrapped in ``AsyncFileWrapper`` so the
+    async context-manager protocol works identically to the fsspec path.
+
     For local files, uses aiofiles for truly async file I/O.
     For remote files (S3, GCS, etc.), dispatches the blocking open() call to a
     thread pool and wraps the result in AsyncFileWrapper whose I/O methods are
@@ -452,6 +541,14 @@ async def open(path: str, mode: str = "r", fs=None, uncached: bool = False, **kw
     Returns:
         Async context manager wrapping the file object.
     """
+    # Proxy mode: route remote-path I/O through the API server
+    if _use_proxy_for(path):
+        from . import storage_proxy
+
+        encoding = kwargs.get("encoding")
+        proxy_file = await asyncio.to_thread(storage_proxy.open_file, path, mode, encoding)
+        return AsyncFileWrapper(proxy_file)
+
     if uncached:
         # Create an uncached filesystem instance
         # If fs is provided, use it to infer protocol/storage options, otherwise infer from path
@@ -597,9 +694,40 @@ async def _close_filesystem(fs) -> None:
 
 
 async def copy_file(src: str, dest: str) -> None:
-    """Copy a single file from src to dest across arbitrary filesystems."""
-    # Run the entire streaming copy in a thread — src_fs.open() and dest_fs.open()
-    # both make blocking network calls for remote filesystems.
+    """Copy a single file from src to dest across arbitrary filesystems.
+
+    In proxy mode, both source and destination remote paths are handled via
+    the HTTP proxy — the data is streamed through the SDK process.
+    """
+    src_proxy = _use_proxy_for(src)
+    dest_proxy = _use_proxy_for(dest)
+
+    # If either end needs the proxy, do a proxy-aware copy
+    if src_proxy or dest_proxy:
+        from . import storage_proxy
+
+        # Read source
+        if src_proxy:
+            data = await asyncio.to_thread(storage_proxy.read_bytes, src)
+        else:
+            # Local source — read directly
+            import aiofiles as _aio
+
+            async with _aio.open(src, "rb") as f:
+                data = await f.read()
+
+        # Write destination
+        if dest_proxy:
+            await asyncio.to_thread(storage_proxy.write_bytes, dest, data)
+        else:
+            # Local destination — write directly
+            import aiofiles as _aio
+
+            async with _aio.open(dest, "wb") as f:
+                await f.write(data)
+        return
+
+    # Original fsspec path (no proxy needed)
     src_fs, _ = _get_fs_for_path(src)
     dest_fs, _ = _get_fs_for_path(dest)
 
@@ -629,8 +757,38 @@ def iter_chunks(file_obj, chunk_size: int = 8 * 1024 * 1024):
 
 
 async def copy_dir(src_dir: str, dest_dir: str) -> None:
-    """Recursively copy a directory tree across arbitrary filesystems."""
+    """Recursively copy a directory tree across arbitrary filesystems.
+
+    In proxy mode, uses proxy-aware ``find`` + ``copy_file``.
+    """
     await makedirs(dest_dir, exist_ok=True)
+
+    src_proxy = _use_proxy_for(src_dir)
+    dest_proxy = _use_proxy_for(dest_dir)
+
+    if src_proxy or dest_proxy:
+        # Proxy-aware copy: use find to list all source files, then copy each
+        if src_proxy:
+            from . import storage_proxy
+
+            src_files = await asyncio.to_thread(storage_proxy.find, src_dir)
+        else:
+            src_fs_local, _ = _get_fs_for_path(src_dir)
+            try:
+                src_files = await asyncio.to_thread(src_fs_local.find, src_dir)
+            finally:
+                await _close_filesystem(src_fs_local)
+
+        for src_file in src_files:
+            rel_path = src_file[len(src_dir) :].lstrip("/")
+            dest_file = join(dest_dir, rel_path)
+            dest_parent = posixpath.dirname(dest_file)
+            if dest_parent:
+                await makedirs(dest_parent, exist_ok=True)
+            await copy_file(src_file, dest_file)
+        return
+
+    # Original fsspec path (no proxy involved)
     # Determine the source filesystem independently of destination
     src_fs, _ = _get_fs_for_path(src_dir)
     # Remember protocol for remote paths so that we can reconstruct full URIs

--- a/lab-sdk/src/lab/storage_proxy.py
+++ b/lab-sdk/src/lab/storage_proxy.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import io
+import os
+from typing import List, Optional
+
+import requests as _requests
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def is_proxy_mode() -> bool:
+    """Return True if the storage proxy should be used (remote node)."""
+    return bool(os.environ.get("_TFL_API_URL"))
+
+
+def _api_url() -> str:
+    url = os.environ.get("_TFL_API_URL", "")
+    if not url:
+        raise RuntimeError(
+            "Storage proxy not configured: _TFL_API_URL environment variable is not set. "
+            "This usually means the job was not launched through the Transformer Lab provider system."
+        )
+    return url.rstrip("/")
+
+
+def _auth_headers() -> dict[str, str]:
+    """Build HTTP headers with the auth token and team id."""
+    token = os.environ.get("_TFL_API_KEY", "")
+    team_id = os.environ.get("_TFL_TEAM_ID", "")
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if team_id:
+        headers["X-Team-Id"] = team_id
+    return headers
+
+
+def _post_json(endpoint: str, json_body: dict, timeout: int = 120) -> dict:
+    """POST JSON to a proxy endpoint and return the parsed response body."""
+    url = f"{_api_url()}/storage/proxy/{endpoint}"
+    resp = _requests.post(url, json=json_body, headers=_auth_headers(), timeout=timeout)
+    if resp.status_code != 200:
+        raise RuntimeError(f"Storage proxy {endpoint} failed (HTTP {resp.status_code}): {resp.text}")
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Filesystem metadata operations (mirror lab.storage API)
+# ---------------------------------------------------------------------------
+
+
+def exists(path: str) -> bool:
+    """Check whether *path* exists (via proxy)."""
+    data = _post_json("exists", {"path": path})
+    return bool(data.get("result", False))
+
+
+def isdir(path: str) -> bool:
+    """Check whether *path* is a directory (via proxy)."""
+    data = _post_json("isdir", {"path": path})
+    return bool(data.get("result", False))
+
+
+def isfile(path: str) -> bool:
+    """Check whether *path* is a file (via proxy)."""
+    data = _post_json("isfile", {"path": path})
+    return bool(data.get("result", False))
+
+
+def makedirs(path: str, exist_ok: bool = True) -> None:
+    """Create directory tree at *path* (via proxy)."""
+    _post_json("makedirs", {"path": path, "exist_ok": exist_ok})
+
+
+def rm(path: str) -> None:
+    """Remove a single file (via proxy)."""
+    _post_json("rm", {"path": path, "recursive": False})
+
+
+def rm_tree(path: str) -> None:
+    """Recursively remove a directory tree (via proxy)."""
+    _post_json("rm", {"path": path, "recursive": True})
+
+
+def ls(path: str, detail: bool = False) -> list:
+    """List children of *path* (via proxy). *detail* is ignored in proxy mode."""
+    data = _post_json("ls", {"path": path})
+    return data.get("paths", [])
+
+
+def find(path: str) -> list[str]:
+    """Recursively list all files under *path* (via proxy)."""
+    data = _post_json("find", {"path": path})
+    return data.get("paths", [])
+
+
+# ---------------------------------------------------------------------------
+# File read / write
+# ---------------------------------------------------------------------------
+
+
+def read_bytes(path: str) -> bytes:
+    """Read the entire contents of *path* as bytes (via proxy)."""
+    url = f"{_api_url()}/storage/proxy/get"
+    resp = _requests.post(url, json={"path": path}, headers=_auth_headers(), stream=True, timeout=300)
+    if resp.status_code == 404:
+        raise FileNotFoundError(f"{path} not found")
+    if resp.status_code != 200:
+        raise RuntimeError(f"Storage proxy read failed (HTTP {resp.status_code}): {resp.text}")
+    chunks: list[bytes] = []
+    for chunk in resp.iter_content(chunk_size=1024 * 1024):
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def read_text(path: str, encoding: str = "utf-8") -> str:
+    """Read the entire contents of *path* as text (via proxy)."""
+    return read_bytes(path).decode(encoding)
+
+
+def write_bytes(path: str, data: bytes) -> None:
+    """Write *data* to *path* (via proxy)."""
+    url = f"{_api_url()}/storage/proxy/put"
+    resp = _requests.post(
+        url,
+        data=data,
+        headers={**_auth_headers(), "Content-Type": "application/octet-stream"},
+        params={"path": path},
+        timeout=300,
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(f"Storage proxy write failed (HTTP {resp.status_code}): {resp.text}")
+
+
+def write_text(path: str, text: str, encoding: str = "utf-8") -> None:
+    """Write *text* to *path* (via proxy)."""
+    write_bytes(path, text.encode(encoding))
+
+
+class ProxyFile:
+    """In-memory file-like object that reads from / writes to the proxy.
+
+    Used by ``lab.storage.open()`` when proxy mode is active.  Supports the
+    async context-manager protocol expected by ``AsyncFileWrapper`` /
+    ``aiofiles``-style callers via thin wrappers.
+
+    Only the subset of the file API actually used by the SDK is implemented:
+    ``read``, ``write``, ``close``.
+    """
+
+    def __init__(self, path: str, mode: str = "r", encoding: Optional[str] = None):
+        self._path = path
+        self._mode = mode
+        self._encoding = encoding
+        self._buffer = io.BytesIO()
+        self._closed = False
+
+        # For read modes, eagerly fetch the content
+        if "r" in mode and "w" not in mode and "a" not in mode:
+            try:
+                raw = read_bytes(path)
+            except FileNotFoundError:
+                raw = b""
+            self._buffer = io.BytesIO(raw)
+
+    def read(self, size: int = -1) -> str | bytes:
+        raw = self._buffer.read(size)
+        if self._encoding or ("b" not in self._mode):
+            return raw.decode(self._encoding or "utf-8")
+        return raw
+
+    def write(self, data: str | bytes) -> int:
+        if isinstance(data, str):
+            encoded = data.encode(self._encoding or "utf-8")
+        else:
+            encoded = data
+        return self._buffer.write(encoded)
+
+    def readline(self, size: int = -1) -> str | bytes:
+        raw = self._buffer.readline(size)
+        if self._encoding or ("b" not in self._mode):
+            return raw.decode(self._encoding or "utf-8")
+        return raw
+
+    def readlines(self, hint: int = -1) -> list:
+        lines = self._buffer.readlines(hint)
+        if self._encoding or ("b" not in self._mode):
+            return [line.decode(self._encoding or "utf-8") for line in lines]
+        return lines
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        return self._buffer.seek(offset, whence)
+
+    def tell(self) -> int:
+        return self._buffer.tell()
+
+    def flush(self) -> None:
+        pass  # no-op; actual flush happens on close
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        # On write/append modes, flush the buffer to the proxy
+        if any(c in self._mode for c in ("w", "a")):
+            write_bytes(self._path, self._buffer.getvalue())
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+
+def open_file(path: str, mode: str = "r", encoding: Optional[str] = None) -> ProxyFile:
+    """Open a remote file via the proxy. Returns a ``ProxyFile`` instance."""
+    return ProxyFile(path, mode=mode, encoding=encoding)
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrappers (original public API kept for backward compat)
+# ---------------------------------------------------------------------------
+
+
+def get(bucket: str, key: str, local_path: str) -> None:
+    """Download ``s3://<bucket>/<key>`` to *local_path* via the storage proxy."""
+    full_path = f"s3://{bucket}/{key}"
+    data = read_bytes(full_path)
+    with open(local_path, "wb") as f:
+        f.write(data)
+
+
+def put(bucket: str, key: str, local_path: str) -> None:
+    """Upload *local_path* to ``s3://<bucket>/<key>`` via the storage proxy."""
+    full_path = f"s3://{bucket}/{key}"
+    with open(local_path, "rb") as f:
+        data = f.read()
+    write_bytes(full_path, data)
+
+
+def list_keys(bucket: str, prefix: str = "") -> List[str]:
+    """List object keys in *bucket* (optionally filtered by *prefix*) via the proxy."""
+    full_path = f"s3://{bucket}"
+    if prefix:
+        full_path = f"{full_path}/{prefix.rstrip('/')}"
+    return ls(full_path)

--- a/lab-sdk/tests/test_storage_proxy.py
+++ b/lab-sdk/tests/test_storage_proxy.py
@@ -1,0 +1,387 @@
+"""Tests for lab.storage_proxy (SDK-side storage proxy client).
+
+HTTP calls are mocked via ``unittest.mock.patch`` on ``requests``.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _set_proxy_env(monkeypatch):
+    """Inject the env vars that the storage_proxy module needs."""
+    monkeypatch.setenv("_TFL_API_URL", "http://localhost:8338")
+    monkeypatch.setenv("_TFL_API_KEY", "tl-test-key-123")
+    monkeypatch.setenv("_TFL_TEAM_ID", "team-abc")
+
+    # Clear cached module so env changes are picked up
+    import sys
+
+    for mod_name in list(sys.modules):
+        if "storage_proxy" in mod_name:
+            del sys.modules[mod_name]
+
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok_response(json_body: dict | None = None, content: bytes = b"", status: int = 200) -> MagicMock:
+    """Build a mock ``requests.Response``."""
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = ""
+    if json_body is not None:
+        resp.json.return_value = json_body
+    resp.content = content
+    resp.iter_content = MagicMock(return_value=[content] if content else [])
+    return resp
+
+
+def _err_response(status: int = 502, text: str = "Server error") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# is_proxy_mode
+# ---------------------------------------------------------------------------
+
+
+def test_is_proxy_mode_true():
+    from lab import storage_proxy
+
+    assert storage_proxy.is_proxy_mode() is True
+
+
+def test_is_proxy_mode_false(monkeypatch):
+    monkeypatch.delenv("_TFL_API_URL", raising=False)
+    import sys
+
+    for mod_name in list(sys.modules):
+        if "storage_proxy" in mod_name:
+            del sys.modules[mod_name]
+    from lab import storage_proxy
+
+    assert storage_proxy.is_proxy_mode() is False
+
+
+# ---------------------------------------------------------------------------
+# _auth_headers
+# ---------------------------------------------------------------------------
+
+
+def test_auth_headers():
+    from lab import storage_proxy
+
+    headers = storage_proxy._auth_headers()
+    assert headers["Authorization"] == "Bearer tl-test-key-123"
+    assert headers["X-Team-Id"] == "team-abc"
+
+
+# ---------------------------------------------------------------------------
+# exists / isdir / isfile
+# ---------------------------------------------------------------------------
+
+
+def test_exists_true():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"result": True})):
+        assert storage_proxy.exists("s3://b/k") is True
+
+
+def test_exists_false():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"result": False})):
+        assert storage_proxy.exists("s3://b/missing") is False
+
+
+def test_isdir():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"result": True})):
+        assert storage_proxy.isdir("s3://b/dir/") is True
+
+
+def test_isfile():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"result": False})):
+        assert storage_proxy.isfile("s3://b/missing") is False
+
+
+# ---------------------------------------------------------------------------
+# makedirs
+# ---------------------------------------------------------------------------
+
+
+def test_makedirs_calls_proxy():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"status": "ok"})) as mock_post:
+        storage_proxy.makedirs("s3://b/new/dir")
+
+    call_kwargs = mock_post.call_args
+    assert "makedirs" in call_kwargs[1].get("url", call_kwargs[0][0] if call_kwargs[0] else "")
+
+
+# ---------------------------------------------------------------------------
+# rm / rm_tree
+# ---------------------------------------------------------------------------
+
+
+def test_rm_calls_proxy():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"status": "ok"})) as mock_post:
+        storage_proxy.rm("s3://b/file.txt")
+
+    json_sent = mock_post.call_args[1].get("json", {})
+    assert json_sent.get("recursive") is False
+
+
+def test_rm_tree_calls_proxy():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"status": "ok"})) as mock_post:
+        storage_proxy.rm_tree("s3://b/dir/")
+
+    json_sent = mock_post.call_args[1].get("json", {})
+    assert json_sent.get("recursive") is True
+
+
+# ---------------------------------------------------------------------------
+# ls / find
+# ---------------------------------------------------------------------------
+
+
+def test_ls():
+    from lab import storage_proxy
+
+    paths = ["s3://b/a/1.txt", "s3://b/a/2.txt"]
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"paths": paths})):
+        result = storage_proxy.ls("s3://b/a")
+
+    assert result == paths
+
+
+def test_find():
+    from lab import storage_proxy
+
+    paths = ["s3://b/a/1.txt", "s3://b/a/sub/2.txt"]
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"paths": paths})):
+        result = storage_proxy.find("s3://b/a")
+
+    assert result == paths
+
+
+# ---------------------------------------------------------------------------
+# read_bytes / read_text
+# ---------------------------------------------------------------------------
+
+
+def test_read_bytes():
+    from lab import storage_proxy
+
+    resp = _ok_response(content=b"raw-data")
+    with patch.object(storage_proxy._requests, "post", return_value=resp):
+        data = storage_proxy.read_bytes("s3://b/file.bin")
+
+    assert data == b"raw-data"
+
+
+def test_read_text():
+    from lab import storage_proxy
+
+    resp = _ok_response(content=b"hello text")
+    with patch.object(storage_proxy._requests, "post", return_value=resp):
+        text = storage_proxy.read_text("s3://b/file.txt")
+
+    assert text == "hello text"
+
+
+def test_read_bytes_not_found():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_err_response(404, "Not found")):
+        with pytest.raises(FileNotFoundError):
+            storage_proxy.read_bytes("s3://b/missing")
+
+
+# ---------------------------------------------------------------------------
+# write_bytes / write_text
+# ---------------------------------------------------------------------------
+
+
+def test_write_bytes():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"status": "ok"})) as mock_post:
+        storage_proxy.write_bytes("s3://b/dst.bin", b"payload")
+
+    assert mock_post.call_args[1]["data"] == b"payload"
+
+
+def test_write_text():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"status": "ok"})) as mock_post:
+        storage_proxy.write_text("s3://b/dst.txt", "hello")
+
+    assert mock_post.call_args[1]["data"] == b"hello"
+
+
+def test_write_bytes_error():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_err_response(502, "fail")):
+        with pytest.raises(RuntimeError, match="Storage proxy write failed"):
+            storage_proxy.write_bytes("s3://b/k", b"x")
+
+
+# ---------------------------------------------------------------------------
+# ProxyFile
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_file_read():
+    from lab import storage_proxy
+
+    resp = _ok_response(content=b"file content")
+    with patch.object(storage_proxy._requests, "post", return_value=resp):
+        pf = storage_proxy.ProxyFile("s3://b/f.txt", mode="r")
+        assert pf.read() == "file content"
+
+
+def test_proxy_file_read_binary():
+    from lab import storage_proxy
+
+    resp = _ok_response(content=b"\x00\x01\x02")
+    with patch.object(storage_proxy._requests, "post", return_value=resp):
+        pf = storage_proxy.ProxyFile("s3://b/f.bin", mode="rb")
+        assert pf.read() == b"\x00\x01\x02"
+
+
+def test_proxy_file_write_flushes_on_close():
+    """ProxyFile writes data to the proxy only when close() is called."""
+    from lab import storage_proxy
+
+    # Create a write-mode file — no network call yet
+    pf = storage_proxy.ProxyFile("s3://b/out.txt", mode="w")
+    pf.write("hello ")
+    pf.write("world")
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"status": "ok"})) as mock_post:
+        pf.close()
+
+    # write_bytes should have been called with the full content
+    assert mock_post.call_args[1]["data"] == b"hello world"
+
+
+def test_proxy_file_context_manager():
+    from lab import storage_proxy
+
+    resp = _ok_response(content=b"ctx")
+    with patch.object(storage_proxy._requests, "post", return_value=resp):
+        with storage_proxy.ProxyFile("s3://b/f.txt", mode="r") as f:
+            assert f.read() == "ctx"
+
+
+# ---------------------------------------------------------------------------
+# open_file
+# ---------------------------------------------------------------------------
+
+
+def test_open_file_returns_proxy_file():
+    from lab import storage_proxy
+
+    resp = _ok_response(content=b"opened")
+    with patch.object(storage_proxy._requests, "post", return_value=resp):
+        pf = storage_proxy.open_file("s3://b/f.txt", mode="r")
+
+    assert isinstance(pf, storage_proxy.ProxyFile)
+    assert pf.read() == "opened"
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat wrappers (get / put / list_keys)
+# ---------------------------------------------------------------------------
+
+
+def test_get_downloads_to_file(tmp_path):
+    from lab import storage_proxy
+
+    dest = tmp_path / "downloaded.txt"
+    resp = _ok_response(content=b"file-data")
+    with patch.object(storage_proxy._requests, "post", return_value=resp):
+        storage_proxy.get("my-bucket", "models/checkpoint.bin", str(dest))
+
+    assert dest.read_bytes() == b"file-data"
+
+
+def test_put_uploads_from_file(tmp_path):
+    from lab import storage_proxy
+
+    src = tmp_path / "upload.txt"
+    src.write_bytes(b"upload-data")
+
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"status": "ok"})) as mock_post:
+        storage_proxy.put("my-bucket", "uploads/file.txt", str(src))
+
+    assert mock_post.call_args[1]["data"] == b"upload-data"
+
+
+def test_list_keys():
+    from lab import storage_proxy
+
+    paths = ["s3://my-bucket/a/1.txt", "s3://my-bucket/a/2.txt"]
+    with patch.object(storage_proxy._requests, "post", return_value=_ok_response({"paths": paths})):
+        result = storage_proxy.list_keys("my-bucket", prefix="a/")
+
+    assert result == paths
+
+
+# ---------------------------------------------------------------------------
+# Error: missing env var
+# ---------------------------------------------------------------------------
+
+
+def test_raises_without_api_url(monkeypatch):
+    """Functions raise RuntimeError when _TFL_API_URL is not set."""
+    monkeypatch.delenv("_TFL_API_URL", raising=False)
+
+    import sys
+
+    for mod_name in list(sys.modules):
+        if "storage_proxy" in mod_name:
+            del sys.modules[mod_name]
+
+    from lab import storage_proxy
+
+    with pytest.raises(RuntimeError, match="_TFL_API_URL"):
+        storage_proxy.exists("s3://b/k")
+
+
+# ---------------------------------------------------------------------------
+# Error: non-200 from _post_json
+# ---------------------------------------------------------------------------
+
+
+def test_post_json_error():
+    from lab import storage_proxy
+
+    with patch.object(storage_proxy._requests, "post", return_value=_err_response(502, "backend down")):
+        with pytest.raises(RuntimeError, match="Storage proxy .* failed"):
+            storage_proxy.exists("s3://b/k")


### PR DESCRIPTION
- Problem
Remote GPU nodes were given full AWS credentials.
This risks credential leaks and gives nodes more access than needed.

- Solution
We removed AWS keys from remote nodes and introduced a proxy on the API server.

- Approach

API server holds AWS credentials and exposes secure storage endpoints
Remote nodes use the SDK to send storage requests through the API
Authentication is done using temporary job tokens
Large files are streamed (Node → API → S3) without local storage

- Key Changes

Added storage proxy service and routes
Updated SDK to route storage via API
Stopped injecting AWS credentials into remote nodes
Migrated internal storage usage to the proxy