### PR TITLE
Fix local tunnel parsing

### DIFF
--- a/api/test/api/test_interactive_gallery_utils.py
+++ b/api/test/api/test_interactive_gallery_utils.py
@@ -63,14 +63,11 @@ def test_resolve_remote_uses_base_command_and_ngrok_from_ports():
     assert setup is None
 
 
-def test_resolve_local_appends_local_echo_with_base_command():
-    """Local path appends local URL echo for known interactive types; run from base_command."""
+def test_resolve_local_returns_base_command_without_echo_injection():
+    """Local path keeps task run command untouched; URL parsing happens from real logs."""
     entry = {"id": "ollama", "interactive_type": "ollama"}
     cmd, setup = resolve_interactive_command(entry, "local", base_command="python run.py")
-    assert "python run.py" in cmd
-    assert "Local Ollama API: http://localhost:11434" in cmd
-    assert "Local Open WebUI: http://localhost:8080" in cmd
-    assert "tee -a /tmp/ngrok.log" in cmd
+    assert cmd == "python run.py"
     assert setup is None
 
 

--- a/api/test/shared/test_tunnel_parser.py
+++ b/api/test/shared/test_tunnel_parser.py
@@ -1,0 +1,64 @@
+"""Tests for parsing interactive tunnel/local URLs from provider logs."""
+
+from transformerlab.shared.tunnel_parser import (
+    get_tunnel_info,
+    get_jupyter_tunnel_info,
+    get_ollama_tunnel_info,
+    get_vllm_tunnel_info,
+)
+
+
+def test_get_jupyter_tunnel_info_parses_local_server_output() -> None:
+    logs = """
+    [I 2026-04-14 10:00:00.000 ServerApp] Jupyter Server 2.14.0 is running at:
+    [I 2026-04-14 10:00:00.000 ServerApp] http://localhost:8888/lab?token=abc123xyz987
+    """
+    info = get_jupyter_tunnel_info(logs)
+
+    assert info["is_ready"] is True
+    assert info["token"] == "abc123xyz987"
+    assert info["tunnel_url"] == "http://localhost:8888/lab?token=abc123xyz987"
+    assert info["jupyter_url"] == "http://localhost:8888/lab?token=abc123xyz987"
+
+
+def test_get_vllm_tunnel_info_parses_local_port_urls() -> None:
+    logs = """
+    INFO vLLM API ready at http://0.0.0.0:8000
+    INFO Open WebUI ready at http://localhost:8080
+    """
+    info = get_vllm_tunnel_info(logs)
+
+    assert info["is_ready"] is True
+    assert info["tunnel_url"] == "http://0.0.0.0:8000"
+    assert info["vllm_url"] == "http://0.0.0.0:8000"
+    assert info["openwebui_url"] == "http://localhost:8080"
+
+
+def test_get_ollama_tunnel_info_parses_local_port_urls() -> None:
+    logs = """
+    INFO Ollama API listening on http://127.0.0.1:11434
+    INFO Open WebUI listening on http://localhost:8080
+    """
+    info = get_ollama_tunnel_info(logs)
+
+    assert info["is_ready"] is True
+    assert info["tunnel_url"] == "http://127.0.0.1:11434"
+    assert info["ollama_url"] == "http://127.0.0.1:11434"
+    assert info["openwebui_url"] == "http://localhost:8080"
+
+
+def test_get_tunnel_info_prefers_gallery_url_patterns_for_known_type() -> None:
+    logs = "INFO service ready at http://localhost:8000"
+    patterns = [
+        {
+            "value_key": "vllm_url",
+            "regex": r"(https?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0):8000[^\s]*)",
+            "group": 1,
+        }
+    ]
+
+    info = get_tunnel_info(logs, "vllm", url_patterns=patterns)
+
+    assert info["is_ready"] is True
+    assert info["status"] == "ready"
+    assert info["vllm_url"] == "http://localhost:8000"

--- a/api/transformerlab/galleries/interactive-gallery.json
+++ b/api/transformerlab/galleries/interactive-gallery.json
@@ -65,6 +65,13 @@
         "protocol": "http"
       }
     ],
+    "url_patterns": [
+      {
+        "value_key": "jupyter_url",
+        "regex": "(https?://(?:localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):8888[^\\s]*)",
+        "group": 1
+      }
+    ],
     "modal_title": "Jupyter Notebook Interactive Session",
     "modal_subtitle": "Access your Jupyter notebook through the URL below.",
     "instructions": [
@@ -135,6 +142,18 @@
         "protocol": "http"
       }
     ],
+    "url_patterns": [
+      {
+        "value_key": "vllm_url",
+        "regex": "(https?://(?:localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):8000[^\\s]*)",
+        "group": 1
+      },
+      {
+        "value_key": "openwebui_url",
+        "regex": "(https?://(?:localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):8080[^\\s]*)",
+        "group": 1
+      }
+    ],
     "modal_title": "vLLM Server Interactive Session",
     "modal_subtitle": "Access your vLLM API server through the URL below.",
     "instructions": [
@@ -194,6 +213,18 @@
         "port": 8080,
         "label": "Open WebUI",
         "protocol": "http"
+      }
+    ],
+    "url_patterns": [
+      {
+        "value_key": "ollama_url",
+        "regex": "(https?://(?:localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):11434[^\\s]*)",
+        "group": 1
+      },
+      {
+        "value_key": "openwebui_url",
+        "regex": "(https?://(?:localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):8080[^\\s]*)",
+        "group": 1
       }
     ],
     "modal_title": "Ollama Server Interactive Session",

--- a/api/transformerlab/routers/experiment/jobs.py
+++ b/api/transformerlab/routers/experiment/jobs.py
@@ -507,16 +507,6 @@ async def get_tunnel_info_for_job(
             job_data = json.loads(job_data)
         except JSONDecodeError:
             job_data = {}
-    # If we have previously cached tunnel info URLs and they are ready, use them immediately
-    # and skip any provider log fetching for a faster response.
-    cached_urls = job_data.get("tunnel_info_urls")
-    cached_legacy = job_data.get("cached_tunnel_info")
-    tunnel_info: dict | None = None
-    if isinstance(cached_urls, dict) and cached_urls.get("is_ready"):
-        tunnel_info = cached_urls
-    elif isinstance(cached_legacy, dict) and cached_legacy.get("is_ready"):
-        tunnel_info = cached_legacy
-
     interactive_type = job_data.get("interactive_type")
 
     # Look up the gallery entry to resolve url_patterns and interactive_type fallbacks
@@ -534,6 +524,36 @@ async def get_tunnel_info_for_job(
         # No explicit type: use "custom" (url_patterns-based parsing) rather than
         # assuming a specific legacy type like "vscode".
         interactive_type = "custom"
+
+    # Build the set of URL keys expected by this interactive template so cache is only
+    # considered "complete" when all expected values are populated.
+    expected_url_keys: set[str] = set()
+    for pattern in url_patterns or []:
+        value_key = pattern.get("value_key")
+        if isinstance(value_key, str) and value_key.endswith("_url"):
+            expected_url_keys.add(value_key)
+    for item in gallery_entry.get("instructions", []) if gallery_entry else []:
+        if item.get("kind") == "url":
+            value_key = item.get("value_key")
+            if isinstance(value_key, str):
+                expected_url_keys.add(value_key)
+
+    def _cache_has_expected_urls(cache: dict) -> bool:
+        if not cache.get("is_ready"):
+            return False
+        if not expected_url_keys:
+            return True
+        return all(cache.get(key) for key in expected_url_keys)
+
+    # If we have previously cached tunnel info URLs and they are complete, use them
+    # immediately and skip provider log fetching for a faster response.
+    cached_urls = job_data.get("tunnel_info_urls")
+    cached_legacy = job_data.get("cached_tunnel_info")
+    tunnel_info: dict | None = None
+    if isinstance(cached_urls, dict) and _cache_has_expected_urls(cached_urls):
+        tunnel_info = cached_urls
+    elif isinstance(cached_legacy, dict) and _cache_has_expected_urls(cached_legacy):
+        tunnel_info = cached_legacy
 
     provider_id = job_data.get("provider_id")
     cluster_name = job_data.get("cluster_name")

--- a/api/transformerlab/shared/interactive_gallery_utils.py
+++ b/api/transformerlab/shared/interactive_gallery_utils.py
@@ -3,7 +3,7 @@ Utilities for resolving interactive gallery commands by environment (local/remot
 See galleries.py for the interactive gallery schema documentation.
 
 Run/setup text comes from the task (e.g. task.yaml from the GitHub example repo).
-Gallery entries supply metadata (ports, interactive_type) for ngrok and local URL hints only.
+Gallery entries supply metadata (ports, interactive_type) for ngrok tunnel setup.
 """
 
 import re
@@ -31,24 +31,6 @@ def _sanitize_tunnel_name(label: Optional[str], port: int) -> str:
         if safe:
             return safe
     return f"port_{port}"
-
-
-def _build_local_url_echo_command(interactive_type: str) -> Optional[str]:
-    """Return shell command that prints local URLs and appends them to /tmp/ngrok.log."""
-    # These echoed lines are parsed by tunnel_parser for local provider UX.
-    if interactive_type == "jupyter":
-        return "echo 'Local URL: http://localhost:8888' | tee -a /tmp/ngrok.log"
-    if interactive_type == "vllm":
-        return (
-            "echo 'Local vLLM API: http://localhost:8000' | tee -a /tmp/ngrok.log; "
-            "echo 'Local Open WebUI: http://localhost:8080' | tee -a /tmp/ngrok.log"
-        )
-    if interactive_type == "ollama":
-        return (
-            "echo 'Local Ollama API: http://localhost:11434' | tee -a /tmp/ngrok.log; "
-            "echo 'Local Open WebUI: http://localhost:8080' | tee -a /tmp/ngrok.log"
-        )
-    return None
 
 
 def build_ngrok_tunnel_command(entry_id: str, ports: list[dict[str, Any]]) -> str:
@@ -126,8 +108,6 @@ def resolve_interactive_command(
         gallery entries.
     """
     env = "local" if environment == "local" else "remote"
-    interactive_type = str(template_entry.get("interactive_type") or template_entry.get("id") or "").strip()
-
     resolved_base = (base_command or "").strip()
 
     if env == "remote":
@@ -139,13 +119,6 @@ def resolve_interactive_command(
                 if resolved_base:
                     return (f"{ngrok_cmd}; {resolved_base}", None)
                 return (ngrok_cmd, None)
-    elif env == "local":
-        echo_cmd = _build_local_url_echo_command(interactive_type)
-        if echo_cmd:
-            if resolved_base:
-                return (f"{echo_cmd}; {resolved_base}", None)
-            return (echo_cmd, None)
-
     return (resolved_base, None)
 
 

--- a/api/transformerlab/shared/tunnel_parser.py
+++ b/api/transformerlab/shared/tunnel_parser.py
@@ -1,6 +1,8 @@
 import re
 from typing import Optional, Tuple
 
+PUBLIC_TUNNEL_URL_PATTERN = r"https://[a-zA-Z0-9-]+\.(?:trycloudflare\.com|ngrok-free\.app|ngrok-free\.dev|ngrok\.io)"
+
 
 def parse_vscode_tunnel_logs(logs: str) -> Tuple[Optional[str], Optional[str]]:
     """
@@ -70,37 +72,24 @@ def parse_jupyter_tunnel_logs(logs: str) -> Tuple[Optional[str], Optional[str]]:
             # Jupyter prints: "http://localhost:8888/?token=abc123..." or "?token=abc123..."
             if "token=" in line and not token:
                 # Look for token in URLs
-                match = re.search(r"[?&]token=([a-f0-9]{32,})", line)
+                match = re.search(r"[?&]token=([A-Za-z0-9._-]{8,})", line)
                 if match:
                     token = match.group(1)
                 else:
                     # Also try to find standalone token mentions
-                    match = re.search(r"token[=:]\s*([a-f0-9]{32,})", line, re.IGNORECASE)
+                    match = re.search(r"token[=:]\s*([A-Za-z0-9._-]{8,})", line, re.IGNORECASE)
                     if match:
                         token = match.group(1)
 
-            # Parse cloudflared tunnel URL: "https://random-name.trycloudflare.com"
+            # Parse public tunnel URL
             if not tunnel_url:
-                # Look for the full URL
-                match = re.search(r"(https://[a-zA-Z0-9-]+\.trycloudflare\.com)", line)
-                if match:
-                    tunnel_url = match.group(1)
-                else:
-                    # If no full URL, look for just the domain
-                    match = re.search(r"([a-zA-Z0-9-]+\.trycloudflare\.com)", line)
-                    if match:
-                        tunnel_url = f"https://{match.group(1)}"
-
-            # Also check for other tunnel services (ngrok, localtunnel, etc.)
-            if not tunnel_url:
-                # Check for ngrok: "https://abc123.ngrok-free.app" or "https://abc123.ngrok-free.dev"
-                match = re.search(r"(https://[a-zA-Z0-9-]+\.(?:ngrok-free\.app|ngrok-free\.dev|ngrok\.io))", line)
+                match = re.search(f"({PUBLIC_TUNNEL_URL_PATTERN})", line)
                 if match:
                     tunnel_url = match.group(1)
 
-            # Check for local URL: "Local URL: http://localhost:8888"
+            # Parse local Jupyter URL from server startup output if no public URL was found
             if not tunnel_url:
-                match = re.search(r"Local URL:\s*(http://localhost:\d+)", line)
+                match = re.search(r"(https?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0):8888[^\s]*)", line)
                 if match:
                     tunnel_url = match.group(1)
 
@@ -132,30 +121,31 @@ def parse_vllm_tunnel_logs(logs: str) -> Tuple[Optional[str], Optional[str], Opt
 
         for line in lines:
             # Look for any HTTPS tunnel URL from supported providers
-            match = re.search(
-                r"(https://[a-zA-Z0-9-]+\.(?:trycloudflare\.com|ngrok-free\.app|ngrok-free\.dev|ngrok\.io))",
-                line,
-            )
+            match = re.search(f"({PUBLIC_TUNNEL_URL_PATTERN})", line)
             if match:
                 url = match.group(1)
                 if url not in found_urls:
                     found_urls.append(url)
 
-            # Check for local URL patterns: "Local vLLM API: http://localhost:8000" or "Local Open WebUI: http://localhost:8080"
-            match = re.search(r"Local (?:vLLM API|Open WebUI):\s*(http://localhost:\d+)", line)
+            # Parse local URLs emitted by startup scripts/servers.
+            match = re.search(r"(https?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(8000|8080)[^\s]*)", line)
             if match:
-                url = match.group(1)
-                if url not in found_urls:
-                    found_urls.append(url)
+                full_url = match.group(1)
+                port = match.group(2)
+                if port == "8000":
+                    vllm_url = full_url
+                elif port == "8080":
+                    openwebui_url = full_url
 
-        # Assign URLs by discovery order:
-        #  - first URL: vLLM API tunnel
-        #  - second URL (if present): Open WebUI tunnel
-        if found_urls:
+        # Prefer explicit local port-derived URLs when available.
+        if vllm_url or openwebui_url:
+            tunnel_url = vllm_url or openwebui_url
+        # Otherwise, assign public URLs by discovery order.
+        elif found_urls:
             tunnel_url = found_urls[0]
-            vllm_url = tunnel_url
-        if len(found_urls) > 1:
-            openwebui_url = found_urls[1]
+            vllm_url = found_urls[0]
+            if len(found_urls) > 1:
+                openwebui_url = found_urls[1]
 
         return tunnel_url, vllm_url, openwebui_url
 
@@ -270,8 +260,8 @@ def get_jupyter_tunnel_info(logs: str) -> dict:
     # Since Jupyter is started without token requirement, use tunnel URL directly
     jupyter_url = tunnel_url
 
-    # If token exists, append it to the URL (though we don't require it)
-    if jupyter_url and token:
+    # If token exists, append it to the URL unless it is already present.
+    if jupyter_url and token and "token=" not in jupyter_url:
         separator = "&" if "?" in jupyter_url else "?"
         jupyter_url = f"{jupyter_url}{separator}token={token}"
 
@@ -332,30 +322,31 @@ def parse_ollama_tunnel_logs(logs: str) -> Tuple[Optional[str], Optional[str], O
 
         for line in lines:
             # Look for any HTTPS tunnel URL from supported providers
-            match = re.search(
-                r"(https://[a-zA-Z0-9-]+\.(?:trycloudflare\.com|ngrok-free\.app|ngrok-free\.dev|ngrok\.io))",
-                line,
-            )
+            match = re.search(f"({PUBLIC_TUNNEL_URL_PATTERN})", line)
             if match:
                 url = match.group(1)
                 if url not in found_urls:
                     found_urls.append(url)
 
-            # Check for local URL patterns: "Local Ollama API: http://localhost:11434" or "Local Open WebUI: http://localhost:8080"
-            match = re.search(r"Local (?:Ollama API|Open WebUI):\s*(http://localhost:\d+)", line)
+            # Parse local URLs emitted by startup scripts/servers.
+            match = re.search(r"(https?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(11434|8080)[^\s]*)", line)
             if match:
-                url = match.group(1)
-                if url not in found_urls:
-                    found_urls.append(url)
+                full_url = match.group(1)
+                port = match.group(2)
+                if port == "11434":
+                    ollama_url = full_url
+                elif port == "8080":
+                    openwebui_url = full_url
 
-        # Assign URLs by discovery order:
-        #  - first URL: Ollama API tunnel
-        #  - second URL (if present): Open WebUI tunnel
-        if found_urls:
+        # Prefer explicit local port-derived URLs when available.
+        if ollama_url or openwebui_url:
+            tunnel_url = ollama_url or openwebui_url
+        # Otherwise, assign public URLs by discovery order.
+        elif found_urls:
             tunnel_url = found_urls[0]
-            ollama_url = tunnel_url
-        if len(found_urls) > 1:
-            openwebui_url = found_urls[1]
+            ollama_url = found_urls[0]
+            if len(found_urls) > 1:
+                openwebui_url = found_urls[1]
 
         return tunnel_url, ollama_url, openwebui_url
 
@@ -492,6 +483,14 @@ def get_tunnel_info(logs: str, interactive_type: str | None, url_patterns: list[
     """
     if not interactive_type or interactive_type == "custom":
         return get_custom_tunnel_info(logs, url_patterns)
+
+    # If gallery-supplied custom patterns exist for a known interactive type,
+    # prefer them first. This lets templates parse exact emitted log lines
+    # without changing built-in parser behavior for older entries.
+    if url_patterns:
+        custom_info = get_custom_tunnel_info(logs, url_patterns)
+        if custom_info.get("is_ready"):
+            return custom_info
 
     if interactive_type == "vscode":
         return get_vscode_tunnel_info(logs)

--- a/src/renderer/components/Experiment/Interactive/Interactive.tsx
+++ b/src/renderer/components/Experiment/Interactive/Interactive.tsx
@@ -823,7 +823,7 @@ export default function Interactive() {
       }
 
       if (!cfg.run && !cfg.github_repo_url && !task.github_repo_url) {
-        return { ok: false, error: 'Task is missing a command to run.' };
+        return { ok: false, error: 'Something went wrong. Please try again.' };
       }
 
       const payload = {


### PR DESCRIPTION
- Remove hardcoded print statements for running interactive tasks on local provider and move to using url_patterns in gallery
- Fix issue with openwebui never printing its server url (Depends on https://github.com/transformerlab/transformerlab-examples/pull/39)
- Fixes tunnel info caching issue where if one url was obtained and the other was still in process, we would cache and mark ready so the other one was never obtained