### PR TITLE
Add file listing to lab job info CLI command

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.12"
+version = "0.0.13"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/job.py
+++ b/cli/src/transformerlab_cli/commands/job.py
@@ -234,6 +234,26 @@ def _render_artifacts(artifacts: list[str]) -> str:
     return "\n".join(filenames)
 
 
+def _format_size(size_bytes: int) -> str:
+    """Format bytes into human-readable size."""
+    for unit in ["B", "KB", "MB", "GB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes //= 1024
+    return f"{size_bytes:.1f} TB"
+
+
+def _fetch_job_files(experiment_id: str, job_id: str) -> list[dict]:
+    """Fetch the list of files in a job's directory."""
+    try:
+        response = api.get(f"/experiment/{experiment_id}/jobs/{job_id}/files")
+        if response.status_code == 200:
+            return response.json().get("files", [])
+    except Exception:
+        pass
+    return []
+
+
 def _render_job(job) -> None:
     """Render all details of a job."""
     job_data = job.get("job_data", {})
@@ -325,6 +345,27 @@ def info_job(job_id: str, experiment_id: str):
     if job:
         console.print(f"[bold success]Job Details for ID {job_id}:[/bold success]")
         _render_job(job)
+
+        # Fetch and display job files
+        with console.status("[bold success]Fetching job files[/bold success]", spinner="dots"):
+            files = _fetch_job_files(experiment_id, job_id)
+        if files:
+            file_table = Table(title="Files", show_header=True, header_style="bold")
+            file_table.add_column("Name")
+            file_table.add_column("Type", width=6)
+            file_table.add_column("Size", justify="right")
+            for f in files:
+                name = f.get("name", "")
+                is_dir = f.get("is_dir", False)
+                size = f.get("size", 0)
+                file_table.add_row(
+                    name,
+                    "dir" if is_dir else "file",
+                    "" if is_dir else _format_size(size),
+                )
+            console.print(file_table)
+        else:
+            console.print("[dim]No files found in job directory.[/dim]")
     else:
         console.print(f"[error]Error:[/error] Job with ID {job_id} not found.")
 

--- a/cli/src/transformerlab_cli/commands/job.py
+++ b/cli/src/transformerlab_cli/commands/job.py
@@ -257,6 +257,7 @@ def _fetch_job_files(experiment_id: str, job_id: str) -> list[dict]:
 def _render_job(job) -> None:
     """Render all details of a job."""
     job_data = job.get("job_data", {})
+    run_command = job_data.get("run") or job_data.get("command", "N/A")
 
     # Render progress bar
     progress = job.get("progress", 0)
@@ -274,7 +275,7 @@ def _render_job(job) -> None:
         "ID": job.get("id", "N/A"),
         "Experiment ID": job.get("experiment_id", "N/A"),
         "Task Name": job_data.get("task_name", "N/A"),
-        "Command": job_data.get("command", "N/A"),
+        "Command": run_command,
         "Cluster Name": job_data.get("cluster_name", "N/A"),
         "CPUs": job_data.get("cpus", "N/A"),
         "Memory": job_data.get("memory", "N/A"),

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Adds a **Files** table to `lab job info <ID>` output, listing all files and directories in the job directory
- Mirrors the Files browser already available in the UI (JobsList.tsx → FileBrowserModal)
- Uses the existing `GET /experiment/{experimentId}/jobs/{jobId}/files` API endpoint

## Test plan
- [ ] Run `lab job info <job_id>` on a job with files and verify the table displays name, type, and size
- [ ] Run `lab job info <job_id>` on a job with no files and verify "No files found" message
- [ ] Run `cd cli && python -m pytest tests/ -v` — all 116 tests pass