### PR TITLE
Fix CLI version banner polluting JSON output

### DIFF
--- a/cli/src/transformerlab_cli/main.py
+++ b/cli/src/transformerlab_cli/main.py
@@ -54,7 +54,7 @@ def common_setup(
     cli_state.output_format = format
     if not ctx.invoked_subcommand:
         show_header(console)  # Display the logo when no command is provided
-    elif ctx.invoked_subcommand != "version":
+    elif ctx.invoked_subcommand != "version" and format != "json":
         check_for_update(console)
 
 


### PR DESCRIPTION
## Summary
- Skip the version update banner when `--format json` is used, preventing the Rich panel from breaking JSON parsing

## Test plan
- [x] All 116 CLI tests pass
- [ ] Run `lab status --format json` when a version update is available and confirm output is valid JSON