### PR TITLE
Add file sidebar to task editor modal

### DIFF
--- a/src/renderer/components/Experiment/Tasks/FileBrowserModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/FileBrowserModal.tsx
@@ -18,7 +18,12 @@ import { FolderIcon, FileIcon, ChevronRightIcon } from 'lucide-react';
 import { Endpoints, getAPIFullPath } from 'renderer/lib/transformerlab-api-sdk';
 import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
 import { fetchWithAuth } from 'renderer/lib/authContext';
-import { formatBytes } from 'renderer/lib/utils';
+import {
+  formatBytes,
+  TEXT_FILE_EXTENSIONS,
+  IMAGE_FILE_EXTENSIONS,
+  getFileExtension,
+} from 'renderer/lib/utils';
 
 type FileSource = 'job' | 'github' | 'local';
 
@@ -198,40 +203,7 @@ export default function FileBrowserModal({
       setFileLoading(true);
       setFileContent(null);
 
-      const ext = file.name.split('.').pop()?.toLowerCase() || '';
-      const textExtensions = [
-        'txt',
-        'log',
-        'csv',
-        'py',
-        'yaml',
-        'yml',
-        'md',
-        'sh',
-        'cfg',
-        'ini',
-        'toml',
-        'json',
-        'xml',
-        'html',
-        'css',
-        'js',
-        'ts',
-        'tsx',
-        'jsx',
-        'sql',
-        'r',
-        'ipynb',
-      ];
-      const imageExtensions = [
-        'png',
-        'jpg',
-        'jpeg',
-        'gif',
-        'bmp',
-        'webp',
-        'svg',
-      ];
+      const ext = getFileExtension(file.name);
 
       try {
         const url = getAPIFullPath('jobs', ['getFile'], {
@@ -240,10 +212,10 @@ export default function FileBrowserModal({
           filePath: encodeURIComponent(filePath),
         });
 
-        if (imageExtensions.includes(ext)) {
+        if (IMAGE_FILE_EXTENSIONS.has(ext)) {
           setFileMediaType('image');
           setFileContent(url);
-        } else if (textExtensions.includes(ext)) {
+        } else if (TEXT_FILE_EXTENSIONS.has(ext)) {
           setFileMediaType('text');
           const res = await fetchWithAuth(url);
           const text = await res.text();
@@ -271,32 +243,7 @@ export default function FileBrowserModal({
     setFileLoading(true);
     setFileContent(null);
 
-    const ext = file.name.split('.').pop()?.toLowerCase() || '';
-    const textExtensions = [
-      'txt',
-      'log',
-      'csv',
-      'py',
-      'yaml',
-      'yml',
-      'md',
-      'sh',
-      'cfg',
-      'ini',
-      'toml',
-      'json',
-      'xml',
-      'html',
-      'css',
-      'js',
-      'ts',
-      'tsx',
-      'jsx',
-      'sql',
-      'r',
-      'ipynb',
-    ];
-    const imageExtensions = ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg'];
+    const ext = getFileExtension(file.name);
 
     try {
       const url =
@@ -328,10 +275,10 @@ export default function FileBrowserModal({
         return;
       }
 
-      if (imageExtensions.includes(ext)) {
+      if (IMAGE_FILE_EXTENSIONS.has(ext)) {
         setFileMediaType('image');
         setFileContent(url);
-      } else if (textExtensions.includes(ext)) {
+      } else if (TEXT_FILE_EXTENSIONS.has(ext)) {
         setFileMediaType('text');
         const res = await fetchWithAuth(url);
         const text = await res.text();

--- a/src/renderer/components/Experiment/Tasks/TaskYamlEditorModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskYamlEditorModal.tsx
@@ -2,12 +2,37 @@ import * as React from 'react';
 import Modal from '@mui/joy/Modal';
 import DialogTitle from '@mui/joy/DialogTitle';
 import DialogContent from '@mui/joy/DialogContent';
-import DialogActions from '@mui/joy/DialogActions';
 import Button from '@mui/joy/Button';
-import { ModalClose, ModalDialog, Divider, Stack } from '@mui/joy';
+import {
+  ModalClose,
+  ModalDialog,
+  Divider,
+  Stack,
+  Sheet,
+  List,
+  ListItemButton,
+  ListItemContent,
+  ListItemDecorator,
+  Typography,
+  Box,
+  CircularProgress,
+} from '@mui/joy';
+import { FileIcon } from 'lucide-react';
 import { Editor } from '@monaco-editor/react';
 import { setTheme, getMonacoEditorOptions } from 'renderer/lib/monacoConfig';
 import * as chatAPI from 'renderer/lib/transformerlab-api-sdk';
+import {
+  TEXT_FILE_EXTENSIONS,
+  getFileExtension,
+  getMonacoLanguage,
+} from 'renderer/lib/utils';
+
+type FileSource = 'github' | 'local';
+
+interface TaskFile {
+  name: string;
+  source: FileSource;
+}
 
 type TaskYamlEditorModalProps = {
   open: boolean;
@@ -33,42 +58,174 @@ export default function TaskYamlEditorModal({
   const [validationMessage, setValidationMessage] = React.useState<
     string | null
   >(null);
+  const [fileList, setFileList] = React.useState<TaskFile[]>([]);
+  const [filesLoading, setFilesLoading] = React.useState(false);
+  const [selectedFile, setSelectedFile] = React.useState<string | null>(null);
 
-  const loadYaml = React.useCallback(async () => {
+  const isTaskYaml =
+    selectedFile === 'task.yaml' || selectedFile === 'task.yml';
+
+  const loadFiles = React.useCallback(async () => {
     if (!experimentId || !taskId) return;
-    setLoading(true);
-    setError(null);
-    setIsMissing(false);
+    setFilesLoading(true);
     try {
       const response = await chatAPI.authenticatedFetch(
-        chatAPI.Endpoints.Task.GetYaml(experimentId, taskId),
+        chatAPI.Endpoints.Task.ListFiles(experimentId, taskId),
       );
       if (!response.ok) {
-        if (response.status === 404) {
-          setIsMissing(true);
-          setContent('');
-        } else {
-          setIsMissing(true);
-          setError(`Failed to load: ${response.status}`);
-        }
+        setFileList([]);
         return;
       }
-      const text = await response.text();
-      setContent(text);
-      setIsMissing(false);
-    } catch (e) {
-      setIsMissing(true);
-      setError(e instanceof Error ? e.message : 'Failed to load task.yaml');
+      const data = await response.json();
+      const allFiles: TaskFile[] = [];
+      if (Array.isArray(data.github_files)) {
+        for (const f of data.github_files) {
+          allFiles.push({ name: f, source: 'github' });
+        }
+      }
+      if (Array.isArray(data.local_files)) {
+        for (const f of data.local_files) {
+          allFiles.push({ name: f, source: 'local' });
+        }
+      }
+      setFileList(allFiles);
+    } catch {
+      setFileList([]);
     } finally {
-      setLoading(false);
+      setFilesLoading(false);
     }
   }, [experimentId, taskId]);
 
+  const loadFileContent = React.useCallback(
+    async (file: TaskFile) => {
+      if (!experimentId || !taskId) return;
+      setLoading(true);
+      setError(null);
+      setIsMissing(false);
+
+      // For task.yaml, use the dedicated YAML endpoint
+      if (file.name === 'task.yaml' || file.name === 'task.yml') {
+        try {
+          const response = await chatAPI.authenticatedFetch(
+            chatAPI.Endpoints.Task.GetYaml(experimentId, taskId),
+          );
+          if (!response.ok) {
+            if (response.status === 404) {
+              setIsMissing(true);
+              setContent('');
+            } else {
+              setIsMissing(true);
+              setError(`Failed to load: ${response.status}`);
+            }
+            return;
+          }
+          const text = await response.text();
+          setContent(text);
+        } catch (e) {
+          setIsMissing(true);
+          setError(e instanceof Error ? e.message : 'Failed to load task.yaml');
+        } finally {
+          setLoading(false);
+        }
+        return;
+      }
+
+      // For other files, check if it's a renderable text file
+      const ext = getFileExtension(file.name);
+      if (!TEXT_FILE_EXTENSIONS.has(ext)) {
+        setContent('Binary file — preview not available');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const url =
+          file.source === 'github'
+            ? chatAPI.Endpoints.Task.GetGithubFile(
+                experimentId,
+                taskId,
+                file.name,
+              )
+            : chatAPI.Endpoints.Task.GetFile(experimentId, taskId, file.name);
+
+        const response = await chatAPI.authenticatedFetch(url);
+        if (!response.ok) {
+          setError(`Failed to load file: ${response.status}`);
+          setContent('');
+          return;
+        }
+        const text = await response.text();
+        setContent(text);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load file');
+        setContent('');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [experimentId, taskId],
+  );
+
+  // When the modal opens, load file list, then auto-select task.yaml (or first file)
   React.useEffect(() => {
-    if (open && experimentId && taskId) {
-      loadYaml();
-    }
-  }, [open, experimentId, taskId, loadYaml]);
+    if (!open || !experimentId || !taskId) return;
+    setSelectedFile(null);
+    setContent('');
+    setError(null);
+    setValidationMessage(null);
+
+    (async () => {
+      setFilesLoading(true);
+      try {
+        const response = await chatAPI.authenticatedFetch(
+          chatAPI.Endpoints.Task.ListFiles(experimentId, taskId),
+        );
+        if (!response.ok) {
+          setFileList([]);
+          return;
+        }
+        const data = await response.json();
+        const allFiles: TaskFile[] = [];
+        if (Array.isArray(data.github_files)) {
+          for (const f of data.github_files) {
+            allFiles.push({ name: f, source: 'github' });
+          }
+        }
+        if (Array.isArray(data.local_files)) {
+          for (const f of data.local_files) {
+            allFiles.push({ name: f, source: 'local' });
+          }
+        }
+        setFileList(allFiles);
+
+        // Auto-select task.yaml, or fall back to first file
+        const taskYaml = allFiles.find(
+          (f) => f.name === 'task.yaml' || f.name === 'task.yml',
+        );
+        const initial = taskYaml || allFiles[0];
+        if (initial) {
+          setSelectedFile(initial.name);
+          await loadFileContent(initial);
+        } else {
+          setLoading(false);
+          setIsMissing(true);
+        }
+      } catch {
+        setFileList([]);
+        setLoading(false);
+        setIsMissing(true);
+      } finally {
+        setFilesLoading(false);
+      }
+    })();
+  }, [open, experimentId, taskId, loadFileContent]);
+
+  const handleFileSelect = (file: TaskFile) => {
+    if (file.name === selectedFile) return;
+    setSelectedFile(file.name);
+    setValidationMessage(null);
+    loadFileContent(file);
+  };
 
   const handleCreateBlank = async () => {
     setCreatingBlank(true);
@@ -90,10 +247,12 @@ export default function TaskYamlEditorModal({
         setError(`Failed to create: ${response.status}`);
         return;
       }
-      // Reload the content to show in editor
       setContent(defaultYaml);
       setIsMissing(false);
       setError(null);
+      // Refresh file list since task.yaml now exists
+      await loadFiles();
+      setSelectedFile('task.yaml');
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create task.yaml');
     } finally {
@@ -187,11 +346,15 @@ export default function TaskYamlEditorModal({
     }
   };
 
+  const editorLanguage = selectedFile
+    ? getMonacoLanguage(selectedFile)
+    : 'yaml';
+
   return (
     <Modal open={open} onClose={onClose}>
       <ModalDialog
         sx={{
-          maxWidth: 900,
+          maxWidth: 1200,
           width: '95vw',
           height: '85vh',
           overflow: 'hidden',
@@ -200,120 +363,205 @@ export default function TaskYamlEditorModal({
         }}
       >
         <ModalClose />
-        <DialogTitle>task.yaml</DialogTitle>
+        <DialogTitle>Edit Task</DialogTitle>
         <Divider />
-        <DialogContent sx={{ flex: 1, minHeight: 0, p: 0 }}>
-          {loading ? (
-            <div style={{ padding: 16 }}>Loading...</div>
-          ) : isMissing ? (
-            <div
-              style={{
-                padding: 16,
+        <DialogContent
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            p: 0,
+            display: 'flex',
+            flexDirection: 'row',
+          }}
+        >
+          {/* File list sidebar */}
+          <Sheet
+            variant="outlined"
+            sx={{
+              flex: 2,
+              minWidth: 180,
+              overflow: 'auto',
+              borderRadius: 0,
+              borderTop: 'none',
+              borderBottom: 'none',
+              borderLeft: 'none',
+            }}
+          >
+            {filesLoading ? (
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  py: 4,
+                }}
+              >
+                <CircularProgress size="sm" />
+              </Box>
+            ) : fileList.length === 0 ? (
+              <Box sx={{ p: 2, textAlign: 'center' }}>
+                <Typography level="body-sm" color="neutral">
+                  No files found
+                </Typography>
+              </Box>
+            ) : (
+              <List size="sm">
+                {fileList.map((file) => (
+                  <ListItemButton
+                    key={file.name}
+                    selected={selectedFile === file.name}
+                    onClick={() => handleFileSelect(file)}
+                  >
+                    <ListItemDecorator>
+                      <FileIcon size={14} />
+                    </ListItemDecorator>
+                    <ListItemContent>
+                      <Typography
+                        level="body-sm"
+                        sx={{
+                          whiteSpace: 'nowrap',
+                          textOverflow: 'ellipsis',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        {file.name}
+                      </Typography>
+                    </ListItemContent>
+                  </ListItemButton>
+                ))}
+              </List>
+            )}
+          </Sheet>
+
+          {/* Editor panel */}
+          <Box
+            sx={{
+              flex: 7,
+              minWidth: 0,
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <Box sx={{ flex: 1, minHeight: 0 }}>
+              {loading ? (
+                <div style={{ padding: 16 }}>Loading...</div>
+              ) : isMissing ? (
+                <div
+                  style={{
+                    padding: 16,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    gap: 16,
+                  }}
+                >
+                  <div
+                    style={{
+                      color: 'var(--joy-palette-neutral-600)',
+                      textAlign: 'center',
+                    }}
+                  >
+                    {error ? (
+                      <>
+                        <div style={{ marginBottom: 8, fontWeight: 500 }}>
+                          Failed to load task.yaml
+                        </div>
+                        <div
+                          style={{
+                            fontSize: '0.875rem',
+                            color: 'var(--joy-palette-danger-500)',
+                          }}
+                        >
+                          {error}
+                        </div>
+                      </>
+                    ) : (
+                      <div style={{ fontWeight: 500 }}>task.yaml not found</div>
+                    )}
+                    <div style={{ marginTop: 16, fontSize: '0.875rem' }}>
+                      Create a blank task.yaml with a sample template?
+                    </div>
+                  </div>
+                  <Button
+                    color="primary"
+                    variant="solid"
+                    onClick={handleCreateBlank}
+                    loading={creatingBlank}
+                    disabled={creatingBlank}
+                  >
+                    Create Blank
+                  </Button>
+                </div>
+              ) : (
+                <Editor
+                  height="100%"
+                  language={editorLanguage}
+                  value={content}
+                  onChange={(v) => setContent(v ?? '')}
+                  onMount={(editor, monaco) => {
+                    setTheme(editor, monaco);
+                  }}
+                  options={{
+                    ...getMonacoEditorOptions(),
+                    readOnly: !isTaskYaml,
+                  }}
+                />
+              )}
+            </Box>
+            <Divider />
+            <Box
+              sx={{
                 display: 'flex',
-                flexDirection: 'column',
+                flexDirection: 'row',
                 alignItems: 'center',
-                justifyContent: 'center',
-                height: '100%',
-                gap: 16,
+                justifyContent: 'space-between',
+                gap: 1,
+                p: 1.5,
               }}
             >
               <div
                 style={{
-                  color: 'var(--joy-palette-neutral-600)',
-                  textAlign: 'center',
+                  minHeight: '1.25rem',
+                  flex: 1,
+                  fontSize: '0.875rem',
+                  color: error
+                    ? 'var(--joy-palette-danger-600)'
+                    : 'var(--joy-palette-success-600)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
                 }}
+                title={error || undefined}
               >
-                {error ? (
-                  <>
-                    <div style={{ marginBottom: 8, fontWeight: 500 }}>
-                      Failed to load task.yaml
-                    </div>
-                    <div
-                      style={{
-                        fontSize: '0.875rem',
-                        color: 'var(--joy-palette-danger-500)',
-                      }}
-                    >
-                      {error}
-                    </div>
-                  </>
-                ) : (
-                  <div style={{ fontWeight: 500 }}>task.yaml not found</div>
-                )}
-                <div style={{ marginTop: 16, fontSize: '0.875rem' }}>
-                  Create a blank task.yaml with a sample template?
-                </div>
+                {error || validationMessage}
               </div>
-              <Button
-                color="primary"
-                variant="solid"
-                onClick={handleCreateBlank}
-                loading={creatingBlank}
-                disabled={creatingBlank}
-              >
-                Create Blank
-              </Button>
-            </div>
-          ) : (
-            <Editor
-              height="100%"
-              language="yaml"
-              value={content}
-              onChange={(v) => setContent(v ?? '')}
-              onMount={(editor, monaco) => {
-                setTheme(editor, monaco);
-              }}
-              options={getMonacoEditorOptions()}
-            />
-          )}
+              <Stack direction="row" spacing={1} alignItems="center">
+                {isTaskYaml && (
+                  <Button
+                    color="primary"
+                    variant="outlined"
+                    onClick={handleValidate}
+                    disabled={loading || isMissing || saving}
+                  >
+                    Validate
+                  </Button>
+                )}
+                {isTaskYaml && (
+                  <Button
+                    color="success"
+                    onClick={handleSave}
+                    loading={saving}
+                    disabled={loading || isMissing}
+                  >
+                    Save
+                  </Button>
+                )}
+              </Stack>
+            </Box>
+          </Box>
         </DialogContent>
-        <DialogActions
-          sx={{
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            gap: 1,
-          }}
-        >
-          <div
-            style={{
-              minHeight: '1.25rem',
-              flex: 1,
-              fontSize: '0.875rem',
-              color: error
-                ? 'var(--joy-palette-danger-600)'
-                : 'var(--joy-palette-success-600)',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-            title={error || undefined}
-          >
-            {error || validationMessage}
-          </div>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Button color="neutral" variant="plain" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button
-              color="primary"
-              variant="outlined"
-              onClick={handleValidate}
-              disabled={loading || isMissing || saving}
-            >
-              Validate
-            </Button>
-            <Button
-              color="success"
-              onClick={handleSave}
-              loading={saving}
-              disabled={loading || isMissing}
-            >
-              Save
-            </Button>
-          </Stack>
-        </DialogActions>
       </ModalDialog>
     </Modal>
   );

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -1295,12 +1295,14 @@ export default function Tasks({ subtype }: { subtype?: string }) {
           onQueueTask={handleQueue}
           onEditTask={handleEditTask}
           onExportTask={handleExportToTeamGallery}
-          onViewFilesTask={(taskRow) =>
-            setViewTaskFilesFromTask({
-              id: taskRow.id,
-              name: (taskRow as any).name ?? (taskRow as any).title ?? null,
-            })
-          }
+          // TODO: potentially deprecated — file browsing is now integrated into the Edit Task modal.
+          // Remove onViewFilesTask and related FileBrowserModal state once confirmed unnecessary.
+          // onViewFilesTask={(taskRow) =>
+          //   setViewTaskFilesFromTask({
+          //     id: taskRow.id,
+          //     name: (taskRow as any).name ?? (taskRow as any).title ?? null,
+          //   })
+          // }
           loading={templatesIsLoading}
         />
       </Sheet>

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -256,3 +256,68 @@ export const colorArray = [
 export function mixColorWithBackground(color: string, percent = '50'): string {
   return `color-mix(in srgb, ${color}, var(--joy-palette-background-surface) ${percent}%)`;
 }
+
+export const TEXT_FILE_EXTENSIONS = new Set([
+  'txt',
+  'log',
+  'csv',
+  'py',
+  'yaml',
+  'yml',
+  'md',
+  'sh',
+  'cfg',
+  'ini',
+  'toml',
+  'json',
+  'xml',
+  'html',
+  'css',
+  'js',
+  'ts',
+  'tsx',
+  'jsx',
+  'sql',
+  'r',
+  'ipynb',
+]);
+
+export const IMAGE_FILE_EXTENSIONS = new Set([
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'webp',
+  'svg',
+]);
+
+export function getFileExtension(fileName: string): string {
+  return fileName.split('.').pop()?.toLowerCase() || '';
+}
+
+const EXTENSION_TO_MONACO_LANGUAGE: Record<string, string> = {
+  py: 'python',
+  yaml: 'yaml',
+  yml: 'yaml',
+  json: 'json',
+  js: 'javascript',
+  ts: 'typescript',
+  tsx: 'typescript',
+  jsx: 'javascript',
+  sh: 'shell',
+  md: 'markdown',
+  html: 'html',
+  css: 'css',
+  xml: 'xml',
+  sql: 'sql',
+  toml: 'ini',
+  ini: 'ini',
+  cfg: 'ini',
+  r: 'r',
+};
+
+export function getMonacoLanguage(fileName: string): string {
+  const ext = getFileExtension(fileName);
+  return EXTENSION_TO_MONACO_LANGUAGE[ext] || 'plaintext';
+}


### PR DESCRIPTION
## Summary
- Adds a file list sidebar to the Edit Task modal, replacing the task.yaml-only editor with a split-pane layout (flex 2 sidebar / flex 7 editor)
- Clicking a file in the sidebar loads its content into the Monaco editor with proper syntax highlighting per file type
- Validate and Save buttons only appear when viewing task.yaml; other files are displayed read-only
- Centralizes `TEXT_FILE_EXTENSIONS`, `IMAGE_FILE_EXTENSIONS`, `getFileExtension`, and `getMonacoLanguage` into `utils.ts`, replacing duplicated inline arrays in `FileBrowserModal`

## Test plan
- [ ] Open the Edit Task modal on a task with multiple files — verify the sidebar lists all files
- [ ] Verify task.yaml is auto-selected on open and shows Validate + Save buttons
- [ ] Click a .py or .json file — verify it loads read-only with correct syntax highlighting
- [ ] Click back to task.yaml — verify Validate and Save buttons reappear
- [ ] Verify FileBrowserModal still works correctly (job mode and task mode)