### PR TITLE
Improve UI density: thinner icons, tighter buttons and padding

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -90,10 +90,11 @@ function AppContent({
         <Box
           sx={{
             px: {
-              md: 3,
-              lg: 4,
+              sm: 1,
+              md: 1,
+              lg: 1,
             },
-            pt: 2,
+            pt: 1,
             pb: 0,
             height: '100%',
             gridArea: 'main',

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -1366,7 +1366,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
           )}
         </Stack>
       </Stack>
-      <Sheet sx={{ px: 1, mt: 1, mb: 2, flex: 2, overflow: 'auto' }}>
+      <Sheet sx={{ px: 1, mt: 1, mb: 1, flex: 2, overflow: 'auto' }}>
         <JobsList
           jobs={filteredJobsForDisplay as any}
           launchProgressByJobId={launchProgressByJobId}

--- a/src/renderer/components/Shared/AnnouncementBanner.tsx
+++ b/src/renderer/components/Shared/AnnouncementBanner.tsx
@@ -161,8 +161,6 @@ export default function AnnouncementBanner() {
         gap: 1,
         px: 2,
         py: 1,
-        mx: -4,
-        mt: -2,
         mb: 2,
         backgroundColor: 'var(--joy-palette-warning-softBg)',
       }}

--- a/src/renderer/components/Shared/VersionUpdateBanner.tsx
+++ b/src/renderer/components/Shared/VersionUpdateBanner.tsx
@@ -40,8 +40,6 @@ export default function VersionUpdateBanner() {
         gap: 1,
         px: 2,
         py: 1,
-        mx: -4,
-        mt: -2,
         mb: 2,
         backgroundColor: 'var(--joy-palette-warning-softBg)',
       }}

--- a/src/renderer/lib/secretPurpleTheme.ts
+++ b/src/renderer/lib/secretPurpleTheme.ts
@@ -5,6 +5,23 @@ export default extendTheme({
     display: '-apple-system, "system-ui", var(--joy-fontFamily-fallback)',
     body: '-apple-system, "system-ui", var(--joy-fontFamily-fallback)',
   },
+  components: {
+    JoyButton: {
+      styleOverrides: {
+        root: {
+          '--Button-minHeight': '1.75rem',
+          paddingBlock: '3px',
+        },
+      },
+    },
+    JoyIconButton: {
+      styleOverrides: {
+        root: {
+          '--IconButton-size': '1.75rem',
+        },
+      },
+    },
+  },
   colorSchemes: {
     light: {
       palette: {
@@ -49,22 +66,6 @@ export default extendTheme({
         },
         text: {
           primary: 'rgb(60, 60, 67)',
-        },
-      },
-    },
-    dark: {
-      palette: {
-        primary: {
-          '50': '#f8fafc',
-          '100': '#f1f5f9',
-          '200': '#e2e8f0',
-          '300': '#cbd5e1',
-          '400': '#94a3b8',
-          '500': '#64748b',
-          '600': '#475569',
-          '700': '#334155',
-          '800': '#1e293b',
-          '900': '#0f172a',
         },
       },
     },

--- a/src/renderer/lib/theme.ts
+++ b/src/renderer/lib/theme.ts
@@ -5,6 +5,23 @@ export default extendTheme({
     display: '-apple-system, "system-ui", var(--joy-fontFamily-fallback)',
     body: '-apple-system, "system-ui", var(--joy-fontFamily-fallback)',
   },
+  components: {
+    JoyButton: {
+      styleOverrides: {
+        root: {
+          '--Button-minHeight': '1.75rem',
+          paddingBlock: '3px',
+        },
+      },
+    },
+    JoyIconButton: {
+      styleOverrides: {
+        root: {
+          '--IconButton-size': '1.75rem',
+        },
+      },
+    },
+  },
   colorSchemes: {
     light: {
       palette: {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2,6 +2,21 @@ body {
   overflow: hidden;
 }
 
+/* Scale icons to match text size in buttons and list items */
+.MuiButton-root svg,
+.MuiIconButton-root svg,
+.MuiListItemDecorator-root svg,
+.MuiListItemButton-root svg {
+  width: 1.1em !important;
+  height: 1.1em !important;
+}
+
+/* Lighter, thinner lucide icons */
+svg[stroke='currentColor'][stroke-width='2'],
+svg[stroke^='var(--joy'][stroke-width='2'] {
+  stroke-width: 1.5px;
+}
+
 a {
   color: var(--joy-palette-primary-400);
 }


### PR DESCRIPTION
## Summary
- Scale SVG icons in buttons and list items to `1.1em` so they match adjacent text size instead of being a fixed 18px
- Reduce lucide icon stroke-width from 2px to 1.5px for a lighter appearance
- Shrink button/icon-button min-height to 1.75rem and reduce vertical padding
- Tighten main content area padding and remove negative margin hacks on banners
- Fix duplicate `dark` key in secretPurpleTheme

## Test plan
- [ ] Verify sidebar icons look proportional to their labels
- [ ] Check buttons across Tasks Gallery, Model Registry, and Compute pages
- [ ] Confirm banners (announcement, version update) display correctly without negative margins
- [ ] Test dark mode to ensure icon stroke changes work in both themes