### PR TITLE
Fix field name for github branch in interactive tasks

### DIFF
--- a/api/transformerlab/routers/experiment/task.py
+++ b/api/transformerlab/routers/experiment/task.py
@@ -168,11 +168,9 @@ async def task_list_files(task_id: str) -> TaskFilesResponse:
     github_files: list[str] = []
     local_files: list[str] = []
 
-    # For tasks, fields are stored directly (flat structure). Prefer canonical github_repo_* keys,
-    # but fall back to legacy github_directory/github_branch for older tasks.
     github_repo_url = task.get("github_repo_url")
-    github_repo_dir = task.get("github_repo_dir") or task.get("github_directory")
-    github_repo_branch = task.get("github_repo_branch") or task.get("github_branch")
+    github_repo_dir = task.get("github_repo_dir")
+    github_repo_branch = task.get("github_repo_branch")
 
     if github_repo_url:
         try:
@@ -357,7 +355,7 @@ async def task_get_github_file(task_id: str, file_path: str):
         raise HTTPException(status_code=404, detail="Task not found")
 
     github_repo_url = task.get("github_repo_url")
-    github_branch = task.get("github_branch")
+    github_repo_branch = task.get("github_repo_branch")
     if not github_repo_url:
         raise HTTPException(status_code=400, detail="Task has no github_repo_url configured")
 
@@ -366,7 +364,7 @@ async def task_get_github_file(task_id: str, file_path: str):
     content_bytes = await fetch_github_file_bytes(
         github_repo_url,
         file_path=file_path,
-        ref=github_branch,
+        ref=github_repo_branch,
     )
 
     _, ext = os.path.splitext(file_path.lower())
@@ -895,15 +893,14 @@ async def import_task_from_gallery(
         # 3. inline setup/command fields on the gallery entry
         github_repo_url = gallery_entry.get("github_repo_url")
         github_repo_dir = gallery_entry.get("github_repo_dir")
-        # Support both canonical github_repo_branch and legacy github_branch.
-        github_branch = gallery_entry.get("github_repo_branch") or gallery_entry.get("github_branch")
+        github_repo_branch = gallery_entry.get("github_repo_branch")
         local_task_dir = gallery_entry.get("local_task_dir")
         source_yaml_data = {}
 
         if github_repo_url:
             try:
                 task_yaml_content = await fetch_task_yaml_from_github(
-                    github_repo_url, directory=github_repo_dir, ref=github_branch
+                    github_repo_url, directory=github_repo_dir, ref=github_repo_branch
                 )
                 source_yaml_data = _parse_yaml_to_task_data(task_yaml_content)
             except Exception as e:
@@ -932,17 +929,17 @@ async def import_task_from_gallery(
         if github_repo_url:
             task_data["github_repo_url"] = github_repo_url
             if github_repo_dir:
-                task_data["github_directory"] = github_repo_dir
-            if github_branch:
-                task_data["github_branch"] = github_branch
+                task_data["github_repo_dir"] = github_repo_dir
+            if github_repo_branch:
+                task_data["github_repo_branch"] = github_repo_branch
 
         # Merge additional fields from source task.yaml (parameters, env_vars, resources, etc.)
         for key in (
             "parameters",
             "env_vars",
             "github_repo_url",
-            "github_directory",
-            "github_branch",
+            "github_repo_dir",
+            "github_repo_branch",
             "cpus",
             "memory",
             "disk_space",
@@ -1030,15 +1027,9 @@ async def import_task_from_gallery(
 
     # Extract gallery entry fields
     title = gallery_entry.get("title", "Imported Task")
-    github_repo_url = gallery_entry.get("github_repo_url") or gallery_entry.get("github_url", "")
-    github_repo_dir = (
-        gallery_entry.get("github_repo_dir")
-        or gallery_entry.get("directory_path")
-        or gallery_entry.get("github_directory")
-    )
-    github_branch = (
-        gallery_entry.get("github_branch") or gallery_entry.get("github_repo_branch") or gallery_entry.get("git_branch")
-    )
+    github_repo_url = gallery_entry.get("github_repo_url") or ""
+    github_repo_dir = gallery_entry.get("github_repo_dir")
+    github_repo_branch = gallery_entry.get("github_repo_branch")
 
     if not github_repo_url:
         raise HTTPException(status_code=400, detail="Gallery entry missing github_repo_url")
@@ -1046,7 +1037,7 @@ async def import_task_from_gallery(
     # Fetch task.yaml from GitHub repository
     try:
         task_yaml_content = await fetch_task_yaml_from_github(
-            github_repo_url, directory=github_repo_dir, ref=github_branch
+            github_repo_url, directory=github_repo_dir, ref=github_repo_branch
         )
     except HTTPException as e:
         if e.status_code == 404:
@@ -1088,13 +1079,13 @@ async def import_task_from_gallery(
     if "plugin" not in task_data:
         task_data["plugin"] = "remote_orchestrator"
 
-    # Ensure GitHub repo info is set (may be in task.yaml as git_repo). Prefer canonical github_repo_* keys.
+    # Ensure GitHub repo info is set when gallery YAML omits it.
     if not task_data.get("github_repo_url"):
         task_data["github_repo_url"] = github_repo_url
     if github_repo_dir and not task_data.get("github_repo_dir"):
         task_data["github_repo_dir"] = github_repo_dir
-    if github_branch and not task_data.get("github_repo_branch"):
-        task_data["github_repo_branch"] = github_branch
+    if github_repo_branch and not task_data.get("github_repo_branch"):
+        task_data["github_repo_branch"] = github_repo_branch
 
     # Resolve provider
     await _resolve_provider(task_data, user_and_team, session)
@@ -1329,15 +1320,9 @@ async def import_task_from_team_gallery(
 
     # Extract gallery entry fields
     title = gallery_entry.get("title", "Imported Task")
-    github_repo_url = gallery_entry.get("github_repo_url") or gallery_entry.get("github_url", "")
-    github_repo_dir = (
-        gallery_entry.get("github_repo_dir")
-        or gallery_entry.get("directory_path")
-        or gallery_entry.get("github_directory")
-    )
-    github_branch = (
-        gallery_entry.get("github_branch") or gallery_entry.get("github_repo_branch") or gallery_entry.get("git_branch")
-    )
+    github_repo_url = gallery_entry.get("github_repo_url") or ""
+    github_repo_dir = gallery_entry.get("github_repo_dir")
+    github_repo_branch = gallery_entry.get("github_repo_branch")
 
     local_task_dir = gallery_entry.get("local_task_dir")
     inline_config = gallery_entry.get("config") if isinstance(gallery_entry.get("config"), dict) else None
@@ -1388,8 +1373,8 @@ async def import_task_from_team_gallery(
             task_data["github_repo_url"] = github_repo_url
         if github_repo_dir and not task_data.get("github_repo_dir"):
             task_data["github_repo_dir"] = github_repo_dir
-        if github_branch and not task_data.get("github_repo_branch"):
-            task_data["github_repo_branch"] = github_branch
+        if github_repo_branch and not task_data.get("github_repo_branch"):
+            task_data["github_repo_branch"] = github_repo_branch
 
         if not is_interactive_import:
             await _resolve_provider(task_data, user_and_team, session)
@@ -1520,7 +1505,7 @@ async def import_task_from_team_gallery(
     # Fetch task.yaml from GitHub repository
     try:
         task_yaml_content = await fetch_task_yaml_from_github(
-            github_repo_url, directory=github_repo_dir, ref=github_branch
+            github_repo_url, directory=github_repo_dir, ref=github_repo_branch
         )
     except HTTPException as e:
         if e.status_code == 404:
@@ -1555,13 +1540,12 @@ async def import_task_from_team_gallery(
         if interactive_gallery_id and not task_data.get("interactive_gallery_id"):
             task_data["interactive_gallery_id"] = interactive_gallery_id
 
-    # Ensure GitHub repo info is set (may be in task.yaml as git_repo)
     if not task_data.get("github_repo_url"):
         task_data["github_repo_url"] = github_repo_url
-    if github_repo_dir and not task_data.get("github_directory"):
-        task_data["github_directory"] = github_repo_dir
-    if github_branch and not task_data.get("github_branch"):
-        task_data["github_branch"] = github_branch
+    if github_repo_dir and not task_data.get("github_repo_dir"):
+        task_data["github_repo_dir"] = github_repo_dir
+    if github_repo_branch and not task_data.get("github_repo_branch"):
+        task_data["github_repo_branch"] = github_repo_branch
 
     # Interactive imports: provider is chosen at launch in the UI, not from YAML/defaults.
     if not is_interactive_import:
@@ -1638,10 +1622,10 @@ async def export_task_to_team_gallery(
         config["file_mounts"] = task.get("file_mounts")
     if task.get("github_repo_url"):
         config["github_repo_url"] = task.get("github_repo_url")
-    if task.get("github_directory"):
-        config["github_directory"] = task.get("github_directory")
-    if task.get("github_branch"):
-        config["github_branch"] = task.get("github_branch")
+    if task.get("github_repo_dir"):
+        config["github_repo_dir"] = task.get("github_repo_dir")
+    if task.get("github_repo_branch"):
+        config["github_repo_branch"] = task.get("github_repo_branch")
     # Preserve interactive metadata in the exported entry so the team interactive tab can round-trip.
     if task.get("subtype"):
         config["subtype"] = task.get("subtype")
@@ -1656,8 +1640,8 @@ async def export_task_to_team_gallery(
         "description": task.get("description"),
         "config": config,
         "github_repo_url": task.get("github_repo_url"),
-        "github_repo_dir": task.get("github_directory"),
-        "github_branch": task.get("github_branch"),
+        "github_repo_dir": task.get("github_repo_dir"),
+        "github_repo_branch": task.get("github_repo_branch"),
         "subtype": task.get("subtype"),
         "interactive_type": task.get("interactive_type"),
         "interactive_gallery_id": task.get("interactive_gallery_id"),
@@ -1706,8 +1690,8 @@ async def export_task_to_team_gallery(
                         "envs": task.get("env_vars") if isinstance(task.get("env_vars"), dict) else None,
                         "parameters": task.get("parameters") if isinstance(task.get("parameters"), dict) else None,
                         "github_repo_url": task.get("github_repo_url"),
-                        "github_repo_dir": task.get("github_directory"),
-                        "github_repo_branch": task.get("github_branch"),
+                        "github_repo_dir": task.get("github_repo_dir"),
+                        "github_repo_branch": task.get("github_repo_branch"),
                     }
                     yaml_obj["resources"] = {
                         k: v for k, v in (yaml_obj.get("resources") or {}).items() if v is not None
@@ -1771,7 +1755,7 @@ async def add_task_to_team_gallery(
         },
         "github_repo_url": request.github_repo_url,
         "github_repo_dir": request.github_repo_dir,
-        "github_repo_branch": request.github_branch,
+        "github_repo_branch": request.github_repo_branch,
     }
     yaml_obj["resources"] = {k: v for k, v in (yaml_obj.get("resources") or {}).items() if v not in (None, "")}
     yaml_obj = {k: v for k, v in yaml_obj.items() if v not in (None, "", {}, [])}
@@ -1803,11 +1787,11 @@ async def add_task_to_team_gallery(
             "supported_accelerators": request.supported_accelerators,
             "github_repo_url": request.github_repo_url,
             "github_repo_dir": request.github_repo_dir,
-            "github_branch": request.github_branch,
+            "github_repo_branch": request.github_repo_branch,
         },
         "github_repo_url": request.github_repo_url,
         "github_repo_dir": request.github_repo_dir,
-        "github_branch": request.github_branch,
+        "github_repo_branch": request.github_repo_branch,
         "local_task_dir": dest_dir,
     }
 

--- a/api/transformerlab/routers/experiment/task.py
+++ b/api/transformerlab/routers/experiment/task.py
@@ -895,7 +895,8 @@ async def import_task_from_gallery(
         # 3. inline setup/command fields on the gallery entry
         github_repo_url = gallery_entry.get("github_repo_url")
         github_repo_dir = gallery_entry.get("github_repo_dir")
-        github_branch = gallery_entry.get("github_branch")
+        # Support both canonical github_repo_branch and legacy github_branch.
+        github_branch = gallery_entry.get("github_repo_branch") or gallery_entry.get("github_branch")
         local_task_dir = gallery_entry.get("local_task_dir")
         source_yaml_data = {}
 

--- a/api/transformerlab/schemas/compute_providers.py
+++ b/api/transformerlab/schemas/compute_providers.py
@@ -135,13 +135,9 @@ class ProviderTemplateLaunchRequest(BaseModel):
         description="Configuration values to override for this specific run. These will be merged with parameters defaults.",
     )
     provider_name: Optional[str] = None
-    # Canonical GitHub fields (preferred)
     github_repo_url: Optional[str] = None
     github_repo_dir: Optional[str] = None
     github_repo_branch: Optional[str] = None
-    # Legacy fields kept for backward compatibility; new code should prefer github_repo_*.
-    github_directory: Optional[str] = None
-    github_branch: Optional[str] = None
     # Sweep configuration
     run_sweeps: Optional[bool] = Field(
         default=False,

--- a/api/transformerlab/schemas/task.py
+++ b/api/transformerlab/schemas/task.py
@@ -45,7 +45,7 @@ class AddTeamTaskToGalleryRequest(BaseModel):
     supported_accelerators: Optional[str] = None
     github_repo_url: Optional[str] = None
     github_repo_dir: Optional[str] = None
-    github_branch: Optional[str] = None
+    github_repo_branch: Optional[str] = None
 
 
 class DeleteTeamTaskFromGalleryRequest(BaseModel):

--- a/api/transformerlab/services/compute_provider/launch_sweep.py
+++ b/api/transformerlab/services/compute_provider/launch_sweep.py
@@ -284,8 +284,8 @@ async def launch_sweep_jobs(
                 if request.github_repo_url:
                     workspace_dir = await get_workspace_dir()
                     github_pat = await read_github_pat_from_workspace(workspace_dir, user_id=user_id)
-                    directory = request.github_repo_dir or request.github_directory
-                    branch = request.github_repo_branch or request.github_branch
+                    directory = request.github_repo_dir
+                    branch = request.github_repo_branch
                     github_setup = generate_github_clone_setup(
                         repo_url=request.github_repo_url,
                         directory=directory,

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -269,18 +269,15 @@ async def launch_template_on_provider(
         task_data = await task_service.task_get_by_id(request.task_id)
         if task_data:
             request.github_repo_url = task_data.get("github_repo_url", "") or ""
-            # Task data may store the directory as either github_repo_dir or github_directory
-            request.github_repo_dir = (
-                task_data.get("github_repo_dir", "") or task_data.get("github_directory", "") or ""
-            )
-            request.github_repo_branch = task_data.get("github_branch", "") or ""
+            request.github_repo_dir = task_data.get("github_repo_dir", "") or ""
+            request.github_repo_branch = task_data.get("github_repo_branch", "") or ""
 
     # Add GitHub clone setup if enabled
     if request.github_repo_url:
         workspace_dir = await get_workspace_dir()
         github_pat = await read_github_pat_from_workspace(workspace_dir, user_id=user_id)
-        directory = request.github_repo_dir or request.github_directory
-        branch = request.github_repo_branch or request.github_branch
+        directory = request.github_repo_dir
+        branch = request.github_repo_branch
         github_setup = generate_github_clone_setup(
             repo_url=request.github_repo_url,
             directory=directory,

--- a/api/transformerlab/services/compute_provider/remote_job_endpoints_service.py
+++ b/api/transformerlab/services/compute_provider/remote_job_endpoints_service.py
@@ -162,8 +162,6 @@ async def resume_remote_job_from_checkpoint(
         "github_repo_url",
         "github_repo_dir",
         "github_repo_branch",
-        "github_directory",
-        "github_branch",
         "user_info",
         "team_id",
     ]
@@ -260,9 +258,9 @@ async def resume_remote_job_from_checkpoint(
         github_pat = await read_github_pat_from_workspace(workspace_dir, user_id=user_id_for_pat)
         github_setup = generate_github_clone_setup(
             repo_url=github_repo_url,
-            directory=job_data.get("github_directory"),
+            directory=job_data.get("github_repo_dir"),
             github_pat=github_pat,
-            branch=job_data.get("github_branch"),
+            branch=job_data.get("github_repo_branch"),
         )
         setup_commands.append(github_setup)
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.11"
+version = "0.0.12"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/task.py
+++ b/cli/src/transformerlab_cli/commands/task.py
@@ -315,8 +315,8 @@ def build_launch_payload(
         "config": param_values if param_values else None,
         "provider_name": provider_name,
         "github_repo_url": task.get("github_repo_url"),
-        "github_repo_dir": task.get("github_repo_dir") or task.get("github_directory"),
-        "github_repo_branch": task.get("github_repo_branch") or task.get("github_branch"),
+        "github_repo_dir": task.get("github_repo_dir"),
+        "github_repo_branch": task.get("github_repo_branch"),
     }
 
 

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/src/renderer/components/Experiment/Interactive/Interactive.tsx
+++ b/src/renderer/components/Experiment/Interactive/Interactive.tsx
@@ -697,7 +697,7 @@ export default function Interactive() {
           env_vars:
             Object.keys(envVarsClean).length > 0 ? envVarsClean : undefined,
           github_repo_url: galleryTemplate?.github_repo_url || undefined,
-          github_directory: galleryTemplate?.github_repo_dir || undefined,
+          github_repo_dir: galleryTemplate?.github_repo_dir || undefined,
         };
 
         response = await chatAPI.authenticatedFetch(
@@ -849,16 +849,8 @@ export default function Interactive() {
         file_mounts: cfg.file_mounts || task.file_mounts,
         provider_name: providerMeta.name,
         github_repo_url: cfg.github_repo_url || task.github_repo_url,
-        github_repo_dir:
-          cfg.github_repo_dir ||
-          cfg.github_directory ||
-          task.github_repo_dir ||
-          task.github_directory,
-        github_repo_branch:
-          cfg.github_repo_branch ||
-          cfg.github_branch ||
-          task.github_repo_branch ||
-          task.github_branch,
+        github_repo_dir: cfg.github_repo_dir || task.github_repo_dir,
+        github_repo_branch: cfg.github_repo_branch || task.github_repo_branch,
         run_sweeps: cfg.run_sweeps || task.run_sweeps || undefined,
         sweep_config: cfg.sweep_config || task.sweep_config || undefined,
         sweep_metric:
@@ -1001,16 +993,8 @@ export default function Interactive() {
         file_mounts: cfg.file_mounts || task.file_mounts,
         provider_name: providerMeta.name,
         github_repo_url: cfg.github_repo_url || task.github_repo_url,
-        github_repo_dir:
-          cfg.github_repo_dir ||
-          cfg.github_directory ||
-          task.github_repo_dir ||
-          task.github_directory,
-        github_repo_branch:
-          cfg.github_repo_branch ||
-          cfg.github_branch ||
-          task.github_repo_branch ||
-          task.github_branch,
+        github_repo_dir: cfg.github_repo_dir || task.github_repo_dir,
+        github_repo_branch: cfg.github_repo_branch || task.github_repo_branch,
         run_sweeps: cfg.run_sweeps || task.run_sweeps || undefined,
         sweep_config: cfg.sweep_config || task.sweep_config || undefined,
         sweep_metric:

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -693,10 +693,8 @@ export default function Tasks({ subtype }: { subtype?: string }) {
         parameters: data.parameters || undefined,
         file_mounts: data.file_mounts || undefined,
         github_repo_url: data.github_repo_url || undefined,
-        github_repo_dir:
-          data.github_repo_dir || data.github_directory || undefined,
-        github_repo_branch:
-          data.github_repo_branch || data.github_branch || undefined,
+        github_repo_dir: data.github_repo_dir || undefined,
+        github_repo_branch: data.github_repo_branch || undefined,
         run_sweeps: data.run_sweeps || undefined,
         sweep_config: data.sweep_config || undefined,
         sweep_metric:
@@ -866,7 +864,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
           provider_name: providerMeta.name,
           env_vars: Object.keys(envVars).length > 0 ? envVars : undefined,
           github_repo_url: template?.github_repo_url || undefined,
-          github_directory: template?.github_repo_dir || undefined,
+          github_repo_dir: template?.github_repo_dir || undefined,
         };
 
         response = await fetchWithAuth(
@@ -1026,16 +1024,8 @@ export default function Tasks({ subtype }: { subtype?: string }) {
         file_mounts: cfg.file_mounts || task.file_mounts,
         provider_name: config?.provider_name ?? providerMeta.name,
         github_repo_url: cfg.github_repo_url || task.github_repo_url,
-        github_repo_dir:
-          cfg.github_repo_dir ||
-          cfg.github_directory ||
-          task.github_repo_dir ||
-          task.github_directory,
-        github_repo_branch:
-          cfg.github_repo_branch ||
-          cfg.github_branch ||
-          task.github_repo_branch ||
-          task.github_branch,
+        github_repo_dir: cfg.github_repo_dir || task.github_repo_dir,
+        github_repo_branch: cfg.github_repo_branch || task.github_repo_branch,
         run_sweeps: cfg.run_sweeps || task.run_sweeps || undefined,
         sweep_config: cfg.sweep_config || task.sweep_config || undefined,
         sweep_metric:

--- a/src/renderer/components/TasksGallery/TasksGallery.tsx
+++ b/src/renderer/components/TasksGallery/TasksGallery.tsx
@@ -48,9 +48,7 @@ function filterTasksGallery(data: any[], searchText: string = '') {
       title.toLowerCase().includes(lowerSearch) ||
       description.toLowerCase().includes(lowerSearch) ||
       (task.github_repo_url || '').toLowerCase().includes(lowerSearch) ||
-      (task.github_repo_branch || task.github_branch || '')
-        .toLowerCase()
-        .includes(lowerSearch)
+      (task.github_repo_branch || '').toLowerCase().includes(lowerSearch)
     );
   });
   return filteredData;
@@ -205,7 +203,7 @@ function TaskCard({
                   href={generateGithubLink(
                     task.github_repo_url,
                     task?.github_repo_dir,
-                    task?.github_repo_branch ?? task?.github_branch,
+                    task?.github_repo_branch,
                   )}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -227,7 +225,7 @@ function TaskCard({
                   href={generateGithubLink(
                     task.github_repo_url,
                     task?.github_repo_dir,
-                    task?.github_repo_branch ?? task?.github_branch,
+                    task?.github_repo_branch,
                   )}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -247,7 +245,7 @@ function TaskCard({
                   {formatGithubPath(
                     task.github_repo_url,
                     task?.github_repo_dir,
-                    task?.github_repo_branch ?? task?.github_branch,
+                    task?.github_repo_branch,
                   )}
                 </Typography>
               </Box>
@@ -792,7 +790,6 @@ export default function TasksGallery() {
                       title?: string;
                       github_repo_url?: string;
                       github_repo_branch?: string;
-                      github_branch?: string;
                     }) =>
                       galleryTask === task ||
                       (galleryTask?.id &&
@@ -802,12 +799,8 @@ export default function TasksGallery() {
                         task?.title &&
                         galleryTask.title === task.title &&
                         galleryTask.github_repo_url === task.github_repo_url &&
-                        (galleryTask.github_repo_branch ??
-                          galleryTask.github_branch ??
-                          '') ===
-                          (task.github_repo_branch ??
-                            task.github_branch ??
-                            '')),
+                        (galleryTask.github_repo_branch ?? '') ===
+                          (task.github_repo_branch ?? '')),
                   );
                   galleryIdentifier =
                     originalIndex >= 0 ? originalIndex : filteredIndex;

--- a/src/renderer/components/TasksGallery/TeamInteractiveGalleryModal.tsx
+++ b/src/renderer/components/TasksGallery/TeamInteractiveGalleryModal.tsx
@@ -45,7 +45,6 @@ interface InteractiveTask {
   github_repo_url?: string;
   github_repo_dir?: string;
   github_repo_branch?: string;
-  github_branch?: string;
 }
 
 interface TeamInteractiveGalleryModalProps {
@@ -128,9 +127,7 @@ function filterTasksGallery(data: InteractiveTask[], searchText: string = '') {
       title.toLowerCase().includes(lowerSearch) ||
       description.toLowerCase().includes(lowerSearch) ||
       (task.github_repo_url || '').toLowerCase().includes(lowerSearch) ||
-      (task.github_repo_branch || task.github_branch || '')
-        .toLowerCase()
-        .includes(lowerSearch)
+      (task.github_repo_branch || '').toLowerCase().includes(lowerSearch)
     );
   });
   return filteredData;
@@ -321,8 +318,7 @@ export default function TeamInteractiveGalleryModal({
                                     href={generateGithubLink(
                                       task.github_repo_url,
                                       task?.github_repo_dir,
-                                      task?.github_repo_branch ??
-                                        task?.github_branch,
+                                      task?.github_repo_branch,
                                     )}
                                     target="_blank"
                                     rel="noopener noreferrer"
@@ -344,8 +340,7 @@ export default function TeamInteractiveGalleryModal({
                                     href={generateGithubLink(
                                       task.github_repo_url,
                                       task?.github_repo_dir,
-                                      task?.github_repo_branch ??
-                                        task?.github_branch,
+                                      task?.github_repo_branch,
                                     )}
                                     target="_blank"
                                     rel="noopener noreferrer"
@@ -365,8 +360,7 @@ export default function TeamInteractiveGalleryModal({
                                     {formatGithubPath(
                                       task.github_repo_url,
                                       task?.github_repo_dir,
-                                      task?.github_repo_branch ??
-                                        task?.github_branch,
+                                      task?.github_repo_branch,
                                     )}
                                   </Typography>
                                 </Box>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small backward-compatible change to field lookup when importing interactive tasks from the gallery; only affects which Git ref is used to fetch `task.yaml`.
> 
> **Overview**
> Interactive gallery task imports now read the GitHub ref from `github_repo_branch` (with fallback to legacy `github_branch`) when fetching `task.yaml`, aligning interactive task templates with the canonical field name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3b1e64b5ce5004a461c2baa451ce24951c4134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->