### PR TITLE
Add markdown description field to job runs (lab task queue -m)

### DIFF
--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -87,7 +87,9 @@ lab task list
 # 3. Queue a task on a compute provider
 #    NOTE: --no-interactive silently picks the DEFAULT provider (Local).
 #    To pick a specific provider, run interactively (see "Selecting a provider" below).
-lab task queue TASK_ID --no-interactive
+#    ALWAYS pass --description/-m with a markdown note describing the iteration
+#    (see "Always write a run description" below).
+lab task queue TASK_ID --no-interactive -m "Testing lr=3e-5 after loss plateaued at 2.1"
 
 # 4. Monitor the job (three log streams — see "Job logs: three real commands" below)
 lab job list --running
@@ -226,6 +228,37 @@ lab task add ./hello-world-task --no-interactive
 10. **Never use the deprecated `lab job logs`** — see the "Job logs: three real commands" section below.
 11. **After queuing a task, ASK the user if they'd like you to watch the logs.** Don't start streaming or polling automatically — jobs can take minutes to hours, and `--follow` blocks. Report the Job ID and ask: "Want me to watch the logs and report back?"
 12. **Never create API keys programmatically** — if auth fails, ask the user to provide an API key from the web UI
+13. **Always pass `--description/-m` when queuing a task. Generate it yourself — never ask the user.** See "Always write a run description" below.
+
+### Always write a run description
+
+Every `lab task queue` call MUST include `--description/-m "..."`. The description is markdown stored on the job and shown in `lab job info`. Its audience is a future researcher reading `lab job list` weeks later — they have git and the task code, but NOT this chat. The description is the only bridge.
+
+**Treat it like a short PR description for this run.** Draft 1–5 lines (bullets for multi-point notes) covering:
+
+1. **What changed vs the prior run / baseline** — the concrete diff (hyperparameters, code, model, data, infra). If nothing changed, say so and link the prior job.
+2. **What hypothesis you're testing** — why this run is worth doing.
+3. **What a future reader should remember** — gotchas, prior surprises, things to check in the output.
+
+Pull these from the conversation and recent git diff / edited files. If the note has newlines or shell-awkward characters, pipe it: `printf '%s' "$DESC" | lab task queue abc123 -m -`.
+
+```bash
+# Good: diff + hypothesis + watch
+printf '%s' "- Bumped lr 1e-5 → 3e-5, warmup 100 → 500 steps.
+- Testing whether higher lr clears the eval/loss=2.1 plateau seen in job 7f21 around step 2k.
+- Watch: earlier runs with lr≥5e-5 diverged by step 500." | lab task queue abc123 --no-interactive -m -
+
+# Good: small change — one line is enough
+lab task queue abc123 --no-interactive -m "Rerun on H100 (was A100) to confirm throughput regression from #1850."
+
+# Good: nothing changed
+lab task queue abc123 --no-interactive -m "Rerun of job 7f21, no code or config changes (network flake on first attempt)."
+
+# Bad: generic filler that tells the reader nothing
+lab task queue abc123 -m "train model"
+```
+
+Don't restate the task name, full hyperparameter dict, or file paths — those are already on the job record. Don't copy the user's last message verbatim — synthesize. If the conversation is truly empty of signal, fall back to `"Rerun of <id>, no changes"`.
 
 ### Selecting a provider when queuing a task
 
@@ -308,7 +341,7 @@ This applies to launching jobs, fetching logs, checking cluster status, and ever
 | `lab task init` | Scaffold `task.yaml` + `main.py` in the current directory (`--interactive` to prompt) | No |
 | `lab task add [dir]` | Add task from directory or `--from-git` URL (`--no-interactive`, `--dry-run`) | Yes |
 | `lab task delete <id>` | Delete a task (`--no-interactive` to skip confirmation) | Yes |
-| `lab task queue <id>` | Queue task on compute provider | Yes |
+| `lab task queue <id>` | Queue task on compute provider (`-m/--description` for a markdown run note; required for agents, see "Always write a run description") | Yes |
 | `lab task gallery` | Browse/import from task gallery | Yes |
 | `lab job list` | List jobs (`--running` for active only) | Yes |
 | `lab job info <id>` | Get detailed job information | Yes |

--- a/.agents/skills/transformerlab-cli/references/commands.md
+++ b/.agents/skills/transformerlab-cli/references/commands.md
@@ -131,6 +131,7 @@ Queue a task on a compute provider.
 | Option | Description |
 |---|---|
 | `--no-interactive` | Skip prompts. Uses the task's configured provider or first available. Parameters use defaults. **Always use this in automated workflows.** |
+| `-m`, `--description <text>` | Markdown note describing what this run is trying to accomplish (stored on the job, shown in `lab job info`). Pass `-` to read from stdin. **Agents: required per SKILL.md rule 13.** |
 
 **JSON output:** Returns the created job object with `id` and `status`.
 

--- a/api/transformerlab/schemas/compute_providers.py
+++ b/api/transformerlab/schemas/compute_providers.py
@@ -112,6 +112,11 @@ class ProviderTemplateLaunchRequest(BaseModel):
     task_name: Optional[str] = Field(None, description="Friendly task name")
     cluster_name: Optional[str] = Field(None, description="Base cluster name, suffix is appended automatically")
     run: str = Field(..., description="Run command to execute on the cluster")
+    description: Optional[str] = Field(
+        None,
+        max_length=8000,
+        description="Free-form markdown describing what this run is trying to accomplish (like a commit description).",
+    )
     subtype: Optional[str] = Field(None, description="Optional subtype for filtering")
     interactive_type: Optional[str] = Field(None, description="Interactive task type (e.g. vscode)")
     interactive_gallery_id: Optional[str] = Field(

--- a/api/transformerlab/services/compute_provider/launch_sweep.py
+++ b/api/transformerlab/services/compute_provider/launch_sweep.py
@@ -87,6 +87,7 @@ async def create_sweep_parent_job(
         "sweep_metric": sweep_metric,
         "lower_is_better": lower_is_better,
         "task_name": request.task_name,
+        "description": request.description,
         "subtype": request.subtype,
         "provider_id": provider.id,
         "provider_type": provider.type,
@@ -320,6 +321,7 @@ async def launch_sweep_jobs(
                     "task_name": f"{request.task_name or 'Task'} (Sweep {i + 1}/{total_configs})"
                     if request.task_name
                     else None,
+                    "description": request.description,
                     "run": run_with_secrets,
                     "cluster_name": formatted_cluster_name,
                     "subtype": request.subtype,

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -565,6 +565,7 @@ async def launch_template_on_provider(
 
     job_data = {
         "task_name": request.task_name,
+        "description": request.description,
         "run": command_with_secrets,
         "cluster_name": formatted_cluster_name,
         "subtype": request.subtype,

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.20"
+version = "0.0.21"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/job.py
+++ b/cli/src/transformerlab_cli/commands/job.py
@@ -275,6 +275,7 @@ def _render_job(job) -> None:
         "ID": job.get("id", "N/A"),
         "Experiment ID": job.get("experiment_id", "N/A"),
         "Task Name": job_data.get("task_name", "N/A"),
+        "Description": job_data.get("description", "N/A"),
         "Command": run_command,
         "Cluster Name": job_data.get("cluster_name", "N/A"),
         "CPUs": job_data.get("cpus", "N/A"),

--- a/cli/src/transformerlab_cli/commands/task.py
+++ b/cli/src/transformerlab_cli/commands/task.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import sys
 import zipfile
 from pathlib import Path
 
@@ -449,6 +450,7 @@ def build_launch_payload(
     provider_name: str,
     param_values: dict | None = None,
     resource_overrides: dict | None = None,
+    description: str | None = None,
 ) -> dict:
     """Build the payload for launching a task on a provider."""
     cfg = task.get("config") or {}
@@ -467,6 +469,7 @@ def build_launch_payload(
         "experiment_id": task.get("experiment_id"),
         "task_id": task.get("id"),
         "task_name": task.get("name"),
+        "description": description,
         "run": task.get("run"),
         "setup": task.get("setup"),
         "cpus": pick("cpus"),
@@ -611,7 +614,12 @@ def _prompt_parameters(parameters: dict) -> dict:
     return values
 
 
-def queue_task(task_id: str, experiment_id: str, interactive: bool = True) -> None:
+def queue_task(
+    task_id: str,
+    experiment_id: str,
+    interactive: bool = True,
+    description: str | None = None,
+) -> None:
     """Queue a task on a compute provider."""
     with console.status("[bold success]Fetching task...[/bold success]", spinner="dots"):
         response = api.get(f"/experiment/{experiment_id}/task/{task_id}/get")
@@ -651,7 +659,9 @@ def queue_task(task_id: str, experiment_id: str, interactive: bool = True) -> No
     else:
         param_values = {k: (v.get("default", "") if isinstance(v, dict) else v) for k, v in parameters.items()}
 
-    payload = build_launch_payload(task, provider.get("name"), param_values, resource_overrides)
+    payload = build_launch_payload(
+        task, provider.get("name"), param_values, resource_overrides, description=description
+    )
     provider_id = provider.get("id")
 
     with console.status("[bold success]Queuing task...[/bold success]", spinner="dots"):
@@ -668,10 +678,28 @@ def queue_task(task_id: str, experiment_id: str, interactive: bool = True) -> No
 def command_task_queue(
     task_id: str = typer.Argument(..., help="Task ID to queue"),
     no_interactive: bool = typer.Option(False, "--no-interactive", help="Skip interactive prompts, use defaults"),
+    description: str | None = typer.Option(
+        None,
+        "--description",
+        "-m",
+        help=(
+            "Markdown note describing what this run is trying to accomplish (like a commit description). "
+            "Pass '-' to read from stdin."
+        ),
+    ),
 ):
     """Queue a task on a compute provider."""
     current_experiment = require_current_experiment()
-    queue_task(task_id, experiment_id=current_experiment, interactive=not no_interactive)
+    if description == "-":
+        if sys.stdin.isatty():
+            raise typer.BadParameter('-m - reads the description from stdin; pipe content in or pass -m "...".')
+        description = sys.stdin.read()
+    queue_task(
+        task_id,
+        experiment_id=current_experiment,
+        interactive=not no_interactive,
+        description=description,
+    )
 
 
 def gallery_tasks(output_format: str = "pretty", gallery_type: str = "all", experiment_id: str = "alpha") -> list[dict]:

--- a/cli/tests/commands/test_task.py
+++ b/cli/tests/commands/test_task.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
+from transformerlab_cli.commands.task import build_launch_payload
 from transformerlab_cli.main import app
 from tests.helpers import strip_ansi
 
@@ -59,3 +60,40 @@ def test_task_list_json_no_spinner(_mock_exp, _mock_api):
     """task list --format json does not mix spinner text with JSON."""
     result = runner.invoke(app, ["--format", "json", "task", "list"])
     json.loads(result.output.strip())  # must not raise
+
+
+def test_build_launch_payload_includes_description():
+    """build_launch_payload forwards the description to the launch API body."""
+    task = {"id": "t1", "name": "finetune", "experiment_id": "exp1", "run": "python main.py"}
+    payload = build_launch_payload(task, "Local", description="Bump lr to 3e-5; expecting faster convergence.")
+    assert payload["description"] == "Bump lr to 3e-5; expecting faster convergence."
+
+
+def test_build_launch_payload_omits_description_by_default():
+    """When --description is not passed, the payload carries description=None (backend treats as absent)."""
+    task = {"id": "t1", "name": "finetune", "experiment_id": "exp1", "run": "python main.py"}
+    payload = build_launch_payload(task, "Local")
+    assert payload["description"] is None
+
+
+SAMPLE_TASK = {
+    "id": "t1",
+    "name": "finetune",
+    "experiment_id": "exp1",
+    "run": "python main.py",
+    "parameters": {},
+    "config": {},
+}
+SAMPLE_PROVIDERS = [{"id": "p1", "name": "Local"}]
+
+
+@patch("transformerlab_cli.commands.task.api.post_json", return_value=_mock_resp({"job_id": "j1"}))
+@patch("transformerlab_cli.commands.task.fetch_providers", return_value=SAMPLE_PROVIDERS)
+@patch("transformerlab_cli.commands.task.api.get", return_value=_mock_resp(SAMPLE_TASK))
+@patch("transformerlab_cli.commands.task.require_current_experiment", return_value="exp1")
+def test_task_queue_sends_description(_mock_exp, _mock_get, _mock_providers, mock_post):
+    """`lab task queue -m "..." --no-interactive` sends description in the launch body."""
+    result = runner.invoke(app, ["task", "queue", "t1", "--no-interactive", "-m", "hypothesis: larger batch"])
+    assert result.exit_code == 0, result.output
+    _path, body = mock_post.call_args.args
+    assert body["description"] == "hypothesis: larger batch"

--- a/src/renderer/components/Experiment/Jobs/OverviewSection.tsx
+++ b/src/renderer/components/Experiment/Jobs/OverviewSection.tsx
@@ -47,6 +47,27 @@ export default function OverviewSection({ job }: { job: JobRecord | null }) {
         <Row label="Provider" value={String(d.provider_name)} />
       )}
       {d.cluster_name && <Row label="Cluster" value={String(d.cluster_name)} />}
+      {typeof d.description === 'string' && d.description.trim() && (
+        <Box sx={{ py: 0.75 }}>
+          <Typography
+            level="body-sm"
+            sx={{ width: 160, color: 'text.secondary', mb: 0.5 }}
+          >
+            Description
+          </Typography>
+          <Typography
+            level="body-sm"
+            sx={{
+              whiteSpace: 'pre-wrap',
+              background: 'var(--joy-palette-background-surface)',
+              p: 1.5,
+              borderRadius: 'sm',
+            }}
+          >
+            {String(d.description)}
+          </Typography>
+        </Box>
+      )}
       {(d as any).template_name && (
         <Row label="Template" value={String((d as any).template_name)} />
       )}

--- a/src/renderer/components/Experiment/Tasks/QueueTaskModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/QueueTaskModal.tsx
@@ -23,6 +23,7 @@ import {
   Option,
   Checkbox,
   Chip,
+  Textarea,
 } from '@mui/joy';
 import { Editor } from '@monaco-editor/react';
 import {
@@ -130,6 +131,8 @@ export default function QueueTaskModal({
     React.useState(false);
   const [showParameterOverrides, setShowParameterOverrides] =
     React.useState(true);
+  const [jobDescription, setJobDescription] = React.useState('');
+  const [showDescription, setShowDescription] = React.useState(false);
   const resourceOverridesRef = React.useRef<HTMLDivElement | null>(null);
   const loadingMessages = React.useMemo(
     () => [
@@ -666,6 +669,13 @@ export default function QueueTaskModal({
           ? String(initMinutesRequested)
           : '',
       );
+      const initDescription = cfg.description ?? task.description ?? '';
+      const normalizedDescription =
+        initDescription !== null && initDescription !== undefined
+          ? String(initDescription)
+          : '';
+      setJobDescription(normalizedDescription);
+      setShowDescription(Boolean(normalizedDescription.trim()));
     }
   }, [open, task, providers]);
 
@@ -808,6 +818,9 @@ export default function QueueTaskModal({
       if (!Number.isNaN(parsedMinutes) && parsedMinutes > 0) {
         config.minutes_requested = parsedMinutes;
       }
+    }
+    if (jobDescription.trim()) {
+      config.description = jobDescription.trim();
     }
 
     // For SLURM providers, add optional per-job SBATCH flags override
@@ -1653,6 +1666,53 @@ export default function QueueTaskModal({
               parameters={parameters}
               disabled={isSubmitting}
             />
+
+            <Divider />
+
+            {/* Optional Description Section */}
+            <Stack spacing={1}>
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                sx={{ cursor: isSubmitting ? 'default' : 'pointer' }}
+                onClick={() => {
+                  if (!isSubmitting) {
+                    setShowDescription((prev) => !prev);
+                  }
+                }}
+              >
+                <Typography level="title-sm">
+                  Add description (optional)
+                </Typography>
+                <ChevronDownIcon
+                  size={18}
+                  style={{
+                    transform: showDescription
+                      ? 'rotate(180deg)'
+                      : 'rotate(0deg)',
+                    transition: 'transform 0.2s ease',
+                  }}
+                />
+              </Stack>
+              {showDescription && (
+                <FormControl>
+                  <FormLabel>Run description</FormLabel>
+                  <Textarea
+                    minRows={3}
+                    maxRows={8}
+                    placeholder="Describe what changed, your hypothesis, and what to watch for in this run."
+                    value={jobDescription}
+                    onChange={(e) => setJobDescription(e.target.value)}
+                    disabled={isSubmitting}
+                  />
+                  <FormHelperText>
+                    Stored with the job and shown in job details. Markdown is
+                    supported.
+                  </FormHelperText>
+                </FormControl>
+              )}
+            </Stack>
 
             {/* Optional Resource Overrides Section */}
             <Divider />

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -1054,6 +1054,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
       const {
         provider_id: _pid,
         provider_name: _pname,
+        description,
         enable_trackio,
         enable_profiling,
         enable_profiling_torch,
@@ -1072,6 +1073,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
         experiment_id: experimentInfo.id,
         task_id: task.id,
         task_name: task.name,
+        description: description?.trim() || undefined,
         cluster_name: cfg.cluster_name || task.cluster_name,
         run: cfg.run || task.run,
         subtype: cfg.subtype || task.subtype,


### PR DESCRIPTION
## Summary

- Adds an optional markdown **description** to each job run — stored in `job_data`, surfaced in `lab job info`, and settable from the CLI via `lab task queue -m/--description "..."` (or `-m -` to read from stdin). Works like a git commit description for the iteration.
- Updates the `transformerlab-cli` agent skill to instruct agents to auto-generate a short PR-style description on every queue (what changed vs prior run, the hypothesis, what a future reader should remember) — and never prompt the user for it.

### Changes

**Backend**
- `ProviderTemplateLaunchRequest.description: Optional[str]` with `max_length=8000` so an agent paste can't blow up sweep children.
- `launch_template.py` / `launch_sweep.py`: persist `description` in job_data for single launches, sweep parent jobs, and sweep child jobs.

**CLI**
- `lab task queue -m/--description "..."` — supports `-m -` to read from stdin (guarded by `sys.stdin.isatty()` so a bare invocation in a terminal fails fast instead of hanging).
- `lab job info` renders a `Description` field alongside `Task Name`.
- Tests in `cli/tests/commands/test_task.py` cover the payload wiring.

**Agent skill**
- `.agents/skills/transformerlab-cli/SKILL.md` — new rule 13 plus a tightened "Always write a run description" section; `references/commands.md` documents the flag.

## Test plan

- [x] `cd cli && python -m pytest tests/ -v` — 134 passed, 4 skipped
- [x] `cd api && ruff check …` + `ruff format --check …` on modified files — clean
- [x] `cd cli && ruff check …` + `ruff format --check …` on modified files — clean
- [ ] Manual: `lab task queue <id> --no-interactive -m "testing"` → `lab job info <job_id>` shows Description
- [ ] Manual: `printf 'multi\nline\nmarkdown' | lab task queue <id> --no-interactive -m -` stores full text
- [ ] Manual: `lab task queue <id> -m -` with no pipe exits with a clear error (isatty guard)
- [ ] Manual (sweep): queue with `run_sweeps=True` via UI/API and confirm the description appears on the parent job and each child