### PR TITLE
fix: make the default admin email env var name consistent

### DIFF
--- a/api/transformerlab/services/experiment_init.py
+++ b/api/transformerlab/services/experiment_init.py
@@ -16,7 +16,7 @@ import json
 import logging
 
 logger = logging.getLogger(__name__)
-DEFAULT_ADMIN_EMAIL_ENV = "TRANSFORMERLAB_DEFAULT_ADMIN_EMAIL"
+DEFAULT_ADMIN_EMAIL_ENV = "TLAB_DEFAULT_ADMIN_EMAIL"
 DEFAULT_ADMIN_EMAIL_FALLBACK = "admin@example.com"
 
 


### PR DESCRIPTION
## Summary
- The CLI writes the admin email to `TLAB_DEFAULT_ADMIN_EMAIL` (cli/src/transformerlab_cli/commands/server.py), but the API was reading `TRANSFORMERLAB_DEFAULT_ADMIN_EMAIL`, so the CLI-configured value was silently ignored and the API fell back to `admin@example.com`.
- Renamed the API-side env var to `TLAB_DEFAULT_ADMIN_EMAIL` to match the CLI.