### PR TITLE
fix: remove Advanced Raw Configuration JSON box from compute provider modals

### DIFF
--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -1260,54 +1260,6 @@ export default function ProviderDetailsModal({
                     />
                   </FormControl>
                 )}
-
-              {/* Show JSON for structured providers in edit mode for advanced users */}
-              {(type === 'slurm' ||
-                type === 'skypilot' ||
-                type === 'dstack' ||
-                type === 'runpod') &&
-                providerId && (
-                  <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>Advanced: Raw Configuration (JSON)</FormLabel>
-                    <Textarea
-                      value={
-                        typeof config === 'string'
-                          ? config
-                          : JSON.stringify(config)
-                      }
-                      onChange={(event) => {
-                        setConfig(event.currentTarget.value);
-                        // Try to parse and update form fields
-                        try {
-                          const configObj = JSON.parse(
-                            event.currentTarget.value,
-                          );
-                          if (type === 'slurm') {
-                            parseSlurmConfig(configObj);
-                          } else if (type === 'skypilot') {
-                            parseSkypilotConfig(configObj);
-                          } else if (type === 'dstack') {
-                            parseDstackConfig(configObj);
-                          } else if (type === 'runpod') {
-                            parseRunpodConfig(configObj);
-                          }
-                        } catch (e) {
-                          // Ignore parse errors
-                        }
-                      }}
-                      placeholder="JSON sent to provider"
-                      minRows={3}
-                      maxRows={5}
-                    />
-                    <Typography
-                      level="body-sm"
-                      sx={{ mt: 0.5, color: 'text.tertiary' }}
-                    >
-                      Edit JSON directly for advanced configuration. Changes
-                      will sync to form fields above.
-                    </Typography>
-                  </FormControl>
-                )}
             </>
           )}
         </DialogContent>


### PR DESCRIPTION
as discussed in [#1849](https://github.com/transformerlab/transformerlab-app/pull/1849)

## Summary
- Removes the "Advanced: Raw Configuration (JSON)" textarea from the edit modal for all four compute providers (Slurm, SkyPilot, dstack, RunPod)
- The box was mostly for cosmetic reasons because on save, config is always rebuilt from individual form state via `build*Config()` functions, never from the raw JSON string
- Plus, every JSON key has a corresponding structured form field, so no configuration capability is lost