### PR TITLE
Add lab experiment CLI command

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.25"
+version = "0.0.26"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.24"
+version = "0.0.25"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/experiment.py
+++ b/cli/src/transformerlab_cli/commands/experiment.py
@@ -1,0 +1,105 @@
+import json
+from urllib.parse import quote
+
+import typer
+
+import transformerlab_cli.util.api as api
+from transformerlab_cli.state import cli_state
+from transformerlab_cli.util.config import check_configs, get_config, set_config
+from transformerlab_cli.util.ui import console, render_table
+
+app = typer.Typer()
+
+
+def _extract_error_detail(response) -> str:
+    try:
+        return response.json().get("detail", response.text)
+    except (ValueError, KeyError):
+        return response.text
+
+
+@app.command("list")
+def command_experiment_list():
+    """List all experiments. Marks the current default with a *."""
+    check_configs(output_format=cli_state.output_format)
+    output_format = cli_state.output_format
+
+    with console.status("[bold success]Fetching experiments...[/bold success]", spinner="dots"):
+        response = api.get("/experiment/")
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to fetch experiments. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    experiments = response.json() or []
+    current = get_config("current_experiment")
+
+    if output_format == "json":
+        print(json.dumps({"current_experiment": current, "experiments": experiments}))
+        return
+
+    rows = [
+        {
+            "default": "*" if str(exp.get("id")) == str(current) or exp.get("name") == current else "",
+            "name": exp.get("name", ""),
+        }
+        for exp in experiments
+    ]
+    render_table(data=rows, format_type=output_format, table_columns=["default", "name"], title="Experiments")
+
+
+@app.command("create")
+def command_experiment_create(
+    name: str = typer.Argument(..., help="Experiment name"),
+    set_default: bool = typer.Option(False, "--set-default", help="Set the new experiment as the default"),
+):
+    """Create a new experiment."""
+    check_configs(output_format=cli_state.output_format)
+
+    with console.status(f"[bold success]Creating experiment {name}...[/bold success]", spinner="dots"):
+        response = api.get(f"/experiment/create?name={quote(name)}")
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to create experiment. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    new_id = response.json()
+    console.print(f"[success]✓[/success] Experiment created: [bold]{new_id}[/bold]")
+
+    if set_default:
+        set_config("current_experiment", str(new_id), cli_state.output_format)
+
+
+@app.command("delete")
+def command_experiment_delete(
+    experiment_id: str = typer.Argument(..., help="Experiment ID to delete"),
+    no_interactive: bool = typer.Option(False, "--no-interactive", help="Skip confirmation prompt"),
+):
+    """Delete an experiment."""
+    check_configs(output_format=cli_state.output_format)
+
+    if not no_interactive:
+        typer.confirm(f"Delete experiment {experiment_id}?", abort=True)
+
+    with console.status(f"[bold success]Deleting experiment {experiment_id}...[/bold success]", spinner="dots"):
+        response = api.get(f"/experiment/{experiment_id}/delete")
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to delete experiment. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    console.print(f"[success]✓[/success] Experiment [bold]{experiment_id}[/bold] deleted.")
+
+    if str(get_config("current_experiment")) == str(experiment_id):
+        console.print(
+            "[warning]Note:[/warning] This was your default experiment. "
+            "Set a new default with [bold]lab experiment set-default <id>[/bold]."
+        )
+
+
+@app.command("set-default")
+def command_experiment_set_default(
+    experiment_id: str = typer.Argument(..., help="Experiment ID to set as the default"),
+):
+    """Set the default experiment (stored in ~/.lab/config.json)."""
+    set_config("current_experiment", experiment_id, cli_state.output_format)

--- a/cli/src/transformerlab_cli/main.py
+++ b/cli/src/transformerlab_cli/main.py
@@ -16,6 +16,7 @@ from transformerlab_cli.commands.task import app as task_app
 from transformerlab_cli.commands.job import app as job_app
 from transformerlab_cli.commands.provider import app as provider_app
 from transformerlab_cli.commands.server import app as server_app
+from transformerlab_cli.commands.experiment import app as experiment_app
 
 
 # Create custom Help screen so we can show the logo
@@ -43,6 +44,7 @@ app.add_typer(task_app, name="task", help="Task management commands", no_args_is
 app.add_typer(job_app, name="job", help="Job management commands", no_args_is_help=True)
 app.add_typer(provider_app, name="provider", help="Compute provider management commands", no_args_is_help=True)
 app.add_typer(server_app, name="server", help="Server installation and configuration commands", no_args_is_help=True)
+app.add_typer(experiment_app, name="experiment", help="Experiment management commands", no_args_is_help=True)
 
 
 # Apply common setup to all commands

--- a/cli/tests/commands/test_experiment.py
+++ b/cli/tests/commands/test_experiment.py
@@ -1,0 +1,91 @@
+"""Tests for experiment commands."""
+
+from unittest.mock import patch, MagicMock
+
+from typer.testing import CliRunner
+from transformerlab_cli.main import app
+
+runner = CliRunner()
+
+SAMPLE_EXPERIMENTS = [
+    {"id": "alpha", "name": "alpha"},
+    {"id": "beta", "name": "beta"},
+]
+
+
+def _mock_response(status_code: int = 200, json_data=None):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data if json_data is not None else {}
+    mock.text = ""
+    return mock
+
+
+def test_experiment_help():
+    result = runner.invoke(app, ["experiment", "--help"])
+    assert result.exit_code == 0
+    assert "Experiment management commands" in result.output
+
+
+@patch("transformerlab_cli.commands.experiment.get_config", return_value="alpha")
+@patch("transformerlab_cli.commands.experiment.api.get", return_value=_mock_response(200, SAMPLE_EXPERIMENTS))
+@patch("transformerlab_cli.commands.experiment.check_configs")
+def test_experiment_list_marks_default(_mock_check, _mock_api, _mock_get_config):
+    result = runner.invoke(app, ["experiment", "list"])
+    assert result.exit_code == 0
+    assert "alpha" in result.output
+    assert "beta" in result.output
+    assert "*" in result.output
+
+
+@patch("transformerlab_cli.commands.experiment.set_config")
+@patch("transformerlab_cli.commands.experiment.api.get", return_value=_mock_response(200, "my-exp"))
+@patch("transformerlab_cli.commands.experiment.check_configs")
+def test_experiment_create(_mock_check, mock_api, mock_set_config):
+    result = runner.invoke(app, ["experiment", "create", "my-exp"])
+    assert result.exit_code == 0
+    assert "my-exp" in result.output
+    mock_api.assert_called_once()
+    assert "name=my-exp" in mock_api.call_args[0][0]
+    mock_set_config.assert_not_called()
+
+
+@patch("transformerlab_cli.commands.experiment.set_config")
+@patch("transformerlab_cli.commands.experiment.api.get", return_value=_mock_response(200, "my-exp"))
+@patch("transformerlab_cli.commands.experiment.check_configs")
+def test_experiment_create_with_set_default(_mock_check, _mock_api, mock_set_config):
+    result = runner.invoke(app, ["experiment", "create", "my-exp", "--set-default"])
+    assert result.exit_code == 0
+    mock_set_config.assert_called_once_with("current_experiment", "my-exp", "pretty")
+
+
+@patch("transformerlab_cli.commands.experiment.get_config", return_value="other")
+@patch(
+    "transformerlab_cli.commands.experiment.api.get",
+    return_value=_mock_response(200, {"message": "Experiment beta deleted"}),
+)
+@patch("transformerlab_cli.commands.experiment.check_configs")
+def test_experiment_delete(_mock_check, _mock_api, _mock_get_config):
+    result = runner.invoke(app, ["experiment", "delete", "beta", "--no-interactive"])
+    assert result.exit_code == 0
+    assert "deleted" in result.output.lower()
+
+
+@patch("transformerlab_cli.commands.experiment.get_config", return_value="beta")
+@patch(
+    "transformerlab_cli.commands.experiment.api.get",
+    return_value=_mock_response(200, {"message": "Experiment beta deleted"}),
+)
+@patch("transformerlab_cli.commands.experiment.check_configs")
+def test_experiment_delete_current_warns(_mock_check, _mock_api, _mock_get_config):
+    result = runner.invoke(app, ["experiment", "delete", "beta", "--no-interactive"])
+    assert result.exit_code == 0
+    assert "default experiment" in result.output
+
+
+@patch("transformerlab_cli.commands.experiment.set_config")
+@patch("transformerlab_cli.commands.experiment.check_configs")
+def test_experiment_set_default(_mock_check, mock_set_config):
+    result = runner.invoke(app, ["experiment", "set-default", "beta"])
+    assert result.exit_code == 0
+    mock_set_config.assert_called_once_with("current_experiment", "beta", "pretty")

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.25"
+version = "0.0.26"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.24"
+version = "0.0.25"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Adds a new `lab experiment` command group to the CLI with `list`, `create`, `delete`, and `set-default` subcommands.
- `list` marks the current default experiment (from `~/.lab/config.json`) with a `*`.
- `create` optionally accepts `--set-default` to create and switch in one step.
- `delete` warns if the deleted experiment was the current default.
- `set-default` writes `current_experiment` to the config; skips the user-info banner so the pre-change value isn't rendered above the confirmation line.

## Test plan
- [ ] `lab experiment list` shows all experiments with `*` on the current default
- [ ] `lab experiment create my-exp` creates and prints the new id
- [ ] `lab experiment create my-exp --set-default` creates and switches
- [ ] `lab experiment delete my-exp` prompts for confirmation and removes it
- [ ] `lab experiment set-default alpha` updates config without printing the user-info table
- [ ] `--format json` works for every subcommand
- [ ] `cd cli && python -m pytest tests/commands/test_experiment.py -v` passes