### PR TITLE
Displaying model info on click

### DIFF
--- a/src/renderer/components/Experiment/Tasks/JobArtifacts/ModelsSection.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobArtifacts/ModelsSection.tsx
@@ -25,6 +25,7 @@ import {
   useSWRWithAuth as useSWR,
 } from 'renderer/lib/authContext';
 import SaveToRegistryDialog, { SaveVersionInfo } from '../SaveToRegistryDialog';
+import ModelDetailsModal from '../../../ModelZoo/ModelDetailsModal';
 
 interface ModelsSectionProps {
   open?: boolean;
@@ -59,6 +60,7 @@ export default function ModelsSection({
   const [saveDialogModel, setSaveDialogModel] = useState<string | null>(null);
   const [saveTaskJobId, setSaveTaskJobId] = useState<string | null>(null);
   const [assetNameError, setAssetNameError] = useState<string | null>(null);
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
 
   // Fetch existing models in the registry for "Add to existing" option
   const { data: registryModels } = useSWR(
@@ -249,6 +251,7 @@ export default function ModelsSection({
                       alignItems: 'center',
                       gap: 1,
                     }}
+                    onClick={() => setSelectedModelId(model.name)}
                   >
                     <ListItemContent sx={{ flex: 1, minWidth: 0 }}>
                       <Typography level="title-sm" noWrap>
@@ -334,6 +337,10 @@ export default function ModelsSection({
         </ModalDialog>
       </Modal>
       {saveDialog}
+      <ModelDetailsModal
+        modelId={selectedModelId}
+        setModelId={setSelectedModelId}
+      />
     </>
   );
 }

--- a/src/renderer/components/Nav/Sidebar.tsx
+++ b/src/renderer/components/Nav/Sidebar.tsx
@@ -51,17 +51,17 @@ function ExperimentMenuItems({ experimentInfo }: ExperimentMenuItemsProps) {
     >
       <>
         <SubNavItem
-          title="Interact"
-          path={`${basePath}/interactive`}
-          matchPattern="/experiment/:experimentName/interactive"
-          icon={<CodeIcon strokeWidth={1} />}
-          disabled={!experimentReady}
-        />
-        <SubNavItem
           title="Tasks"
           path={`${basePath}/tasks`}
           matchPattern="/experiment/:experimentName/tasks"
           icon={<StretchHorizontalIcon />}
+          disabled={!experimentReady}
+        />
+        <SubNavItem
+          title="Interact"
+          path={`${basePath}/interactive`}
+          matchPattern="/experiment/:experimentName/interactive"
+          icon={<CodeIcon strokeWidth={1} />}
           disabled={!experimentReady}
         />
         <SubNavItem

--- a/src/renderer/components/Nav/Sidebar.tsx
+++ b/src/renderer/components/Nav/Sidebar.tsx
@@ -51,17 +51,17 @@ function ExperimentMenuItems({ experimentInfo }: ExperimentMenuItemsProps) {
     >
       <>
         <SubNavItem
-          title="Tasks"
-          path={`${basePath}/tasks`}
-          matchPattern="/experiment/:experimentName/tasks"
-          icon={<StretchHorizontalIcon />}
-          disabled={!experimentReady}
-        />
-        <SubNavItem
           title="Interact"
           path={`${basePath}/interactive`}
           matchPattern="/experiment/:experimentName/interactive"
           icon={<CodeIcon strokeWidth={1} />}
+          disabled={!experimentReady}
+        />
+        <SubNavItem
+          title="Tasks"
+          path={`${basePath}/tasks`}
+          matchPattern="/experiment/:experimentName/tasks"
+          icon={<StretchHorizontalIcon />}
           disabled={!experimentReady}
         />
         <SubNavItem


### PR DESCRIPTION
This PR adds the ability to click on models in the job artifacts section to view detailed model information, similar to what Hugging Face provides. When users click on a model name in the list, a modal opens showing the model's description, architecture, license, parameters, context, and size.

Changes made:
- Imported ModelDetailsModal component into ModelsSection.tsx
- Added state for selectedModelId
- Added onClick handler to ListItemButton to open the model details modal
- Rendered the ModelDetailsModal in the component

This enhances the user experience by providing more information about models directly in the app, without needing to navigate to external sites.