### PR TITLE
Add GitHub workflow to auto-sync galleries to transformerlab/galleries repo

### DIFF
--- a/.github/workflows/README-sync-galleries.md
+++ b/.github/workflows/README-sync-galleries.md
@@ -1,0 +1,60 @@
+# Gallery Sync Workflow
+
+## Overview
+
+The `sync-galleries.yml` workflow automatically syncs gallery JSON files from `api/transformerlab/galleries/` in this repository to the [transformerlab/galleries](https://github.com/transformerlab/galleries) repository whenever changes are merged to the `main` branch.
+
+## How It Works
+
+1. **Trigger**: The workflow runs when:
+   - A PR is merged to `main`
+   - The PR contains changes to any `*.json` file in `api/transformerlab/galleries/`
+
+2. **Process**:
+   - Checks out both repositories
+   - Copies all gallery JSON files from this repo to the galleries repo
+   - Commits and pushes changes if any files were modified
+   - Includes a reference to the source commit for traceability
+
+3. **Files Synced**:
+   - `announcement-gallery.json`
+   - `dataset-gallery.json`
+   - `exp-recipe-gallery.json`
+   - `interactive-gallery.json`
+   - `model-gallery.json`
+   - `model-group-gallery.json`
+   - `plugin-gallery.json`
+   - `task-gallery.json`
+
+## Setup Requirements
+
+### Personal Access Token (PAT)
+
+The workflow requires a GitHub Personal Access Token with write access to the `transformerlab/galleries` repository.
+
+**To set up the token:**
+
+1. Create a PAT with `repo` scope (or fine-grained token with `Contents: Read and write` permission for the galleries repo)
+2. Add it as a repository secret named `GALLERIES_SYNC_TOKEN` in this repository:
+   - Go to Settings → Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `GALLERIES_SYNC_TOKEN`
+   - Value: Your PAT
+   - Click "Add secret"
+
+**Alternative**: If using a GitHub App or organization-level token, update the workflow to use that authentication method instead.
+
+## Testing
+
+To test the workflow:
+
+1. Make a change to any gallery JSON file in `api/transformerlab/galleries/`
+2. Create a PR and merge it to `main`
+3. Check the Actions tab to see the workflow run
+4. Verify the changes appear in the [transformerlab/galleries](https://github.com/transformerlab/galleries) repository
+
+## Troubleshooting
+
+- **Authentication errors**: Verify the `GALLERIES_SYNC_TOKEN` secret is set correctly and has the required permissions
+- **No changes pushed**: The workflow only pushes if files actually changed (uses `git status --porcelain` to detect changes)
+- **Workflow doesn't trigger**: Ensure your PR includes changes to `*.json` files in the `api/transformerlab/galleries/` directory

--- a/.github/workflows/sync-galleries.yml
+++ b/.github/workflows/sync-galleries.yml
@@ -1,0 +1,58 @@
+name: Sync Galleries to transformerlab/galleries
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "api/transformerlab/galleries/*.json"
+
+permissions:
+  contents: read
+
+jobs:
+  sync-galleries:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout transformerlab-app repo
+        uses: actions/checkout@v4
+        with:
+          path: transformerlab-app
+      
+      - name: Checkout transformerlab/galleries repo
+        uses: actions/checkout@v4
+        with:
+          repository: transformerlab/galleries
+          token: ${{ secrets.GALLERIES_SYNC_TOKEN }}
+          path: galleries
+      
+      - name: Copy gallery files
+        run: |
+          echo "Copying gallery JSON files from transformerlab-app to galleries repo..."
+          cp -v transformerlab-app/api/transformerlab/galleries/*.json galleries/
+      
+      - name: Check for changes
+        id: check_changes
+        run: |
+          cd galleries
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected:"
+            git status --short
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected"
+          fi
+      
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          cd galleries
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add *.json
+          git commit -m "Sync gallery files from transformerlab-app@${{ github.sha }}
+
+          Auto-synced from: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+          git push


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds a GitHub Actions workflow that automatically syncs gallery JSON files from `api/transformerlab/galleries/` to the [transformerlab/galleries](https://github.com/transformerlab/galleries) repository whenever changes are merged to main.

## Changes

- **New workflow**: `.github/workflows/sync-galleries.yml`
  - Triggers on push to `main` when `*.json` files in `api/transformerlab/galleries/` change
  - Checks out both repositories
  - Copies all gallery JSON files to the galleries repo
  - Commits and pushes changes with a reference to the source commit
  
- **Documentation**: `.github/workflows/README-sync-galleries.md`
  - Explains how the workflow works
  - Documents setup requirements (PAT token)
  - Provides testing and troubleshooting guidance

## Setup Required

Before this workflow can run successfully, a repository secret must be added:

1. Create a GitHub Personal Access Token with `repo` scope (or fine-grained token with `Contents: Read and write` for the galleries repo)
2. Add it as a repository secret named `GALLERIES_SYNC_TOKEN`

## Testing

After merging and setting up the token, test by:
1. Making a change to any file in `api/transformerlab/galleries/`
2. Merging a PR with that change to `main`
3. Verifying the workflow runs and pushes to transformerlab/galleries

## Related

Implements the idea from Slack: automatically publish gallery changes from the core repo to the transformerlab-galleries repo via CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://transformerlabgroup.slack.com/archives/C07Q4HCDYNT/p1775841817391809?thread_ts=1775841817.391809&cid=C07Q4HCDYNT)

<div><a href="https://cursor.com/agents/bc-e18dd5a7-fde4-59e2-98fd-46b82434a8e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e18dd5a7-fde4-59e2-98fd-46b82434a8e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

