### PR TITLE
fix: remove api_token placeholder from dstack default template

### DIFF
--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -61,7 +61,6 @@ const DEFAULT_CONFIGS = {
 }`,
   dstack: `{
   "server_url": "<Your dstack server URL e.g. http://0.0.0.0:3000>",
-  "api_token": "<Your dstack API token>",
   "dstack_project": "<Your dstack project name e.g. main>"
 }`,
   local: `{}`,


### PR DESCRIPTION
## Summary
- Drop `api_token` from the dstack `DEFAULT_CONFIGS` template so the password input isn't pre-filled with the literal password-hashed (dotted) form of `<Your dstack API token>` placeholder (as it looked like some pre-filled real token)
- Matches the runpod precedent, which also leaves the api key field blank in the default template