### PR TITLE
Fix layout of file browser left pane to avoid weird wrapping

### DIFF
--- a/src/renderer/components/Experiment/Tasks/FileBrowserModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/FileBrowserModal.tsx
@@ -403,7 +403,7 @@ export default function FileBrowserModal({
                           <FileIcon size={16} />
                         )}
                       </ListItemDecorator>
-                      <ListItemContent>
+                      <ListItemContent sx={{ minWidth: 0 }}>
                         <Typography
                           level="body-sm"
                           sx={{
@@ -454,7 +454,11 @@ export default function FileBrowserModal({
                         <ChevronRightIcon size={14} />
                       )}
                       {mode === 'job' && !file.is_dir && (
-                        <Typography level="body-xs" color="neutral">
+                        <Typography
+                          level="body-xs"
+                          color="neutral"
+                          sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+                        >
                           {formatBytes(file.size)}
                         </Typography>
                       )}


### PR DESCRIPTION
Before

<img width="1106" height="645" alt="Monosnap Transformer Lab 2026-04-13 20-04-01" src="https://github.com/user-attachments/assets/9d8645c1-0c91-40c8-ac18-d8afb985dd19" />

After

<img width="1098" height="669" alt="Monosnap Transformer Lab 2026-04-13 20-13-46" src="https://github.com/user-attachments/assets/c7954fef-131e-474f-a54e-d5105411b38d" />
