### PR TITLE
Fix response handling for runpod delete pod

### DIFF
--- a/api/transformerlab/compute_providers/runpod.py
+++ b/api/transformerlab/compute_providers/runpod.py
@@ -484,9 +484,26 @@ class RunpodProvider(ComputeProvider):
             }
 
         try:
-            # Terminate the pod
+            # Terminate the pod. RunPod documents 204 No Content on success (no body).
+            # https://docs.runpod.io/api-reference/pods/DELETE/pods/podId
             response = self._make_request("DELETE", f"/pods/{pod_id}")
-            result = response.json()
+            status = response.status_code
+            result: Optional[Any] = None
+
+            if status == 204:
+                result = None
+            elif 200 <= status < 300:
+                if response.content:
+                    try:
+                        result = response.json()
+                    except requests.exceptions.JSONDecodeError:
+                        if response.text:
+                            result = {"raw_response": response.text}
+            else:
+                # Should not occur: _make_request uses raise_for_status() (non-2xx raise before here).
+                raise RuntimeError(
+                    f"Unexpected HTTP status from RunPod delete pod: {status} (expected 2xx, typically 204)"
+                )
 
             # Remove from cache
             if cluster_name in self._cluster_name_to_pod_id:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `RunpodProvider.stop_cluster` response parsing to avoid JSON decoding on `204 No Content` and tolerate empty/non-JSON bodies.
> 
> **Overview**
> Fixes RunPod pod termination handling by no longer assuming the `DELETE /pods/{id}` response contains JSON. `stop_cluster` now treats `204 No Content` as success with no body, conditionally parses JSON only when content exists, and falls back to returning raw text for non-JSON success responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 623e3173c53434d803d9719dd5834f7ed5487e69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->