### PR TITLE
Fix lab job artifacts/download CLI commands

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -55,7 +55,6 @@ from transformerlab.routers.auth import get_user_and_team  # noqa: E402
 
 
 from transformerlab.routers.experiment import experiment  # noqa: E402
-from transformerlab.routers.experiment import jobs  # noqa: E402
 from transformerlab.shared import shared  # noqa: E402
 from transformerlab.shared import dirs  # noqa: E402
 from lab.dirs import set_organization_id as lab_set_org_id  # noqa: E402
@@ -306,7 +305,6 @@ app.include_router(model.router, dependencies=[Depends(get_user_and_team)])
 app.include_router(serverinfo.router, dependencies=[Depends(get_user_and_team)])
 app.include_router(data.router, dependencies=[Depends(get_user_and_team)])
 app.include_router(experiment.router, dependencies=[Depends(get_user_and_team)])
-app.include_router(jobs.router, dependencies=[Depends(get_user_and_team)])
 app.include_router(config.router, dependencies=[Depends(get_user_and_team)])
 app.include_router(teams.router, dependencies=[Depends(get_user_and_team)])
 app.include_router(compute_provider.router)

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.20"
+version = "0.0.21"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/job.py
+++ b/cli/src/transformerlab_cli/commands/job.py
@@ -371,13 +371,14 @@ def info_job(job_id: str, experiment_id: str):
         console.print(f"[error]Error:[/error] Job with ID {job_id} not found.")
 
 
-def list_artifacts(job_id: str, output_format: str = "pretty") -> list[dict]:
+def list_artifacts(job_id: str, experiment_id: str, output_format: str = "pretty") -> list[dict]:
     """List artifacts for a job by ID. Returns list of artifact dicts."""
+    artifacts_url = f"/experiment/{experiment_id}/jobs/{job_id}/artifacts"
     if output_format != "json":
         with console.status(f"[bold success]Fetching artifacts for job {job_id}...[/bold success]", spinner="dots"):
-            response = api.get(f"/jobs/{job_id}/artifacts")
+            response = api.get(artifacts_url)
     else:
-        response = api.get(f"/jobs/{job_id}/artifacts")
+        response = api.get(artifacts_url)
 
     if response.status_code != 200:
         if output_format == "json":
@@ -410,7 +411,7 @@ def list_artifacts(job_id: str, output_format: str = "pretty") -> list[dict]:
     return artifacts
 
 
-def download_artifacts(job_id: str, output_dir: str = None) -> None:
+def download_artifacts(job_id: str, experiment_id: str, output_dir: str | None = None) -> None:
     """Download all artifacts for a job as a zip file."""
     if output_dir is None:
         output_dir = os.getcwd()
@@ -426,9 +427,10 @@ def download_artifacts(job_id: str, output_dir: str = None) -> None:
     if os.path.exists(output_path):
         console.print(f"[warning]Warning:[/warning] File {output_path} already exists. It will be overwritten.")
 
+    download_all_url = f"/experiment/{experiment_id}/jobs/{job_id}/artifacts/download_all"
     try:
         with console.status(f"[bold success]Downloading artifacts for job {job_id}...[/bold success]", spinner="dots"):
-            response = api.get(f"/jobs/{job_id}/artifacts/download_all", timeout=300.0)
+            response = api.get(download_all_url, timeout=300.0)
 
         if response.status_code == 200:
             # Get filename from Content-Disposition header if available
@@ -485,7 +487,8 @@ def command_job_artifacts(
 ):
     """List artifacts for a job."""
     check_configs(output_format=cli_state.output_format)
-    list_artifacts(job_id, output_format=cli_state.output_format)
+    current_experiment = require_current_experiment()
+    list_artifacts(job_id, current_experiment, output_format=cli_state.output_format)
 
 
 @app.command("download")
@@ -502,14 +505,15 @@ def command_job_download(
 ):
     """Download artifacts for a job. Use --file to download specific files."""
     check_configs(output_format=cli_state.output_format)
+    current_experiment = require_current_experiment()
     out = os.path.abspath(output_dir) if output_dir else os.getcwd()
     output_format = cli_state.output_format
 
     if not file:
-        download_artifacts(job_id, output_dir)
+        download_artifacts(job_id, current_experiment, output_dir)
         return
 
-    raw_resp = api.get(f"/jobs/{job_id}/artifacts")
+    raw_resp = api.get(f"/experiment/{current_experiment}/jobs/{job_id}/artifacts")
     if raw_resp.status_code != 200:
         if output_format == "json":
             print(json.dumps({"error": f"Failed to fetch artifacts. Status code: {raw_resp.status_code}"}))
@@ -532,7 +536,7 @@ def command_job_download(
     for filename in matched:
         if output_format != "json":
             console.print(f"Downloading [cyan]{filename}[/cyan]...")
-        path = download_single_artifact(job_id, filename, out)
+        path = download_single_artifact(job_id, current_experiment, filename, out)
         if path:
             downloaded.append({"filename": filename, "path": path})
         elif output_format != "json":
@@ -544,17 +548,18 @@ def command_job_download(
         console.print(f"[green]✓[/green] Downloaded {len(downloaded)}/{len(matched)} file(s) to {out}")
 
 
-def download_single_artifact(job_id: str, filename: str, output_dir: str) -> str | None:
+def download_single_artifact(job_id: str, experiment_id: str, filename: str, output_dir: str) -> str | None:
     """Download a single artifact by filename. Returns local path or None on failure."""
     output_path = os.path.join(output_dir, filename)
+    base_url = f"/experiment/{experiment_id}/jobs/{job_id}"
     try:
-        response = api.get(f"/jobs/{job_id}/artifact/{filename}?task=download", timeout=300.0)
+        response = api.get(f"{base_url}/artifact/{filename}?task=download", timeout=300.0)
         if response.status_code == 200:
             with open(output_path, "wb") as f:
                 f.write(response.content)
             return output_path
         if response.status_code in (404, 405):
-            zip_response = api.get(f"/jobs/{job_id}/artifacts/download_all", timeout=300.0)
+            zip_response = api.get(f"{base_url}/artifacts/download_all", timeout=300.0)
             if zip_response.status_code == 200:
                 with zipfile.ZipFile(io.BytesIO(zip_response.content)) as zf:
                     names = zf.namelist()

--- a/cli/src/transformerlab_cli/commands/job_monitor/JobDetails.py
+++ b/cli/src/transformerlab_cli/commands/job_monitor/JobDetails.py
@@ -210,8 +210,9 @@ class JobDetails(Vertical):
             output_path = os.path.join(output_dir, filename)
 
             # Make the API request
+            experiment_id = get_current_experiment() or "alpha"
             try:
-                response = api.get(f"/jobs/{job_id}/artifacts/download_all", timeout=300.0)
+                response = api.get(f"/experiment/{experiment_id}/jobs/{job_id}/artifacts/download_all", timeout=300.0)
             except httpx.HTTPError as e:
                 self.notify(f"Failed to connect to server: {str(e)}", severity="error")
                 return

--- a/cli/tests/integration/test_live_cli_routes.py
+++ b/cli/tests/integration/test_live_cli_routes.py
@@ -343,19 +343,24 @@ def test_cli_job_and_artifact_routes_live_server(live_context: dict[str, str]) -
             "GET /experiment/{id}/jobs/{job_id}/tunnel_info",
         )
         _assert_status_in(
-            client.get(f"{BASE_URL}/jobs/{fake_job_id}/artifacts", headers=headers),
+            client.get(f"{BASE_URL}/experiment/{experiment_id}/jobs/{fake_job_id}/artifacts", headers=headers),
             {200, 400, 404},
-            "GET /jobs/{job_id}/artifacts",
+            "GET /experiment/{id}/jobs/{job_id}/artifacts",
         )
         _assert_status_in(
-            client.get(f"{BASE_URL}/jobs/{fake_job_id}/artifact/does-not-exist.txt?task=download", headers=headers),
+            client.get(
+                f"{BASE_URL}/experiment/{experiment_id}/jobs/{fake_job_id}/artifact/does-not-exist.txt?task=download",
+                headers=headers,
+            ),
             {400, 404, 405},
-            "GET /jobs/{job_id}/artifact/{filename}",
+            "GET /experiment/{id}/jobs/{job_id}/artifact/{filename}",
         )
         _assert_status_in(
-            client.get(f"{BASE_URL}/jobs/{fake_job_id}/artifacts/download_all", headers=headers),
+            client.get(
+                f"{BASE_URL}/experiment/{experiment_id}/jobs/{fake_job_id}/artifacts/download_all", headers=headers
+            ),
             {400, 404},
-            "GET /jobs/{job_id}/artifacts/download_all",
+            "GET /experiment/{id}/jobs/{job_id}/artifacts/download_all",
         )
         _assert_status_in(
             client.post(

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.19"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- `lab job artifacts` and `lab job download` were hitting the bare `/jobs/{job_id}/artifacts*` endpoints, which require an `experimentId` query param and so returned 400.
- Switch the CLI (and the Textual job monitor's download button) to the already-mounted `/experiment/{experimentId}/jobs/{job_id}/...` form. `require_current_experiment()` supplies the id, matching the pattern used by `lab job info`, `lab job list`, etc.
- Drop the now-redundant top-level `/jobs` mount in `api/api.py` so the only way to reach these routes is via the experiment-prefixed path, which also enforces the `require_permission("experiment", "read")` dep.
- Update the skipped live integration checks to the new paths.

## Test plan
- [x] `cd cli && python -m pytest tests/ -v` (131 passed, 4 skipped)
- [x] `ruff format` / `ruff check` on touched files
- [ ] Manually run `lab job artifacts <job_id>` and `lab job download <job_id>` against a live server
- [ ] Click "Download All Artifacts" in `lab job monitor`