### PR TITLE
add: GCP credential injection for remote pod launches

### DIFF
--- a/api/transformerlab/services/compute_provider/launch_credentials.py
+++ b/api/transformerlab/services/compute_provider/launch_credentials.py
@@ -66,15 +66,15 @@ def generate_aws_credentials_setup(
     return setup_script
 
 
-GCP_CREDENTIALS_PATH = "/tmp/tfl-gcp-service-account.json"
-
-
-def generate_gcp_credentials_setup(service_account_json: str) -> str:
+def generate_gcp_credentials_setup(service_account_json: str, credentials_path: Optional[str] = None) -> str:
+    target_path = credentials_path or "~/.config/gcloud/application_default_credentials.json"
     encoded = base64.b64encode(service_account_json.encode()).decode()
     setup_script = (
         "echo 'Setting up GCP service account credentials...'; "
-        f"echo '{encoded}' | base64 -d > {GCP_CREDENTIALS_PATH}; "
-        f"chmod 600 {GCP_CREDENTIALS_PATH}; "
+        f"mkdir -p $(dirname {target_path}); "
+        f"echo '{encoded}' | base64 -d > {target_path}; "
+        f"chmod 600 {target_path}; "
+        f"export GOOGLE_APPLICATION_CREDENTIALS={target_path}; "
         "echo 'GCP credentials configured successfully'"
     )
     return setup_script

--- a/api/transformerlab/services/compute_provider/launch_credentials.py
+++ b/api/transformerlab/services/compute_provider/launch_credentials.py
@@ -1,5 +1,6 @@
 """Remote launch: cloud credential materialization helpers for setup scripts."""
 
+import base64
 import configparser
 import os
 from typing import Optional, Tuple
@@ -65,20 +66,15 @@ def generate_aws_credentials_setup(
     return setup_script
 
 
-def generate_gcp_credentials_setup(service_account_json: str, credentials_path: Optional[str] = None) -> str:
-    target_path = credentials_path or "$HOME/.config/gcloud/tfl-service-account.json"
+GCP_CREDENTIALS_PATH = "/tmp/tfl-gcp-service-account.json"
 
-    def escape_bash_single_quoted(s: str) -> str:
-        return s.replace("'", "'\"'\"'")
 
-    escaped_json = escape_bash_single_quoted(service_account_json)
-
+def generate_gcp_credentials_setup(service_account_json: str) -> str:
+    encoded = base64.b64encode(service_account_json.encode()).decode()
     setup_script = (
         "echo 'Setting up GCP service account credentials...'; "
-        'mkdir -p "$HOME/.config/gcloud"; '
-        f"echo '{escaped_json}' > {target_path}; "
-        f"chmod 600 {target_path}; "
-        f"export GOOGLE_APPLICATION_CREDENTIALS={target_path}; "
+        f"echo '{encoded}' | base64 -d > {GCP_CREDENTIALS_PATH}; "
+        f"chmod 600 {GCP_CREDENTIALS_PATH}; "
         "echo 'GCP credentials configured successfully'"
     )
     return setup_script

--- a/api/transformerlab/services/compute_provider/launch_sweep.py
+++ b/api/transformerlab/services/compute_provider/launch_sweep.py
@@ -14,7 +14,6 @@ from transformerlab.services import job_service
 from transformerlab.services.compute_provider.cluster_naming import sanitize_cluster_basename
 from transformerlab.services.compute_provider.launch_credentials import (
     COPY_FILE_MOUNTS_SETUP,
-    GCP_CREDENTIALS_PATH,
     RUNPOD_AWS_CREDENTIALS_DIR,
     generate_aws_credentials_setup,
     generate_azure_credentials_setup,
@@ -258,10 +257,6 @@ async def launch_sweep_jobs(
                         if gcp_sa_json:
                             gcp_setup = generate_gcp_credentials_setup(gcp_sa_json)
                             setup_commands.append(gcp_setup)
-                            env_vars["GOOGLE_APPLICATION_CREDENTIALS"] = GCP_CREDENTIALS_PATH
-                        gcp_project = os.getenv("GCP_PROJECT")
-                        if gcp_project:
-                            env_vars["GCP_PROJECT"] = gcp_project
                     elif STORAGE_PROVIDER == "azure":
                         azure_connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
                         azure_account = os.getenv("AZURE_STORAGE_ACCOUNT")

--- a/api/transformerlab/services/compute_provider/launch_sweep.py
+++ b/api/transformerlab/services/compute_provider/launch_sweep.py
@@ -14,6 +14,7 @@ from transformerlab.services import job_service
 from transformerlab.services.compute_provider.cluster_naming import sanitize_cluster_basename
 from transformerlab.services.compute_provider.launch_credentials import (
     COPY_FILE_MOUNTS_SETUP,
+    GCP_CREDENTIALS_PATH,
     RUNPOD_AWS_CREDENTIALS_DIR,
     generate_aws_credentials_setup,
     generate_azure_credentials_setup,
@@ -257,6 +258,10 @@ async def launch_sweep_jobs(
                         if gcp_sa_json:
                             gcp_setup = generate_gcp_credentials_setup(gcp_sa_json)
                             setup_commands.append(gcp_setup)
+                            env_vars["GOOGLE_APPLICATION_CREDENTIALS"] = GCP_CREDENTIALS_PATH
+                        gcp_project = os.getenv("GCP_PROJECT")
+                        if gcp_project:
+                            env_vars["GCP_PROJECT"] = gcp_project
                     elif STORAGE_PROVIDER == "azure":
                         azure_connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
                         azure_account = os.getenv("AZURE_STORAGE_ACCOUNT")

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -14,9 +14,11 @@ from transformerlab.schemas.secrets import SPECIAL_SECRET_TYPES
 from transformerlab.services import job_service, quota_service
 from transformerlab.services.compute_provider.launch_credentials import (
     COPY_FILE_MOUNTS_SETUP,
+    GCP_CREDENTIALS_PATH,
     RUNPOD_AWS_CREDENTIALS_DIR,
     generate_aws_credentials_setup,
     generate_azure_credentials_setup,
+    generate_gcp_credentials_setup,
     get_aws_credentials_from_file,
 )
 from transformerlab.services.compute_provider.launch_secrets import find_missing_secrets_for_template_launch
@@ -227,6 +229,15 @@ async def launch_template_on_provider(
                 setup_commands.append(aws_setup)
                 if aws_credentials_dir:
                     env_vars["AWS_SHARED_CREDENTIALS_FILE"] = f"{aws_credentials_dir}/credentials"
+        elif STORAGE_PROVIDER == "gcp":
+            gcp_sa_json = os.getenv("TFL_GCP_SERVICE_ACCOUNT_JSON")
+            if gcp_sa_json:
+                gcp_setup = generate_gcp_credentials_setup(gcp_sa_json)
+                setup_commands.append(gcp_setup)
+                env_vars["GOOGLE_APPLICATION_CREDENTIALS"] = GCP_CREDENTIALS_PATH
+            gcp_project = os.getenv("GCP_PROJECT")
+            if gcp_project:
+                env_vars["GCP_PROJECT"] = gcp_project
         elif STORAGE_PROVIDER == "azure":
             azure_connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
             azure_account = os.getenv("AZURE_STORAGE_ACCOUNT")

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -14,7 +14,6 @@ from transformerlab.schemas.secrets import SPECIAL_SECRET_TYPES
 from transformerlab.services import job_service, quota_service
 from transformerlab.services.compute_provider.launch_credentials import (
     COPY_FILE_MOUNTS_SETUP,
-    GCP_CREDENTIALS_PATH,
     RUNPOD_AWS_CREDENTIALS_DIR,
     generate_aws_credentials_setup,
     generate_azure_credentials_setup,
@@ -234,10 +233,6 @@ async def launch_template_on_provider(
             if gcp_sa_json:
                 gcp_setup = generate_gcp_credentials_setup(gcp_sa_json)
                 setup_commands.append(gcp_setup)
-                env_vars["GOOGLE_APPLICATION_CREDENTIALS"] = GCP_CREDENTIALS_PATH
-            gcp_project = os.getenv("GCP_PROJECT")
-            if gcp_project:
-                env_vars["GCP_PROJECT"] = gcp_project
         elif STORAGE_PROVIDER == "azure":
             azure_connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
             azure_account = os.getenv("AZURE_STORAGE_ACCOUNT")


### PR DESCRIPTION
## Summary
- `launch_template.py` was missing the `gcp` if/else branch entirely in the storage provider credential setup block (only had `aws` and `azure`)
- `launch_sweep.py` had the gcp if/else branch but wasn't setting `GOOGLE_APPLICATION_CREDENTIALS` or `GCP_PROJECT` in `env_vars`, so remote pods couldn't authenticate
- Switched `generate_gcp_credentials_setup` from shell single-quote escaping to base64 encoding — safer for service account JSON with PEM private keys (witnessed this with service account json file I downloaded from gcloud console)
- Credentials written to `/tmp/tfl-gcp-service-account.json` (fixed absolute path, writable by any user on any provider)


Note: this might need further testing