### PR TITLE
Sanitize cluster names to work on dstack

### DIFF
--- a/api/transformerlab/services/compute_provider/cluster_naming.py
+++ b/api/transformerlab/services/compute_provider/cluster_naming.py
@@ -3,12 +3,22 @@
 from typing import Optional
 
 
+# Cap cluster names to 41 characters to stay withing the limit of
+# the strictest provider (dstack).
+# This means capping the basename portion to 25 characters to leave room for a
+# ``-job-<short_id>`` suffix (13 chars).
+_MAX_BASENAME_LENGTH = 25
+
+
 def sanitize_cluster_basename(base_name: Optional[str]) -> str:
     """Return a cluster base name that is safe across compute providers.
 
     Some providers have restrictions on resource names.
-    Sanitize generated name so the result is lowercased, underscores are
-    replaced with hyphens, and the name is guaranteed to start with a letter.
+    Sanitize generated name so the result is:
+     - lowercased
+     - underscores are replaced with hyphens
+     - name is guaranteed to start with a letter
+     - no longer than 41 characters
     """
     if not base_name:
         return "remote-template"
@@ -19,4 +29,6 @@ def sanitize_cluster_basename(base_name: Optional[str]) -> str:
         return "remote-template"
     if not normalized[0].isalpha():
         normalized = f"t-{normalized}"
+    if len(normalized) > _MAX_BASENAME_LENGTH:
+        normalized = normalized[:_MAX_BASENAME_LENGTH].rstrip("-")
     return normalized

--- a/api/transformerlab/services/compute_provider/cluster_naming.py
+++ b/api/transformerlab/services/compute_provider/cluster_naming.py
@@ -5,8 +5,8 @@ from typing import Optional
 
 # Cap cluster names to 41 characters to stay withing the limit of
 # the strictest provider (dstack).
-# This means capping the basename portion to 25 characters to leave room for a
-# ``-job-<short_id>`` suffix (13 chars).
+# This means capping the basename portion to 28 characters (use 25 to be safe)
+# to leave room for a ``-job-<short_id>`` suffix (13 chars).
 _MAX_BASENAME_LENGTH = 25
 
 

--- a/api/transformerlab/services/compute_provider/cluster_naming.py
+++ b/api/transformerlab/services/compute_provider/cluster_naming.py
@@ -4,9 +4,19 @@ from typing import Optional
 
 
 def sanitize_cluster_basename(base_name: Optional[str]) -> str:
-    """Return a filesystem-safe cluster base name."""
+    """Return a cluster base name that is safe across compute providers.
+
+    Some providers have restrictions on resource names.
+    Sanitize generated name so the result is lowercased, underscores are
+    replaced with hyphens, and the name is guaranteed to start with a letter.
+    """
     if not base_name:
         return "remote-template"
-    normalized = "".join(ch if ch.isalnum() or ch in ("-", "_") else "-" for ch in base_name.strip())
-    normalized = normalized.strip("-_")
-    return normalized or "remote-template"
+    lowered = base_name.strip().lower()
+    normalized = "".join(ch if (ch.isalnum() and ch.isascii()) or ch == "-" else "-" for ch in lowered)
+    normalized = normalized.strip("-")
+    if not normalized:
+        return "remote-template"
+    if not normalized[0].isalpha():
+        normalized = f"t-{normalized}"
+    return normalized


### PR DESCRIPTION
I think this is needed to run clusters on dstack. Here is the error I was getting:

```
Error: dstack API request failed (POST /api/project/main/runs/apply) with status 400. response: {"detail":[{"msg":"Resource name should match regex '^[a-z][a-z0-9-]{1,40}$'","code":"error"}]}
```