### PR TITLE
Add AWS as a provider

### DIFF
--- a/api/test/api/test_aws_credentials.py
+++ b/api/test/api/test_aws_credentials.py
@@ -86,27 +86,34 @@ def test_create_aws_provider_injects_aws_profile_and_team_id():
     provider_data.name = "my-aws"
     provider_data.config = FakeConfig()
 
-    with patch(
-        "transformerlab.services.compute_provider.team_provider_endpoints.create_team_provider",
-        side_effect=fake_create_team_provider,
-    ), patch(
-        "transformerlab.services.compute_provider.team_provider_endpoints.list_team_providers",
-        new_callable=AsyncMock,
-        return_value=[],
-    ), patch(
-        "transformerlab.services.compute_provider.team_provider_endpoints.cache.invalidate",
-        new_callable=AsyncMock,
-    ), patch(
-        "transformerlab.services.compute_provider.team_provider_endpoints.get_provider_read",
-        new_callable=AsyncMock,
+    with (
+        patch(
+            "transformerlab.services.compute_provider.team_provider_endpoints.create_team_provider",
+            side_effect=fake_create_team_provider,
+        ),
+        patch(
+            "transformerlab.services.compute_provider.team_provider_endpoints.list_team_providers",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "transformerlab.services.compute_provider.team_provider_endpoints.cache.invalidate",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "transformerlab.services.compute_provider.team_provider_endpoints.get_provider_read",
+            new_callable=AsyncMock,
+        ),
     ):
-        asyncio.run(create_provider_for_team(
-            session=MagicMock(),
-            team_id="team-xyz",
-            user=MagicMock(id="user-1"),
-            provider_data=provider_data,
-            force_refresh=False,
-        ))
+        asyncio.run(
+            create_provider_for_team(
+                session=MagicMock(),
+                team_id="team-xyz",
+                user=MagicMock(id="user-1"),
+                provider_data=provider_data,
+                force_refresh=False,
+            )
+        )
 
     assert captured_config["aws_profile"] == "transformerlab-compute-team-xyz"
     assert captured_config["team_id"] == "team-xyz"
@@ -118,23 +125,27 @@ def test_save_aws_credentials_endpoint():
     mock_provider.type = "aws"
     mock_provider.config = {"aws_profile": "transformerlab-compute-team-abc"}
 
-    with patch(
-        "transformerlab.routers.compute_provider.providers.get_team_provider",
-        new_callable=AsyncMock,
-        return_value=mock_provider,
-    ), patch(
-        "transformerlab.routers.compute_provider.providers.write_aws_credentials_to_profile"
-    ) as mock_write:
+    with (
+        patch(
+            "transformerlab.routers.compute_provider.providers.get_team_provider",
+            new_callable=AsyncMock,
+            return_value=mock_provider,
+        ),
+        patch("transformerlab.routers.compute_provider.providers.write_aws_credentials_to_profile") as mock_write,
+    ):
         from transformerlab.routers.compute_provider.providers import AwsCredentialsRequest, set_aws_credentials
+
         mock_session = MagicMock()
         mock_owner_info = {"team_id": "team-abc"}
 
-        asyncio.run(set_aws_credentials(
-            provider_id="prov-123",
-            body=AwsCredentialsRequest(access_key_id="AKIATEST", secret_access_key="mysecret"),
-            owner_info=mock_owner_info,
-            session=mock_session,
-        ))
+        asyncio.run(
+            set_aws_credentials(
+                provider_id="prov-123",
+                body=AwsCredentialsRequest(access_key_id="AKIATEST", secret_access_key="mysecret"),
+                owner_info=mock_owner_info,
+                session=mock_session,
+            )
+        )
 
         mock_write.assert_called_once_with("transformerlab-compute-team-abc", "AKIATEST", "mysecret")
 
@@ -172,16 +183,20 @@ def test_update_aws_provider_reinjects_profile_and_team_id_when_missing():
         provider.config = config
         return provider
 
-    with patch(
-        "transformerlab.services.compute_provider.team_provider_endpoints.get_team_provider",
-        new_callable=AsyncMock,
-        return_value=provider,
-    ), patch(
-        "transformerlab.services.compute_provider.team_provider_endpoints.update_team_provider",
-        side_effect=fake_update_team_provider,
-    ), patch(
-        "transformerlab.services.compute_provider.team_provider_endpoints.cache.invalidate",
-        new_callable=AsyncMock,
+    with (
+        patch(
+            "transformerlab.services.compute_provider.team_provider_endpoints.get_team_provider",
+            new_callable=AsyncMock,
+            return_value=provider,
+        ),
+        patch(
+            "transformerlab.services.compute_provider.team_provider_endpoints.update_team_provider",
+            side_effect=fake_update_team_provider,
+        ),
+        patch(
+            "transformerlab.services.compute_provider.team_provider_endpoints.cache.invalidate",
+            new_callable=AsyncMock,
+        ),
     ):
         asyncio.run(
             update_provider_for_team(

--- a/api/test/api/test_aws_credentials.py
+++ b/api/test/api/test_aws_credentials.py
@@ -137,3 +137,78 @@ def test_save_aws_credentials_endpoint():
         ))
 
         mock_write.assert_called_once_with("transformerlab-compute-team-abc", "AKIATEST", "mysecret")
+
+
+def test_update_aws_provider_reinjects_profile_and_team_id_when_missing():
+    """update_provider_for_team must keep AWS config launchable even for legacy providers missing aws_profile."""
+    from transformerlab.services.compute_provider.team_provider_endpoints import update_provider_for_team
+
+    provider = MagicMock()
+    provider.id = "prov-aws"
+    provider.team_id = "team-xyz"
+    provider.name = "aws-provider"
+    provider.type = "aws"
+    provider.config = {"region": "us-east-1"}
+    provider.created_by_user_id = "user-1"
+    provider.created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    provider.updated_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    provider.disabled = False
+    provider.is_default = False
+
+    class FakeConfig:
+        def model_dump(self, **kwargs):
+            return {"region": "us-west-2"}
+
+    provider_update = MagicMock()
+    provider_update.name = None
+    provider_update.config = FakeConfig()
+    provider_update.disabled = None
+    provider_update.is_default = None
+
+    captured = {}
+
+    async def fake_update_team_provider(session, provider, name, config, disabled, is_default):
+        captured.update(config or {})
+        provider.config = config
+        return provider
+
+    with patch(
+        "transformerlab.services.compute_provider.team_provider_endpoints.get_team_provider",
+        new_callable=AsyncMock,
+        return_value=provider,
+    ), patch(
+        "transformerlab.services.compute_provider.team_provider_endpoints.update_team_provider",
+        side_effect=fake_update_team_provider,
+    ), patch(
+        "transformerlab.services.compute_provider.team_provider_endpoints.cache.invalidate",
+        new_callable=AsyncMock,
+    ):
+        asyncio.run(
+            update_provider_for_team(
+                session=MagicMock(),
+                team_id="team-xyz",
+                provider_id="prov-aws",
+                provider_data=provider_update,
+            )
+        )
+
+    assert captured["region"] == "us-west-2"
+    assert captured["aws_profile"] == "transformerlab-compute-team-xyz"
+    assert captured["team_id"] == "team-xyz"
+
+
+def test_db_record_to_provider_config_backfills_missing_aws_fields():
+    """db_record_to_provider_config should make legacy AWS records instantiable."""
+    from transformerlab.services.provider_service import db_record_to_provider_config
+
+    record = MagicMock()
+    record.type = "aws"
+    record.name = "legacy-aws"
+    record.team_id = "team-legacy"
+    record.config = {"region": "us-west-2"}
+
+    cfg = db_record_to_provider_config(record)
+
+    assert cfg.aws_profile == "transformerlab-compute-team-legacy"
+    assert cfg.team_id == "team-legacy"
+    assert cfg.region == "us-west-2"

--- a/api/test/api/test_aws_credentials.py
+++ b/api/test/api/test_aws_credentials.py
@@ -1,0 +1,139 @@
+import asyncio
+import configparser
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from transformerlab.services.compute_provider.launch_credentials import write_aws_credentials_to_profile
+
+
+def test_write_creates_new_profile(tmp_path):
+    creds_file = tmp_path / ".aws" / "credentials"
+    with patch(
+        "transformerlab.services.compute_provider.launch_credentials._aws_credentials_path",
+        return_value=str(creds_file),
+    ):
+        write_aws_credentials_to_profile("my-profile", "AKIATEST", "secrettest")
+
+    config = configparser.ConfigParser()
+    config.read(str(creds_file))
+    assert "my-profile" in config
+    assert config["my-profile"]["aws_access_key_id"] == "AKIATEST"
+    assert config["my-profile"]["aws_secret_access_key"] == "secrettest"
+
+
+def test_write_overwrites_existing_profile(tmp_path):
+    creds_file = tmp_path / ".aws" / "credentials"
+    creds_file.parent.mkdir(parents=True)
+    creds_file.write_text("[my-profile]\naws_access_key_id = OLD\naws_secret_access_key = OLDSECRET\n")
+
+    with patch(
+        "transformerlab.services.compute_provider.launch_credentials._aws_credentials_path",
+        return_value=str(creds_file),
+    ):
+        write_aws_credentials_to_profile("my-profile", "AKIANEW", "newsecret")
+
+    config = configparser.ConfigParser()
+    config.read(str(creds_file))
+    assert config["my-profile"]["aws_access_key_id"] == "AKIANEW"
+    assert config["my-profile"]["aws_secret_access_key"] == "newsecret"
+
+
+def test_write_preserves_other_profiles(tmp_path):
+    creds_file = tmp_path / ".aws" / "credentials"
+    creds_file.parent.mkdir(parents=True)
+    creds_file.write_text("[other-profile]\naws_access_key_id = OTHER\naws_secret_access_key = OTHERSEC\n")
+
+    with patch(
+        "transformerlab.services.compute_provider.launch_credentials._aws_credentials_path",
+        return_value=str(creds_file),
+    ):
+        write_aws_credentials_to_profile("my-profile", "AKIATEST", "secrettest")
+
+    config = configparser.ConfigParser()
+    config.read(str(creds_file))
+    assert "other-profile" in config
+    assert config["other-profile"]["aws_access_key_id"] == "OTHER"
+
+
+def test_create_aws_provider_injects_aws_profile_and_team_id():
+    """create_provider_for_team must inject aws_profile and team_id into config for AWS providers."""
+    from transformerlab.services.compute_provider.team_provider_endpoints import create_provider_for_team
+
+    class FakeConfig:
+        def model_dump(self, **kwargs):
+            return {"region": "us-east-1"}
+
+    captured_config = {}
+
+    async def fake_create_team_provider(session, team_id, name, provider_type, config, created_by_user_id):
+        captured_config.update(config)
+        mock_provider = MagicMock()
+        mock_provider.type = "aws"
+        mock_provider.id = "prov-1"
+        mock_provider.name = name
+        mock_provider.config = config
+        mock_provider.is_default = False
+        mock_provider.disabled = False
+        mock_provider.supported_accelerators = []
+        mock_provider.team_id = team_id
+        mock_provider.created_by_user_id = created_by_user_id
+        mock_provider.created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_provider.updated_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        return mock_provider
+
+    provider_data = MagicMock()
+    provider_data.type = "aws"
+    provider_data.name = "my-aws"
+    provider_data.config = FakeConfig()
+
+    with patch(
+        "transformerlab.services.compute_provider.team_provider_endpoints.create_team_provider",
+        side_effect=fake_create_team_provider,
+    ), patch(
+        "transformerlab.services.compute_provider.team_provider_endpoints.list_team_providers",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "transformerlab.services.compute_provider.team_provider_endpoints.cache.invalidate",
+        new_callable=AsyncMock,
+    ), patch(
+        "transformerlab.services.compute_provider.team_provider_endpoints.get_provider_read",
+        new_callable=AsyncMock,
+    ):
+        asyncio.run(create_provider_for_team(
+            session=MagicMock(),
+            team_id="team-xyz",
+            user=MagicMock(id="user-1"),
+            provider_data=provider_data,
+            force_refresh=False,
+        ))
+
+    assert captured_config["aws_profile"] == "transformerlab-compute-team-xyz"
+    assert captured_config["team_id"] == "team-xyz"
+
+
+def test_save_aws_credentials_endpoint():
+    """POST /{provider_id}/aws/credentials calls write_aws_credentials_to_profile."""
+    mock_provider = MagicMock()
+    mock_provider.type = "aws"
+    mock_provider.config = {"aws_profile": "transformerlab-compute-team-abc"}
+
+    with patch(
+        "transformerlab.routers.compute_provider.providers.get_team_provider",
+        new_callable=AsyncMock,
+        return_value=mock_provider,
+    ), patch(
+        "transformerlab.routers.compute_provider.providers.write_aws_credentials_to_profile"
+    ) as mock_write:
+        from transformerlab.routers.compute_provider.providers import AwsCredentialsRequest, set_aws_credentials
+        mock_session = MagicMock()
+        mock_owner_info = {"team_id": "team-abc"}
+
+        asyncio.run(set_aws_credentials(
+            provider_id="prov-123",
+            body=AwsCredentialsRequest(access_key_id="AKIATEST", secret_access_key="mysecret"),
+            owner_info=mock_owner_info,
+            session=mock_session,
+        ))
+
+        mock_write.assert_called_once_with("transformerlab-compute-team-abc", "AKIATEST", "mysecret")

--- a/api/test/api/test_aws_credentials.py
+++ b/api/test/api/test_aws_credentials.py
@@ -56,20 +56,21 @@ def test_write_preserves_other_profiles(tmp_path):
 
 
 def test_create_aws_provider_injects_aws_profile_and_team_id():
-    """create_provider_for_team must inject aws_profile and team_id into config for AWS providers."""
+    """create_provider_for_team must persist aws_profile and team_id into config for AWS providers."""
     from transformerlab.services.compute_provider.team_provider_endpoints import create_provider_for_team
 
     class FakeConfig:
         def model_dump(self, **kwargs):
             return {"region": "us-east-1"}
 
-    captured_config = {}
+    captured_create_config = {}
+    captured_update_config = {}
 
     async def fake_create_team_provider(session, team_id, name, provider_type, config, created_by_user_id):
-        captured_config.update(config)
+        captured_create_config.update(config)
         mock_provider = MagicMock()
         mock_provider.type = "aws"
-        mock_provider.id = "prov-1"
+        mock_provider.id = "prov-1234"
         mock_provider.name = name
         mock_provider.config = config
         mock_provider.is_default = False
@@ -81,6 +82,11 @@ def test_create_aws_provider_injects_aws_profile_and_team_id():
         mock_provider.updated_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
         return mock_provider
 
+    async def fake_update_team_provider(session, provider, name, config, disabled, is_default):
+        captured_update_config.update(config or {})
+        provider.config = config
+        return provider
+
     provider_data = MagicMock()
     provider_data.type = "aws"
     provider_data.name = "my-aws"
@@ -90,6 +96,10 @@ def test_create_aws_provider_injects_aws_profile_and_team_id():
         patch(
             "transformerlab.services.compute_provider.team_provider_endpoints.create_team_provider",
             side_effect=fake_create_team_provider,
+        ),
+        patch(
+            "transformerlab.services.compute_provider.team_provider_endpoints.update_team_provider",
+            side_effect=fake_update_team_provider,
         ),
         patch(
             "transformerlab.services.compute_provider.team_provider_endpoints.list_team_providers",
@@ -115,15 +125,17 @@ def test_create_aws_provider_injects_aws_profile_and_team_id():
             )
         )
 
-    assert captured_config["aws_profile"] == "transformerlab-compute-team-xyz"
-    assert captured_config["team_id"] == "team-xyz"
+    assert captured_create_config["team_id"] == "team-xyz"
+    assert "aws_profile" not in captured_create_config
+    assert captured_update_config["aws_profile"] == "tlab-compute-team-xyz-prov-123"
+    assert captured_update_config["team_id"] == "team-xyz"
 
 
 def test_save_aws_credentials_endpoint():
     """POST /{provider_id}/aws/credentials calls write_aws_credentials_to_profile."""
     mock_provider = MagicMock()
     mock_provider.type = "aws"
-    mock_provider.config = {"aws_profile": "transformerlab-compute-team-abc"}
+    mock_provider.config = {"aws_profile": "tlab-compute-team-abc-provider"}
 
     with (
         patch(
@@ -147,11 +159,11 @@ def test_save_aws_credentials_endpoint():
             )
         )
 
-        mock_write.assert_called_once_with("transformerlab-compute-team-abc", "AKIATEST", "mysecret")
+        mock_write.assert_called_once_with("tlab-compute-team-abc-provider", "AKIATEST", "mysecret")
 
 
-def test_update_aws_provider_reinjects_profile_and_team_id_when_missing():
-    """update_provider_for_team must keep AWS config launchable even for legacy providers missing aws_profile."""
+def test_update_aws_provider_preserves_missing_profile_without_backfill():
+    """update_provider_for_team should not backfill aws_profile for legacy AWS configs."""
     from transformerlab.services.compute_provider.team_provider_endpoints import update_provider_for_team
 
     provider = MagicMock()
@@ -208,12 +220,12 @@ def test_update_aws_provider_reinjects_profile_and_team_id_when_missing():
         )
 
     assert captured["region"] == "us-west-2"
-    assert captured["aws_profile"] == "transformerlab-compute-team-xyz"
+    assert "aws_profile" not in captured
     assert captured["team_id"] == "team-xyz"
 
 
-def test_db_record_to_provider_config_backfills_missing_aws_fields():
-    """db_record_to_provider_config should make legacy AWS records instantiable."""
+def test_db_record_to_provider_config_does_not_backfill_missing_aws_profile():
+    """db_record_to_provider_config should not backfill aws_profile for legacy AWS configs."""
     from transformerlab.services.provider_service import db_record_to_provider_config
 
     record = MagicMock()
@@ -224,6 +236,6 @@ def test_db_record_to_provider_config_backfills_missing_aws_fields():
 
     cfg = db_record_to_provider_config(record)
 
-    assert cfg.aws_profile == "transformerlab-compute-team-legacy"
+    assert cfg.aws_profile is None
     assert cfg.team_id == "team-legacy"
     assert cfg.region == "us-west-2"

--- a/api/test/api/test_remote_job_status_service.py
+++ b/api/test/api/test_remote_job_status_service.py
@@ -547,6 +547,46 @@ async def test_check_job_via_provider_local_still_running(monkeypatch):
     assert result is False
 
 
+@pytest.mark.asyncio
+async def test_check_job_via_provider_aws_stopping_terminal_transitions_stopped(monkeypatch):
+    """AWS provider STOPPING + terminal cluster state should mark job STOPPED."""
+    from transformerlab.compute_providers.models import ClusterStatus, ClusterState
+
+    job = _make_job(status="STOPPING")
+    record = _make_provider_record("aws")
+
+    cluster_status = MagicMock(spec=ClusterStatus)
+    cluster_status.state = ClusterState.DOWN
+    cluster_status.status_message = "terminated"
+
+    instance = MagicMock()
+    instance.get_cluster_status = MagicMock(return_value=cluster_status)
+
+    calls = []
+
+    async def fake_update_kv(job_id, key, value, exp_id):
+        calls.append(("kv", key))
+
+    async def fake_update_status(job_id, status, experiment_id=None):
+        calls.append(("status", status))
+
+    monkeypatch.setattr(
+        remote_job_status_service.job_service,
+        "job_update_job_data_insert_key_value",
+        fake_update_kv,
+    )
+    monkeypatch.setattr(
+        remote_job_status_service.job_service,
+        "job_update_status",
+        fake_update_status,
+    )
+
+    result = await _check_job_via_provider(job, "exp-1", record, instance)
+
+    assert result is True
+    assert ("status", "STOPPED") in calls
+
+
 # ---------------------------------------------------------------------------
 # _check_job_via_provider tests — interactive jobs (dead process detection)
 # ---------------------------------------------------------------------------

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -182,6 +182,33 @@ class TestLaunchCluster:
         assert tag_map["transformerlab-cluster-name"] == "my-cluster"
 
 
+class TestDeepLearningAmiLookup:
+    def test_uses_fallback_name_pattern_when_primary_has_no_results(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_images.side_effect = [
+            {"Images": []},
+            {"Images": [{"ImageId": "ami-fallback", "CreationDate": "2024-05-01T00:00:00Z"}]},
+        ]
+
+        ami_id = provider._get_latest_dl_ami(mock_ec2)
+
+        assert ami_id == "ami-fallback"
+        assert mock_ec2.describe_images.call_count == 2
+
+    def test_raises_when_no_patterns_match(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_images.return_value = {"Images": []}
+
+        with pytest.raises(RuntimeError, match="No Deep Learning AMI found"):
+            provider._get_latest_dl_ami(mock_ec2)
+
+
+class TestUserDataScript:
+    def test_sets_pip_break_system_packages_for_ubuntu24(self):
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"))
+        assert "export PIP_BREAK_SYSTEM_PACKAGES=1" in user_data
+
+
 class TestStopCluster:
     def test_terminates_instance_by_cluster_name(self, provider):
         mock_ec2 = MagicMock()

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -73,13 +73,15 @@ class TestCheck:
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {"Account": "123456789"}
         with patch.object(provider, "_get_sts_client", return_value=mock_sts):
-            assert provider.check() is True
+            assert provider.check() == (True, None)
 
     def test_returns_false_on_exception(self, provider):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.side_effect = Exception("NoCredentialProviders")
         with patch.object(provider, "_get_sts_client", return_value=mock_sts):
-            assert provider.check() is False
+            ok, reason = provider.check()
+            assert ok is False
+            assert reason == "AWS provider check failed: NoCredentialProviders"
 
 
 class TestEnsureSecurityGroup:

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -85,9 +85,7 @@ class TestCheck:
 class TestEnsureSecurityGroup:
     def test_returns_existing_group_id(self, provider):
         mock_ec2 = MagicMock()
-        mock_ec2.describe_security_groups.return_value = {
-            "SecurityGroups": [{"GroupId": "sg-existing123"}]
-        }
+        mock_ec2.describe_security_groups.return_value = {"SecurityGroups": [{"GroupId": "sg-existing123"}]}
         result = provider._ensure_security_group(mock_ec2)
         assert result == "sg-existing123"
         mock_ec2.create_security_group.assert_not_called()
@@ -120,6 +118,7 @@ class TestEnsureKeyPair:
     def test_imports_key_when_missing(self, provider):
         mock_ec2 = MagicMock()
         from botocore.exceptions import ClientError
+
         mock_ec2.describe_key_pairs.side_effect = ClientError(
             {"Error": {"Code": "InvalidKeyPair.NotFound", "Message": ""}}, "DescribeKeyPairs"
         )
@@ -136,40 +135,46 @@ class TestLaunchCluster:
         mock_ec2.describe_images.return_value = {
             "Images": [{"ImageId": "ami-0123456789", "CreationDate": "2024-01-01T00:00:00Z"}]
         }
-        mock_ec2.run_instances.return_value = {
-            "Instances": [{"InstanceId": "i-0abc123"}]
-        }
+        mock_ec2.run_instances.return_value = {"Instances": [{"InstanceId": "i-0abc123"}]}
         return mock_ec2
 
     def test_returns_instance_id(self, provider):
         mock_ec2 = self._make_mock_ec2()
         # get_org_ssh_public_key returns str; .encode() is called on it inside launch_cluster
-        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2), \
-             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"):
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+        ):
             result = provider.launch_cluster("my-cluster", ClusterConfig(run="python train.py"))
         assert result["instance_id"] == "i-0abc123"
         assert result["request_id"] == "i-0abc123"
 
     def test_passes_disk_size_to_block_device(self, provider):
         mock_ec2 = self._make_mock_ec2()
-        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2), \
-             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"):
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+        ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py", disk_size=200))
         call_kwargs = mock_ec2.run_instances.call_args[1]
         assert call_kwargs["BlockDeviceMappings"][0]["Ebs"]["VolumeSize"] == 200
 
     def test_no_block_device_when_disk_size_not_set(self, provider):
         mock_ec2 = self._make_mock_ec2()
-        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2), \
-             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"):
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+        ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
         call_kwargs = mock_ec2.run_instances.call_args[1]
         assert "BlockDeviceMappings" not in call_kwargs
 
     def test_tags_include_team_id_and_cluster_name(self, provider):
         mock_ec2 = self._make_mock_ec2()
-        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2), \
-             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"):
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+        ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
         tags = mock_ec2.run_instances.call_args[1]["TagSpecifications"][0]["Tags"]
         tag_map = {t["Key"]: t["Value"] for t in tags}
@@ -181,9 +186,7 @@ class TestStopCluster:
     def test_terminates_instance_by_cluster_name(self, provider):
         mock_ec2 = MagicMock()
         mock_ec2.describe_instances.return_value = {
-            "Reservations": [{
-                "Instances": [{"InstanceId": "i-0abc123", "State": {"Name": "running"}}]
-            }]
+            "Reservations": [{"Instances": [{"InstanceId": "i-0abc123", "State": {"Name": "running"}}]}]
         }
         with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
             result = provider.stop_cluster("my-cluster")
@@ -201,15 +204,20 @@ class TestStopCluster:
 class TestGetClusterStatus:
     def test_maps_running_to_up(self, provider):
         from transformerlab.compute_providers.models import ClusterState
+
         mock_ec2 = MagicMock()
         mock_ec2.describe_instances.return_value = {
-            "Reservations": [{
-                "Instances": [{
-                    "InstanceId": "i-0abc123",
-                    "State": {"Name": "running"},
-                    "PublicIpAddress": "1.2.3.4",
-                }]
-            }]
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-0abc123",
+                            "State": {"Name": "running"},
+                            "PublicIpAddress": "1.2.3.4",
+                        }
+                    ]
+                }
+            ]
         }
         with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
             status = provider.get_cluster_status("my-cluster")
@@ -217,11 +225,10 @@ class TestGetClusterStatus:
 
     def test_maps_terminated_to_down(self, provider):
         from transformerlab.compute_providers.models import ClusterState
+
         mock_ec2 = MagicMock()
         mock_ec2.describe_instances.return_value = {
-            "Reservations": [{
-                "Instances": [{"InstanceId": "i-0abc123", "State": {"Name": "terminated"}}]
-            }]
+            "Reservations": [{"Instances": [{"InstanceId": "i-0abc123", "State": {"Name": "terminated"}}]}]
         }
         with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
             status = provider.get_cluster_status("my-cluster")
@@ -229,6 +236,7 @@ class TestGetClusterStatus:
 
     def test_returns_unknown_when_not_found(self, provider):
         from transformerlab.compute_providers.models import ClusterState
+
         mock_ec2 = MagicMock()
         mock_ec2.describe_instances.return_value = {"Reservations": []}
         with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
@@ -238,11 +246,19 @@ class TestGetClusterStatus:
 
 class TestGetJobLogs:
     def test_returns_log_content_via_ssh(self, provider):
-        with patch("transformerlab.compute_providers.aws.asyncio.run", return_value=b"PRIVATE_KEY"), \
-             patch("transformerlab.compute_providers.aws._ssh_read_file", return_value="training loss: 0.5"):
+        with (
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value=b"PRIVATE_KEY"),
+            patch("transformerlab.compute_providers.aws._ssh_read_file", return_value="training loss: 0.5"),
+        ):
             mock_ec2 = MagicMock()
             mock_ec2.describe_instances.return_value = {
-                "Reservations": [{"Instances": [{"InstanceId": "i-0abc", "State": {"Name": "running"}, "PublicIpAddress": "1.2.3.4"}]}]
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {"InstanceId": "i-0abc", "State": {"Name": "running"}, "PublicIpAddress": "1.2.3.4"}
+                        ]
+                    }
+                ]
             }
             with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
                 logs = provider.get_job_logs("my-cluster", "job-1")
@@ -260,16 +276,20 @@ class TestListClusters:
     def test_returns_cluster_statuses(self, provider):
         mock_ec2 = MagicMock()
         mock_ec2.describe_instances.return_value = {
-            "Reservations": [{
-                "Instances": [{
-                    "InstanceId": "i-0abc",
-                    "State": {"Name": "running"},
-                    "Tags": [
-                        {"Key": "transformerlab-cluster-name", "Value": "cluster-1"},
-                        {"Key": "transformerlab-team-id", "Value": "abc"},
-                    ],
-                }]
-            }]
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-0abc",
+                            "State": {"Name": "running"},
+                            "Tags": [
+                                {"Key": "transformerlab-cluster-name", "Value": "cluster-1"},
+                                {"Key": "transformerlab-team-id", "Value": "abc"},
+                            ],
+                        }
+                    ]
+                }
+            ]
         }
         with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
             clusters = provider.list_clusters()

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -338,6 +338,38 @@ class TestLaunchCluster:
         assert mock_ec2.run_instances.call_count == 2
         mock_sleep.assert_called_once_with(10)
 
+    def test_uses_cpu_ami_for_cpu_only_launches(self, provider):
+        mock_ec2 = self._make_mock_ec2()
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(
+                provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"
+            ),
+            patch.object(provider, "_get_latest_cpu_ami", return_value="ami-cpu") as mock_cpu_ami,
+            patch.object(provider, "_get_latest_dl_ami", return_value="ami-gpu") as mock_gpu_ami,
+        ):
+            provider.launch_cluster("cpu-cluster", ClusterConfig(run="train.py"))
+        assert mock_cpu_ami.call_count == 1
+        assert mock_gpu_ami.call_count == 0
+        assert mock_ec2.run_instances.call_args[1]["ImageId"] == "ami-cpu"
+
+    def test_uses_dl_ami_for_gpu_launches(self, provider):
+        mock_ec2 = self._make_mock_ec2()
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(
+                provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"
+            ),
+            patch.object(provider, "_get_latest_cpu_ami", return_value="ami-cpu") as mock_cpu_ami,
+            patch.object(provider, "_get_latest_dl_ami", return_value="ami-gpu") as mock_gpu_ami,
+        ):
+            provider.launch_cluster("gpu-cluster", ClusterConfig(run="train.py", accelerators="T4:1"))
+        assert mock_gpu_ami.call_count == 1
+        assert mock_cpu_ami.call_count == 0
+        assert mock_ec2.run_instances.call_args[1]["ImageId"] == "ami-gpu"
+
 
 class TestDeepLearningAmiLookup:
     def test_uses_fallback_name_pattern_when_primary_has_no_results(self, provider):
@@ -358,6 +390,27 @@ class TestDeepLearningAmiLookup:
 
         with pytest.raises(RuntimeError, match="No Deep Learning AMI found"):
             provider._get_latest_dl_ami(mock_ec2)
+
+
+class TestCpuAmiLookup:
+    def test_uses_fallback_name_pattern_when_primary_has_no_results(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_images.side_effect = [
+            {"Images": []},
+            {"Images": [{"ImageId": "ami-cpu-fallback", "CreationDate": "2024-05-01T00:00:00Z"}]},
+        ]
+
+        ami_id = provider._get_latest_cpu_ami(mock_ec2)
+
+        assert ami_id == "ami-cpu-fallback"
+        assert mock_ec2.describe_images.call_count == 2
+
+    def test_raises_when_no_patterns_match(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_images.return_value = {"Images": []}
+
+        with pytest.raises(RuntimeError, match="No CPU Ubuntu AMI found"):
+            provider._get_latest_cpu_ami(mock_ec2)
 
 
 class TestUserDataScript:

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -204,9 +204,11 @@ class TestDeepLearningAmiLookup:
 
 
 class TestUserDataScript:
-    def test_sets_pip_break_system_packages_for_ubuntu24(self):
+    def test_bootstraps_dedicated_python_venv(self):
         user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"))
-        assert "export PIP_BREAK_SYSTEM_PACKAGES=1" in user_data
+        assert "apt-get install -y -qq python3 python3-venv python3-pip" in user_data
+        assert "python3 -m venv /opt/transformerlab-venv" in user_data
+        assert 'export PATH="/opt/transformerlab-venv/bin:$PATH"' in user_data
 
     def test_installs_uv_and_exports_path(self):
         user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"))

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -212,7 +212,7 @@ class TestUserDataScript:
         user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"))
         assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in user_data
         assert 'export PATH="$HOME/.local/bin:/root/.local/bin:/home/ubuntu/.local/bin:$PATH"' in user_data
-        assert "ln -sf /root/.local/bin/uv /usr/local/bin/uv" in user_data
+        assert "cp /root/.local/bin/uv /usr/local/bin/uv && chmod +x /usr/local/bin/uv" in user_data
 
 
 class TestStopCluster:

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -208,6 +208,11 @@ class TestUserDataScript:
         user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"))
         assert "export PIP_BREAK_SYSTEM_PACKAGES=1" in user_data
 
+    def test_installs_uv_and_exports_path(self):
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"))
+        assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in user_data
+        assert 'export PATH="$HOME/.local/bin:$PATH"' in user_data
+
 
 class TestStopCluster:
     def test_terminates_instance_by_cluster_name(self, provider):

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -127,6 +127,94 @@ class TestEnsureKeyPair:
         mock_ec2.import_key_pair.assert_called_once()
 
 
+class TestEnsureIamInstanceProfile:
+    def _make_mock_iam(self, role_exists: bool = True, profile_exists: bool = True, role_in_profile: bool = True):
+        from botocore.exceptions import ClientError
+        mock_iam = MagicMock()
+
+        if role_exists:
+            mock_iam.get_role.return_value = {"Role": {"RoleName": "transformerlab-ec2-role-abc"}}
+        else:
+            mock_iam.get_role.side_effect = ClientError(
+                {"Error": {"Code": "NoSuchEntity", "Message": ""}}, "GetRole"
+            )
+            mock_iam.create_role.return_value = {"Role": {"RoleName": "transformerlab-ec2-role-abc"}}
+
+        if profile_exists:
+            roles_in_profile = [{"RoleName": "transformerlab-ec2-role-abc"}] if role_in_profile else []
+            mock_iam.get_instance_profile.return_value = {
+                "InstanceProfile": {
+                    "InstanceProfileName": "transformerlab-ec2-profile-abc",
+                    "Arn": "arn:aws:iam::123456789:instance-profile/transformerlab-ec2-profile-abc",
+                    "Roles": roles_in_profile,
+                }
+            }
+        else:
+            mock_iam.get_instance_profile.side_effect = ClientError(
+                {"Error": {"Code": "NoSuchEntity", "Message": ""}}, "GetInstanceProfile"
+            )
+            mock_iam.create_instance_profile.return_value = {
+                "InstanceProfile": {
+                    "InstanceProfileName": "transformerlab-ec2-profile-abc",
+                    "Arn": "arn:aws:iam::123456789:instance-profile/transformerlab-ec2-profile-abc",
+                    "Roles": [],
+                }
+            }
+
+        return mock_iam
+
+    def test_returns_existing_profile_arn_without_creating(self, provider):
+        mock_iam = self._make_mock_iam(role_exists=True, profile_exists=True, role_in_profile=True)
+        with patch.object(provider, "_get_iam_client", return_value=mock_iam):
+            arn = provider._ensure_iam_instance_profile()
+        assert arn.startswith("arn:aws:iam::")
+        assert "transformerlab-ec2-profile-abc" in arn
+        mock_iam.create_role.assert_not_called()
+        mock_iam.create_instance_profile.assert_not_called()
+        mock_iam.add_role_to_instance_profile.assert_not_called()
+        mock_iam.put_role_policy.assert_called_once()
+
+    def test_creates_role_when_missing(self, provider):
+        mock_iam = self._make_mock_iam(role_exists=False, profile_exists=True, role_in_profile=True)
+        with patch.object(provider, "_get_iam_client", return_value=mock_iam):
+            provider._ensure_iam_instance_profile()
+        mock_iam.create_role.assert_called_once()
+        call_kwargs = mock_iam.create_role.call_args[1]
+        assert "transformerlab-ec2-role-abc" in call_kwargs["RoleName"]
+
+    def test_creates_profile_when_missing(self, provider):
+        mock_iam = self._make_mock_iam(role_exists=True, profile_exists=False)
+        with patch.object(provider, "_get_iam_client", return_value=mock_iam):
+            provider._ensure_iam_instance_profile()
+        mock_iam.create_instance_profile.assert_called_once()
+
+    def test_adds_role_to_profile_when_not_already_attached(self, provider):
+        mock_iam = self._make_mock_iam(role_exists=True, profile_exists=True, role_in_profile=False)
+        with patch.object(provider, "_get_iam_client", return_value=mock_iam):
+            provider._ensure_iam_instance_profile()
+        mock_iam.add_role_to_instance_profile.assert_called_once()
+
+    def test_role_name_and_profile_name_include_team_id(self, provider):
+        mock_iam = self._make_mock_iam(role_exists=False, profile_exists=False)
+        with patch.object(provider, "_get_iam_client", return_value=mock_iam):
+            provider._ensure_iam_instance_profile()
+        role_name = mock_iam.create_role.call_args[1]["RoleName"]
+        profile_name = mock_iam.create_instance_profile.call_args[1]["InstanceProfileName"]
+        assert "abc" in role_name
+        assert "abc" in profile_name
+
+    def test_inline_policy_scoped_to_team_id(self, provider):
+        import json
+        mock_iam = self._make_mock_iam(role_exists=False, profile_exists=False)
+        with patch.object(provider, "_get_iam_client", return_value=mock_iam):
+            provider._ensure_iam_instance_profile()
+        call_kwargs = mock_iam.put_role_policy.call_args[1]
+        policy = json.loads(call_kwargs["PolicyDocument"])
+        stmt = policy["Statement"][0]
+        assert stmt["Action"] == "ec2:TerminateInstances"
+        assert stmt["Condition"]["StringEquals"]["ec2:ResourceTag/transformerlab-team-id"] == "abc"
+
+
 class TestLaunchCluster:
     def _make_mock_ec2(self):
         mock_ec2 = MagicMock()
@@ -144,6 +232,7 @@ class TestLaunchCluster:
         with (
             patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
         ):
             result = provider.launch_cluster("my-cluster", ClusterConfig(run="python train.py"))
         assert result["instance_id"] == "i-0abc123"
@@ -154,6 +243,7 @@ class TestLaunchCluster:
         with (
             patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
         ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py", disk_size=200))
         call_kwargs = mock_ec2.run_instances.call_args[1]
@@ -164,6 +254,7 @@ class TestLaunchCluster:
         with (
             patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
         ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
         call_kwargs = mock_ec2.run_instances.call_args[1]
@@ -174,12 +265,65 @@ class TestLaunchCluster:
         with (
             patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
         ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
         tags = mock_ec2.run_instances.call_args[1]["TagSpecifications"][0]["Tags"]
         tag_map = {t["Key"]: t["Value"] for t in tags}
         assert tag_map["transformerlab-team-id"] == "abc"
         assert tag_map["transformerlab-cluster-name"] == "my-cluster"
+
+    def test_attaches_iam_instance_profile(self, provider):
+        mock_ec2 = self._make_mock_ec2()
+        mock_ensure_iam = MagicMock(return_value="arn:aws:iam::123:instance-profile/transformerlab-ec2-profile-abc")
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(provider, "_ensure_iam_instance_profile", mock_ensure_iam),
+        ):
+            provider.launch_cluster("my-cluster", ClusterConfig(run="python train.py"))
+        call_kwargs = mock_ec2.run_instances.call_args[1]
+        assert call_kwargs["IamInstanceProfile"]["Arn"] == "arn:aws:iam::123:instance-profile/transformerlab-ec2-profile-abc"
+        mock_ensure_iam.assert_called_once()
+
+    def test_raises_runtime_error_when_iam_profile_fails(self, provider):
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=self._make_mock_ec2()),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(
+                provider,
+                "_ensure_iam_instance_profile",
+                side_effect=RuntimeError("IAM permission denied"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="IAM instance profile"):
+                provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
+
+    def test_retries_run_instances_on_iam_propagation_error(self, provider):
+        from botocore.exceptions import ClientError
+
+        mock_ec2 = self._make_mock_ec2()
+        propagation_error = ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidParameterValue",
+                    "Message": "Value (arn:...) for parameter iamInstanceProfile.arn is invalid. Invalid IAM Instance Profile ARN",
+                }
+            },
+            "RunInstances",
+        )
+        # Fail once with propagation error, then succeed.
+        mock_ec2.run_instances.side_effect = [propagation_error, mock_ec2.run_instances.return_value]
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
+            patch("transformerlab.compute_providers.aws.time.sleep") as mock_sleep,
+        ):
+            result = provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
+        assert result["instance_id"] == "i-0abc123"
+        assert mock_ec2.run_instances.call_count == 2
+        mock_sleep.assert_called_once_with(10)
 
 
 class TestDeepLearningAmiLookup:
@@ -205,16 +349,40 @@ class TestDeepLearningAmiLookup:
 
 class TestUserDataScript:
     def test_bootstraps_dedicated_python_venv(self):
-        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"))
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
         assert "apt-get install -y -qq python3 python3-venv python3-pip" in user_data
         assert "python3 -m venv /opt/transformerlab-venv" in user_data
         assert 'export PATH="/opt/transformerlab-venv/bin:$PATH"' in user_data
 
     def test_installs_uv_and_exports_path(self):
-        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"))
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
         assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in user_data
         assert 'export PATH="$HOME/.local/bin:/root/.local/bin:/home/ubuntu/.local/bin:$PATH"' in user_data
         assert "cp /root/.local/bin/uv /usr/local/bin/uv && chmod +x /usr/local/bin/uv" in user_data
+
+    def test_includes_self_termination_trap(self):
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
+        assert "trap" in user_data
+        assert "_tfl_self_terminate" in user_data
+
+    def test_self_termination_uses_imdsv2(self):
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
+        assert "169.254.169.254/latest/api/token" in user_data
+        assert "169.254.169.254/latest/meta-data/instance-id" in user_data
+
+    def test_self_termination_uses_correct_region(self):
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="eu-west-1")
+        assert "eu-west-1" in user_data
+
+    def test_trap_fires_on_exit_not_only_success(self):
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
+        assert "trap _tfl_self_terminate EXIT" in user_data
+
+    def test_self_termination_aws_call_suppresses_errors(self):
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
+        term_lines = [line for line in user_data.splitlines() if "terminate-instances" in line]
+        assert len(term_lines) == 1
+        assert "|| true" in term_lines[0]
 
 
 class TestStopCluster:

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -130,14 +130,13 @@ class TestEnsureKeyPair:
 class TestEnsureIamInstanceProfile:
     def _make_mock_iam(self, role_exists: bool = True, profile_exists: bool = True, role_in_profile: bool = True):
         from botocore.exceptions import ClientError
+
         mock_iam = MagicMock()
 
         if role_exists:
             mock_iam.get_role.return_value = {"Role": {"RoleName": "transformerlab-ec2-role-abc"}}
         else:
-            mock_iam.get_role.side_effect = ClientError(
-                {"Error": {"Code": "NoSuchEntity", "Message": ""}}, "GetRole"
-            )
+            mock_iam.get_role.side_effect = ClientError({"Error": {"Code": "NoSuchEntity", "Message": ""}}, "GetRole")
             mock_iam.create_role.return_value = {"Role": {"RoleName": "transformerlab-ec2-role-abc"}}
 
         if profile_exists:
@@ -205,6 +204,7 @@ class TestEnsureIamInstanceProfile:
 
     def test_inline_policy_scoped_to_team_id(self, provider):
         import json
+
         mock_iam = self._make_mock_iam(role_exists=False, profile_exists=False)
         with patch.object(provider, "_get_iam_client", return_value=mock_iam):
             provider._ensure_iam_instance_profile()
@@ -232,7 +232,9 @@ class TestLaunchCluster:
         with (
             patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
-            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
+            patch.object(
+                provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"
+            ),
         ):
             result = provider.launch_cluster("my-cluster", ClusterConfig(run="python train.py"))
         assert result["instance_id"] == "i-0abc123"
@@ -243,7 +245,9 @@ class TestLaunchCluster:
         with (
             patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
-            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
+            patch.object(
+                provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"
+            ),
         ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py", disk_size=200))
         call_kwargs = mock_ec2.run_instances.call_args[1]
@@ -254,7 +258,9 @@ class TestLaunchCluster:
         with (
             patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
-            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
+            patch.object(
+                provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"
+            ),
         ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
         call_kwargs = mock_ec2.run_instances.call_args[1]
@@ -265,7 +271,9 @@ class TestLaunchCluster:
         with (
             patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
-            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
+            patch.object(
+                provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"
+            ),
         ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
         tags = mock_ec2.run_instances.call_args[1]["TagSpecifications"][0]["Tags"]
@@ -283,7 +291,10 @@ class TestLaunchCluster:
         ):
             provider.launch_cluster("my-cluster", ClusterConfig(run="python train.py"))
         call_kwargs = mock_ec2.run_instances.call_args[1]
-        assert call_kwargs["IamInstanceProfile"]["Arn"] == "arn:aws:iam::123:instance-profile/transformerlab-ec2-profile-abc"
+        assert (
+            call_kwargs["IamInstanceProfile"]["Arn"]
+            == "arn:aws:iam::123:instance-profile/transformerlab-ec2-profile-abc"
+        )
         mock_ensure_iam.assert_called_once()
 
     def test_raises_runtime_error_when_iam_profile_fails(self, provider):
@@ -317,7 +328,9 @@ class TestLaunchCluster:
         with (
             patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
-            patch.object(provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"),
+            patch.object(
+                provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"
+            ),
             patch("transformerlab.compute_providers.aws.time.sleep") as mock_sleep,
         ):
             result = provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -1,0 +1,301 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from transformerlab.compute_providers.aws import AWSProvider, _resolve_cpu_instance_type, _resolve_gpu_instance_type
+from transformerlab.compute_providers.models import ClusterConfig
+from transformerlab.shared.models.models import ProviderType
+
+
+def test_aws_provider_type_value():
+    assert ProviderType.AWS == "aws"
+    assert ProviderType("aws") == ProviderType.AWS
+
+
+class TestResolveGpuInstanceType:
+    def test_t4_single(self):
+        assert _resolve_gpu_instance_type("T4:1") == "g4dn.xlarge"
+
+    def test_t4_four(self):
+        assert _resolve_gpu_instance_type("T4:4") == "g4dn.12xlarge"
+
+    def test_a100_eight(self):
+        assert _resolve_gpu_instance_type("A100:8") == "p4d.24xlarge"
+
+    def test_h100_eight(self):
+        assert _resolve_gpu_instance_type("H100:8") == "p5.48xlarge"
+
+    def test_radon_v520_two(self):
+        assert _resolve_gpu_instance_type("RadeonV520:2") == "g4ad.8xlarge"
+
+    def test_implicit_count_one(self):
+        assert _resolve_gpu_instance_type("T4") == "g4dn.xlarge"
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ValueError, match="Unsupported accelerator"):
+            _resolve_gpu_instance_type("H200X:1")
+
+    def test_unsupported_count_raises(self):
+        with pytest.raises(ValueError, match="Unsupported accelerator"):
+            _resolve_gpu_instance_type("T4:3")
+
+
+class TestResolveCpuInstanceType:
+    def test_no_requirements_returns_minimum(self):
+        assert _resolve_cpu_instance_type(None, None) == "c5.large"
+
+    def test_exact_match(self):
+        assert _resolve_cpu_instance_type(2, 4) == "c5.large"
+
+    def test_rounds_up_cpus(self):
+        # 3 cpus → next is c5.xlarge (4 vcpus, 8 GB)
+        assert _resolve_cpu_instance_type(3, 4) == "c5.xlarge"
+
+    def test_memory_pushes_to_higher_family(self):
+        # 4 cpus, 20 GB memory → m5.xlarge (4, 16) not enough → r5.xlarge (4, 32)
+        assert _resolve_cpu_instance_type(4, 20) == "r5.xlarge"
+
+    def test_string_memory(self):
+        # "16GB" should parse to 16.0
+        assert _resolve_cpu_instance_type(4, "16GB") == "m5.xlarge"
+
+    def test_exceeds_max_raises(self):
+        with pytest.raises(ValueError, match="No EC2 CPU instance"):
+            _resolve_cpu_instance_type(200, 0)
+
+
+@pytest.fixture
+def provider():
+    return AWSProvider(aws_profile="transformerlab-compute-abc", region="us-east-1", team_id="abc")
+
+
+class TestCheck:
+    def test_returns_true_when_sts_succeeds(self, provider):
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Account": "123456789"}
+        with patch.object(provider, "_get_sts_client", return_value=mock_sts):
+            assert provider.check() is True
+
+    def test_returns_false_on_exception(self, provider):
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.side_effect = Exception("NoCredentialProviders")
+        with patch.object(provider, "_get_sts_client", return_value=mock_sts):
+            assert provider.check() is False
+
+
+class TestEnsureSecurityGroup:
+    def test_returns_existing_group_id(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_security_groups.return_value = {
+            "SecurityGroups": [{"GroupId": "sg-existing123"}]
+        }
+        result = provider._ensure_security_group(mock_ec2)
+        assert result == "sg-existing123"
+        mock_ec2.create_security_group.assert_not_called()
+
+    def test_creates_group_when_missing(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_security_groups.return_value = {"SecurityGroups": []}
+        mock_ec2.create_security_group.return_value = {"GroupId": "sg-new456"}
+        result = provider._ensure_security_group(mock_ec2)
+        assert result == "sg-new456"
+        mock_ec2.authorize_security_group_ingress.assert_called_once()
+
+    def test_new_group_name_includes_team_id(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_security_groups.return_value = {"SecurityGroups": []}
+        mock_ec2.create_security_group.return_value = {"GroupId": "sg-x"}
+        provider._ensure_security_group(mock_ec2)
+        call_kwargs = mock_ec2.create_security_group.call_args[1]
+        assert "abc" in call_kwargs["GroupName"]
+
+
+class TestEnsureKeyPair:
+    def test_returns_existing_key_name(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_key_pairs.return_value = {"KeyPairs": [{"KeyName": "transformerlab-abc"}]}
+        result = provider._ensure_key_pair(mock_ec2, b"ssh-ed25519 AAAA...")
+        assert result == "transformerlab-abc"
+        mock_ec2.import_key_pair.assert_not_called()
+
+    def test_imports_key_when_missing(self, provider):
+        mock_ec2 = MagicMock()
+        from botocore.exceptions import ClientError
+        mock_ec2.describe_key_pairs.side_effect = ClientError(
+            {"Error": {"Code": "InvalidKeyPair.NotFound", "Message": ""}}, "DescribeKeyPairs"
+        )
+        result = provider._ensure_key_pair(mock_ec2, b"ssh-ed25519 AAAA...")
+        assert result == "transformerlab-abc"
+        mock_ec2.import_key_pair.assert_called_once()
+
+
+class TestLaunchCluster:
+    def _make_mock_ec2(self):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_security_groups.return_value = {"SecurityGroups": [{"GroupId": "sg-123"}]}
+        mock_ec2.describe_key_pairs.return_value = {"KeyPairs": [{"KeyName": "transformerlab-abc"}]}
+        mock_ec2.describe_images.return_value = {
+            "Images": [{"ImageId": "ami-0123456789", "CreationDate": "2024-01-01T00:00:00Z"}]
+        }
+        mock_ec2.run_instances.return_value = {
+            "Instances": [{"InstanceId": "i-0abc123"}]
+        }
+        return mock_ec2
+
+    def test_returns_instance_id(self, provider):
+        mock_ec2 = self._make_mock_ec2()
+        # get_org_ssh_public_key returns str; .encode() is called on it inside launch_cluster
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2), \
+             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"):
+            result = provider.launch_cluster("my-cluster", ClusterConfig(run="python train.py"))
+        assert result["instance_id"] == "i-0abc123"
+        assert result["request_id"] == "i-0abc123"
+
+    def test_passes_disk_size_to_block_device(self, provider):
+        mock_ec2 = self._make_mock_ec2()
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2), \
+             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"):
+            provider.launch_cluster("my-cluster", ClusterConfig(run="train.py", disk_size=200))
+        call_kwargs = mock_ec2.run_instances.call_args[1]
+        assert call_kwargs["BlockDeviceMappings"][0]["Ebs"]["VolumeSize"] == 200
+
+    def test_no_block_device_when_disk_size_not_set(self, provider):
+        mock_ec2 = self._make_mock_ec2()
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2), \
+             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"):
+            provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
+        call_kwargs = mock_ec2.run_instances.call_args[1]
+        assert "BlockDeviceMappings" not in call_kwargs
+
+    def test_tags_include_team_id_and_cluster_name(self, provider):
+        mock_ec2 = self._make_mock_ec2()
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2), \
+             patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"):
+            provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
+        tags = mock_ec2.run_instances.call_args[1]["TagSpecifications"][0]["Tags"]
+        tag_map = {t["Key"]: t["Value"] for t in tags}
+        assert tag_map["transformerlab-team-id"] == "abc"
+        assert tag_map["transformerlab-cluster-name"] == "my-cluster"
+
+
+class TestStopCluster:
+    def test_terminates_instance_by_cluster_name(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_instances.return_value = {
+            "Reservations": [{
+                "Instances": [{"InstanceId": "i-0abc123", "State": {"Name": "running"}}]
+            }]
+        }
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
+            result = provider.stop_cluster("my-cluster")
+        mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=["i-0abc123"])
+        assert result["status"] == "success"
+
+    def test_returns_error_when_instance_not_found(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_instances.return_value = {"Reservations": []}
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
+            result = provider.stop_cluster("my-cluster")
+        assert result["status"] == "error"
+
+
+class TestGetClusterStatus:
+    def test_maps_running_to_up(self, provider):
+        from transformerlab.compute_providers.models import ClusterState
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_instances.return_value = {
+            "Reservations": [{
+                "Instances": [{
+                    "InstanceId": "i-0abc123",
+                    "State": {"Name": "running"},
+                    "PublicIpAddress": "1.2.3.4",
+                }]
+            }]
+        }
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
+            status = provider.get_cluster_status("my-cluster")
+        assert status.state == ClusterState.UP
+
+    def test_maps_terminated_to_down(self, provider):
+        from transformerlab.compute_providers.models import ClusterState
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_instances.return_value = {
+            "Reservations": [{
+                "Instances": [{"InstanceId": "i-0abc123", "State": {"Name": "terminated"}}]
+            }]
+        }
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
+            status = provider.get_cluster_status("my-cluster")
+        assert status.state == ClusterState.DOWN
+
+    def test_returns_unknown_when_not_found(self, provider):
+        from transformerlab.compute_providers.models import ClusterState
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_instances.return_value = {"Reservations": []}
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
+            status = provider.get_cluster_status("my-cluster")
+        assert status.state == ClusterState.UNKNOWN
+
+
+class TestGetJobLogs:
+    def test_returns_log_content_via_ssh(self, provider):
+        with patch("transformerlab.compute_providers.aws.asyncio.run", return_value=b"PRIVATE_KEY"), \
+             patch("transformerlab.compute_providers.aws._ssh_read_file", return_value="training loss: 0.5"):
+            mock_ec2 = MagicMock()
+            mock_ec2.describe_instances.return_value = {
+                "Reservations": [{"Instances": [{"InstanceId": "i-0abc", "State": {"Name": "running"}, "PublicIpAddress": "1.2.3.4"}]}]
+            }
+            with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
+                logs = provider.get_job_logs("my-cluster", "job-1")
+        assert "training loss" in logs
+
+    def test_returns_message_when_instance_not_running(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_instances.return_value = {"Reservations": []}
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
+            logs = provider.get_job_logs("my-cluster", "job-1")
+        assert "not found" in logs.lower() or "no" in logs.lower()
+
+
+class TestListClusters:
+    def test_returns_cluster_statuses(self, provider):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_instances.return_value = {
+            "Reservations": [{
+                "Instances": [{
+                    "InstanceId": "i-0abc",
+                    "State": {"Name": "running"},
+                    "Tags": [
+                        {"Key": "transformerlab-cluster-name", "Value": "cluster-1"},
+                        {"Key": "transformerlab-team-id", "Value": "abc"},
+                    ],
+                }]
+            }]
+        }
+        with patch.object(provider, "_get_ec2_client", return_value=mock_ec2):
+            clusters = provider.list_clusters()
+        assert len(clusters) == 1
+        assert clusters[0].cluster_name == "cluster-1"
+
+
+def test_factory_creates_aws_provider():
+    from transformerlab.compute_providers.config import ComputeProviderConfig, create_compute_provider
+
+    config = ComputeProviderConfig(
+        type="aws",
+        name="my-aws",
+        aws_profile="transformerlab-compute-abc",
+        region="us-east-1",
+        team_id="abc",
+    )
+    provider = create_compute_provider(config)
+    assert isinstance(provider, AWSProvider)
+    assert provider.region == "us-east-1"
+    assert provider.team_id == "abc"
+
+
+def test_factory_raises_without_aws_profile():
+    from transformerlab.compute_providers.config import ComputeProviderConfig, create_compute_provider
+
+    config = ComputeProviderConfig(type="aws", name="my-aws", team_id="abc")
+    with pytest.raises(ValueError, match="aws_profile"):
+        create_compute_provider(config)

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -211,7 +211,8 @@ class TestUserDataScript:
     def test_installs_uv_and_exports_path(self):
         user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"))
         assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in user_data
-        assert 'export PATH="$HOME/.local/bin:$PATH"' in user_data
+        assert 'export PATH="$HOME/.local/bin:/root/.local/bin:/home/ubuntu/.local/bin:$PATH"' in user_data
+        assert "ln -sf /root/.local/bin/uv /usr/local/bin/uv" in user_data
 
 
 class TestStopCluster:

--- a/api/transformerlab/compute_providers/aws-iam-requirements.md
+++ b/api/transformerlab/compute_providers/aws-iam-requirements.md
@@ -1,0 +1,110 @@
+# AWS IAM Requirements for Transformer Lab Compute Provider
+
+This document lists all IAM permissions required by the AWS credentials used to configure the Transformer Lab AWS compute provider. These permissions are checked at provider setup time and exercised during cluster launch and termination.
+
+## Required IAM Policy
+
+The following policy covers all operations TransformerLab performs. Attach it to the IAM user or role whose credentials are configured in the provider.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "STSIdentity",
+      "Effect": "Allow",
+      "Action": "sts:GetCallerIdentity",
+      "Resource": "*"
+    },
+    {
+      "Sid": "EC2Launch",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeSecurityGroups",
+        "ec2:CreateSecurityGroup",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:DescribeKeyPairs",
+        "ec2:ImportKeyPair",
+        "ec2:DescribeImages",
+        "ec2:RunInstances",
+        "ec2:DescribeInstances",
+        "ec2:TerminateInstances",
+        "ec2:CreateTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IAMSelfTerminationSetup",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:CreateRole",
+        "iam:PutRolePolicy",
+        "iam:GetRolePolicy",
+        "iam:GetInstanceProfile",
+        "iam:CreateInstanceProfile",
+        "iam:AddRoleToInstanceProfile"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:role/transformerlab-ec2-role-*",
+        "arn:aws:iam::*:instance-profile/transformerlab-ec2-profile-*"
+      ]
+    },
+    {
+      "Sid": "IAMPassRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::*:role/transformerlab-ec2-role-*"
+    }
+  ]
+}
+```
+
+## What Each Section Grants
+
+### STSIdentity
+Used by the provider health check (`check()`) to verify the credentials are valid.
+
+### EC2Launch
+Core EC2 operations for managing compute clusters:
+- `Describe*` — read existing resources (security groups, key pairs, AMIs, instances)
+- `CreateSecurityGroup` + `AuthorizeSecurityGroupIngress` — one-time SSH security group setup per team
+- `ImportKeyPair` — registers the team's SSH public key for instance access
+- `RunInstances` — launches a new EC2 instance for a job
+- `TerminateInstances` — stops a cluster on demand
+- `CreateTags` — tags instances with team and cluster metadata
+
+### IAMSelfTerminationSetup
+Allows TransformerLab to create and manage a minimal IAM role that the EC2 instance uses to terminate **itself** when the job finishes or crashes. Resources are scoped to `transformerlab-ec2-role-*` and `transformerlab-ec2-profile-*` to limit blast radius.
+
+`iam:PassRole` is required so that `ec2:RunInstances` can attach the instance profile to the new instance.
+
+## Resources Created Automatically
+
+TransformerLab creates these resources once per team and reuses them on subsequent launches:
+
+| Resource | Name Pattern | Purpose |
+|---|---|---|
+| Security group | `transformerlab-compute-<team_id>` | Allow SSH (port 22) inbound |
+| Key pair | `transformerlab-<team_id>` | SSH access to instances |
+| IAM role | `transformerlab-ec2-role-<team_id>` | EC2 assume-role principal for self-termination |
+| IAM instance profile | `transformerlab-ec2-profile-<team_id>` | Wraps the role; attached to every launched instance |
+
+## Instance Self-Termination Policy
+
+The IAM role attached to each EC2 instance grants only:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": "ec2:TerminateInstances",
+  "Resource": "arn:aws:ec2:*:*:instance/*",
+  "Condition": {
+    "StringEquals": {
+      "ec2:ResourceTag/transformerlab-team-id": "<team_id>"
+    }
+  }
+}
+```
+
+This means an instance can only terminate other instances belonging to the same team — it cannot terminate arbitrary EC2 instances in the account.

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import re
+import shlex
 import time
 from typing import Any, Dict, List, Optional, Union
 
@@ -359,7 +361,12 @@ class AWSProvider(ComputeProvider):
 
     @staticmethod
     def _build_user_data(config: ClusterConfig, region: str) -> str:
-        env_exports = "\n".join(f'export {k}="{v}"' for k, v in config.env_vars.items())
+        env_exports_lines = []
+        for key, value in config.env_vars.items():
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+                raise ValueError(f"Invalid environment variable name: {key!r}")
+            env_exports_lines.append(f"export {key}={shlex.quote(str(value))}")
+        env_exports = "\n".join(env_exports_lines)
         setup_block = config.setup or ""
         run_cmd = config.run or ""
         return f"""#!/bin/bash

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -281,6 +281,9 @@ class AWSProvider(ComputeProvider):
         return f"""#!/bin/bash
 set -eo pipefail
 mkdir -p /workspace
+# Ubuntu 24+ marks system Python as externally managed (PEP 668).
+# Allow bootstrap pip installs used by remote setup commands.
+export PIP_BREAK_SYSTEM_PACKAGES=1
 {env_exports}
 {setup_block}
 ({run_cmd}) 2>&1 | tee /workspace/run_logs.txt

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -287,9 +287,10 @@ export PIP_BREAK_SYSTEM_PACKAGES=1
 # Install uv for task setups that use `uv pip ...`.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$HOME/.local/bin:/root/.local/bin:/home/ubuntu/.local/bin:$PATH"
-# Make uv available even when later commands run with a different shell/user PATH.
-if [ -x /root/.local/bin/uv ]; then ln -sf /root/.local/bin/uv /usr/local/bin/uv; fi
-if [ -x /root/.local/bin/uvx ]; then ln -sf /root/.local/bin/uvx /usr/local/bin/uvx; fi
+# Make uv available even when later commands run as a different user.
+# Do not symlink into /root; copy binaries so non-root users can execute them.
+if [ -x /root/.local/bin/uv ]; then cp /root/.local/bin/uv /usr/local/bin/uv && chmod +x /usr/local/bin/uv; fi
+if [ -x /root/.local/bin/uvx ]; then cp /root/.local/bin/uvx /usr/local/bin/uvx && chmod +x /usr/local/bin/uvx; fi
 {env_exports}
 {setup_block}
 ({run_cmd}) 2>&1 | tee /workspace/run_logs.txt

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -272,7 +272,6 @@ class AWSProvider(ComputeProvider):
 set -eo pipefail
 mkdir -p /workspace
 {env_exports}
-pip3 install transformerlab --quiet >> /workspace/install.log 2>&1
 {setup_block}
 ({run_cmd}) 2>&1 | tee /workspace/run_logs.txt
 """

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -330,15 +330,7 @@ class AWSProvider(ComputeProvider):
 
         return profile_arn
 
-    def _get_latest_dl_ami(self, ec2) -> str:
-        # AWS occasionally changes DLAMI naming. Try multiple known patterns.
-        name_patterns = [
-            "Deep Learning AMI GPU PyTorch*Ubuntu*",
-            "Deep Learning Base OSS Nvidia Driver GPU AMI*Ubuntu*",
-            "Deep Learning OSS Nvidia Driver AMI GPU*Ubuntu*",
-        ]
-        owners = ["amazon", "898082745236"]
-
+    def _find_latest_ami_by_patterns(self, ec2, owners: List[str], name_patterns: List[str]) -> Optional[str]:
         for name_pattern in name_patterns:
             response = ec2.describe_images(
                 Owners=owners,
@@ -352,7 +344,39 @@ class AWSProvider(ComputeProvider):
             if images:
                 return images[0]["ImageId"]
 
+        return None
+
+    def _get_latest_dl_ami(self, ec2) -> str:
+        # AWS occasionally changes DLAMI naming. Try multiple known patterns.
+        dl_ami_name_patterns = [
+            "Deep Learning AMI GPU PyTorch*Ubuntu*",
+            "Deep Learning Base OSS Nvidia Driver GPU AMI*Ubuntu*",
+            "Deep Learning OSS Nvidia Driver AMI GPU*Ubuntu*",
+        ]
+        dl_ami_owners = ["amazon", "898082745236"]
+        ami_id = self._find_latest_ami_by_patterns(ec2, owners=dl_ami_owners, name_patterns=dl_ami_name_patterns)
+        if ami_id:
+            return ami_id
         raise RuntimeError(f"No Deep Learning AMI found in region {self.region}")
+
+    def _get_latest_cpu_ami(self, ec2) -> str:
+        # Prefer lightweight Ubuntu server AMIs for CPU-only runs.
+        ubuntu_owners = ["099720109477"]
+        ubuntu_name_patterns = [
+            "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*",
+            "ubuntu/images/hvm-ssd-gp3/ubuntu-jammy-22.04-amd64-server-*",
+            "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*",
+            "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+        ]
+        ami_id = self._find_latest_ami_by_patterns(ec2, owners=ubuntu_owners, name_patterns=ubuntu_name_patterns)
+        if ami_id:
+            return ami_id
+        raise RuntimeError(f"No CPU Ubuntu AMI found in region {self.region}")
+
+    def _resolve_ami_id(self, ec2, config: ClusterConfig) -> str:
+        if config.accelerators:
+            return self._get_latest_dl_ami(ec2)
+        return self._get_latest_cpu_ami(ec2)
 
     def _resolve_instance_type(self, config: ClusterConfig) -> str:
         if config.accelerators:
@@ -435,7 +459,7 @@ if [ -x /root/.local/bin/uvx ]; then cp /root/.local/bin/uvx /usr/local/bin/uvx 
         sg_id = self._ensure_security_group(ec2)
         public_key_str = asyncio.run(_ensure_and_get_public_key())
         key_name = self._ensure_key_pair(ec2, public_key_str.encode("utf-8"))
-        ami_id = self._get_latest_dl_ami(ec2)
+        ami_id = self._resolve_ami_id(ec2, config)
         try:
             profile_arn = self._ensure_iam_instance_profile()
         except Exception as e:

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -286,7 +286,10 @@ mkdir -p /workspace
 export PIP_BREAK_SYSTEM_PACKAGES=1
 # Install uv for task setups that use `uv pip ...`.
 curl -LsSf https://astral.sh/uv/install.sh | sh
-export PATH="$HOME/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:/root/.local/bin:/home/ubuntu/.local/bin:$PATH"
+# Make uv available even when later commands run with a different shell/user PATH.
+if [ -x /root/.local/bin/uv ]; then ln -sf /root/.local/bin/uv /usr/local/bin/uv; fi
+if [ -x /root/.local/bin/uvx ]; then ln -sf /root/.local/bin/uvx /usr/local/bin/uvx; fi
 {env_exports}
 {setup_block}
 ({run_cmd}) 2>&1 | tee /workspace/run_logs.txt

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -281,9 +281,11 @@ class AWSProvider(ComputeProvider):
         return f"""#!/bin/bash
 set -eo pipefail
 mkdir -p /workspace
-# Ubuntu 24+ marks system Python as externally managed (PEP 668).
-# Allow bootstrap pip installs used by remote setup commands.
-export PIP_BREAK_SYSTEM_PACKAGES=1
+# Ensure Python tooling is available and use an isolated runtime for setup/run.
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3 python3-venv python3-pip >/dev/null 2>&1
+python3 -m venv /opt/transformerlab-venv
+export PATH="/opt/transformerlab-venv/bin:$PATH"
 # Install uv for task setups that use `uv pip ...`.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$HOME/.local/bin:/root/.local/bin:/home/ubuntu/.local/bin:$PATH"

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import logging
 import re
 import shlex
 import time
@@ -21,6 +22,8 @@ from .models import (
     JobInfo,
     ResourceInfo,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -207,13 +210,14 @@ class AWSProvider(ComputeProvider):
     def _get_iam_client(self):
         return self._get_boto3_session().client("iam")
 
-    def check(self) -> bool:
+    def check(self) -> tuple[bool, str | None]:
         try:
             self._get_sts_client().get_caller_identity()
-            return True
+            return True, None
         except Exception as e:
-            print(f"AWS provider check failed: {e}")
-            return False
+            reason = f"AWS provider check failed: {e}"
+            logger.warning(reason)
+            return False, reason
 
     def _ensure_security_group(self, ec2) -> str:
         sg_name = f"transformerlab-compute-{self.team_id}"

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -8,6 +8,8 @@ import json
 import time
 from typing import Any, Dict, List, Optional, Union
 
+from transformerlab.shared.ssh_policy import get_add_if_verified_policy
+
 from .base import ComputeProvider
 from .models import (
     ClusterConfig,
@@ -162,7 +164,7 @@ def _ssh_read_file(host: str, key_bytes: bytes, remote_path: str, tail_lines: in
         return "Failed to load SSH key."
 
     ssh = paramiko.SSHClient()
-    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.set_missing_host_key_policy(get_add_if_verified_policy())
     try:
         ssh.connect(hostname=host, port=22, username="ubuntu", pkey=pkey, timeout=15, banner_timeout=15)
         cmd = f"tail -n {tail_lines} {remote_path} 2>/dev/null || echo 'No log file yet.'"

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -284,6 +284,9 @@ mkdir -p /workspace
 # Ubuntu 24+ marks system Python as externally managed (PEP 668).
 # Allow bootstrap pip installs used by remote setup commands.
 export PIP_BREAK_SYSTEM_PACKAGES=1
+# Install uv for task setups that use `uv pip ...`.
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
 {env_exports}
 {setup_block}
 ({run_cmd}) 2>&1 | tee /workspace/run_logs.txt

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -245,18 +245,28 @@ class AWSProvider(ComputeProvider):
         return key_name
 
     def _get_latest_dl_ami(self, ec2) -> str:
-        response = ec2.describe_images(
-            Owners=["amazon"],
-            Filters=[
-                {"Name": "name", "Values": ["Deep Learning AMI GPU PyTorch*Ubuntu*"]},
-                {"Name": "state", "Values": ["available"]},
-                {"Name": "architecture", "Values": ["x86_64"]},
-            ],
-        )
-        images = sorted(response["Images"], key=lambda x: x["CreationDate"], reverse=True)
-        if not images:
-            raise RuntimeError(f"No Deep Learning AMI found in region {self.region}")
-        return images[0]["ImageId"]
+        # AWS occasionally changes DLAMI naming. Try multiple known patterns.
+        name_patterns = [
+            "Deep Learning AMI GPU PyTorch*Ubuntu*",
+            "Deep Learning Base OSS Nvidia Driver GPU AMI*Ubuntu*",
+            "Deep Learning OSS Nvidia Driver AMI GPU*Ubuntu*",
+        ]
+        owners = ["amazon", "898082745236"]
+
+        for name_pattern in name_patterns:
+            response = ec2.describe_images(
+                Owners=owners,
+                Filters=[
+                    {"Name": "name", "Values": [name_pattern]},
+                    {"Name": "state", "Values": ["available"]},
+                    {"Name": "architecture", "Values": ["x86_64"]},
+                ],
+            )
+            images = sorted(response.get("Images", []), key=lambda x: x.get("CreationDate", ""), reverse=True)
+            if images:
+                return images[0]["ImageId"]
+
+        raise RuntimeError(f"No Deep Learning AMI found in region {self.region}")
 
     def _resolve_instance_type(self, config: ClusterConfig) -> str:
         if config.accelerators:

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import io
+import json
+import time
 from typing import Any, Dict, List, Optional, Union
 
 from .base import ComputeProvider
@@ -198,6 +200,9 @@ class AWSProvider(ComputeProvider):
     def _get_sts_client(self):
         return self._get_boto3_session().client("sts")
 
+    def _get_iam_client(self):
+        return self._get_boto3_session().client("iam")
+
     def check(self) -> bool:
         try:
             self._get_sts_client().get_caller_identity()
@@ -244,6 +249,83 @@ class AWSProvider(ComputeProvider):
         ec2.import_key_pair(KeyName=key_name, PublicKeyMaterial=public_key_bytes)
         return key_name
 
+    def _ensure_iam_instance_profile(self) -> str:
+        """Idempotently create IAM role + scoped policy + instance profile for EC2 self-termination.
+
+        Returns the instance profile ARN.
+        """
+        from botocore.exceptions import ClientError
+
+        iam = self._get_iam_client()
+        role_name = f"transformerlab-ec2-role-{self.team_id}"
+        profile_name = f"transformerlab-ec2-profile-{self.team_id}"
+
+        trust_policy = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "ec2.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    }
+                ],
+            }
+        )
+        terminate_policy = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "ec2:TerminateInstances",
+                        "Resource": "arn:aws:ec2:*:*:instance/*",
+                        "Condition": {"StringEquals": {"ec2:ResourceTag/transformerlab-team-id": self.team_id}},
+                    }
+                ],
+            }
+        )
+
+        # Ensure role exists.
+        try:
+            iam.get_role(RoleName=role_name)
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "NoSuchEntity":
+                raise
+            iam.create_role(
+                RoleName=role_name,
+                AssumeRolePolicyDocument=trust_policy,
+                Description=f"TransformerLab EC2 self-termination role for team {self.team_id}",
+            )
+
+        # Ensure inline policy is attached to the role.
+        iam.put_role_policy(
+            RoleName=role_name,
+            PolicyName="tfl-ec2-self-terminate",
+            PolicyDocument=terminate_policy,
+        )
+
+        # Ensure instance profile exists.
+        try:
+            response = iam.get_instance_profile(InstanceProfileName=profile_name)
+            profile_arn: str = response["InstanceProfile"]["Arn"]
+            existing_roles = [r["RoleName"] for r in response["InstanceProfile"]["Roles"]]
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "NoSuchEntity":
+                raise
+            response = iam.create_instance_profile(InstanceProfileName=profile_name)
+            profile_arn = response["InstanceProfile"]["Arn"]
+            existing_roles = []
+
+        # Attach role to profile if not already attached.
+        if role_name not in existing_roles:
+            iam.add_role_to_instance_profile(
+                InstanceProfileName=profile_name,
+                RoleName=role_name,
+            )
+
+        return profile_arn
+
     def _get_latest_dl_ami(self, ec2) -> str:
         # AWS occasionally changes DLAMI naming. Try multiple known patterns.
         name_patterns = [
@@ -274,13 +356,28 @@ class AWSProvider(ComputeProvider):
         return _resolve_cpu_instance_type(config.cpus, config.memory)
 
     @staticmethod
-    def _build_user_data(config: ClusterConfig) -> str:
+    def _build_user_data(config: ClusterConfig, region: str) -> str:
         env_exports = "\n".join(f'export {k}="{v}"' for k, v in config.env_vars.items())
         setup_block = config.setup or ""
         run_cmd = config.run or ""
         return f"""#!/bin/bash
 set -eo pipefail
 mkdir -p /workspace
+
+# Self-terminate on EXIT (success or crash) using IMDSv2.
+_tfl_self_terminate() {{
+  local _token _iid
+  _token=$(curl -sX PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null) || true
+  _iid=$(curl -sf -H "X-aws-ec2-metadata-token: $_token" \
+    "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null) || true
+  if [ -n "$_iid" ]; then
+    aws ec2 terminate-instances --instance-ids "$_iid" --region "{region}" >/dev/null 2>&1 || true
+  fi
+  return 0
+}}
+trap _tfl_self_terminate EXIT
+
 # Ensure Python tooling is available and use an isolated runtime for setup/run.
 apt-get update -qq
 DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3 python3-venv python3-pip >/dev/null 2>&1
@@ -330,7 +427,11 @@ if [ -x /root/.local/bin/uvx ]; then cp /root/.local/bin/uvx /usr/local/bin/uvx 
         public_key_str = asyncio.run(_ensure_and_get_public_key())
         key_name = self._ensure_key_pair(ec2, public_key_str.encode("utf-8"))
         ami_id = self._get_latest_dl_ami(ec2)
-        user_data = self._build_user_data(config)
+        try:
+            profile_arn = self._ensure_iam_instance_profile()
+        except Exception as e:
+            raise RuntimeError(f"Failed to ensure IAM instance profile: {e}") from e
+        user_data = self._build_user_data(config, region=self.region)
 
         launch_params: Dict[str, Any] = {
             "ImageId": ami_id,
@@ -339,6 +440,7 @@ if [ -x /root/.local/bin/uvx ]; then cp /root/.local/bin/uvx /usr/local/bin/uvx 
             "MaxCount": 1,
             "KeyName": key_name,
             "SecurityGroupIds": [sg_id],
+            "IamInstanceProfile": {"Arn": profile_arn},
             "UserData": user_data,
             "TagSpecifications": [
                 {
@@ -360,12 +462,25 @@ if [ -x /root/.local/bin/uvx ]; then cp /root/.local/bin/uvx /usr/local/bin/uvx 
                 }
             ]
 
-        try:
-            response = ec2.run_instances(**launch_params)
-            instance_id = response["Instances"][0]["InstanceId"]
-            return {"instance_id": instance_id, "request_id": instance_id}
-        except Exception as e:
-            raise RuntimeError(f"Failed to launch EC2 instance: {e}") from e
+        # IAM instance profiles are eventually consistent. Retry on the specific
+        # propagation error so freshly-created profiles don't cause launch failures.
+        _IAM_PROPAGATION_RETRIES = 5
+        _IAM_PROPAGATION_DELAY_S = 10
+        for attempt in range(_IAM_PROPAGATION_RETRIES):
+            try:
+                response = ec2.run_instances(**launch_params)
+                instance_id = response["Instances"][0]["InstanceId"]
+                return {"instance_id": instance_id, "request_id": instance_id}
+            except Exception as e:
+                is_iam_propagation = (
+                    hasattr(e, "response")
+                    and e.response.get("Error", {}).get("Code") == "InvalidParameterValue"
+                    and "iamInstanceProfile" in e.response.get("Error", {}).get("Message", "")
+                )
+                if is_iam_propagation and attempt < _IAM_PROPAGATION_RETRIES - 1:
+                    time.sleep(_IAM_PROPAGATION_DELAY_S)
+                    continue
+                raise RuntimeError(f"Failed to launch EC2 instance: {e}") from e
 
     def stop_cluster(self, cluster_name: str) -> Dict[str, Any]:
         ec2 = self._get_ec2_client()

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -1,0 +1,489 @@
+"""AWS EC2 compute provider implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from typing import Any, Dict, List, Optional, Union
+
+from .base import ComputeProvider
+from .models import (
+    ClusterConfig,
+    ClusterState,
+    ClusterStatus,
+    JobConfig,
+    JobInfo,
+    ResourceInfo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Instance selection tables
+# ---------------------------------------------------------------------------
+
+_GPU_INSTANCE_MAP: Dict[tuple, str] = {
+    ("T4", 1): "g4dn.xlarge",
+    ("T4", 4): "g4dn.12xlarge",
+    ("T4", 8): "g4dn.metal",
+    ("A10G", 1): "g5.xlarge",
+    ("A10G", 4): "g5.12xlarge",
+    ("A10G", 8): "g5.48xlarge",
+    ("L4", 1): "g6.xlarge",
+    ("L4", 4): "g6.12xlarge",
+    ("L4", 8): "g6.48xlarge",
+    ("L40S", 1): "g6e.xlarge",
+    ("L40S", 4): "g6e.12xlarge",
+    ("L40S", 8): "g6e.48xlarge",
+    ("V100", 1): "p3.2xlarge",
+    ("V100", 4): "p3.8xlarge",
+    ("V100", 8): "p3.16xlarge",
+    ("V100-32GB", 8): "p3dn.24xlarge",
+    ("A100", 8): "p4d.24xlarge",
+    ("A100-80GB", 8): "p4de.24xlarge",
+    ("H100", 8): "p5.48xlarge",
+    ("H200", 8): "p5e.48xlarge",
+    ("RadeonV520", 1): "g4ad.xlarge",
+    ("RadeonV520", 2): "g4ad.8xlarge",
+    ("RadeonV520", 4): "g4ad.16xlarge",
+}
+
+_CPU_INSTANCE_OPTIONS: List[tuple] = sorted(
+    [
+        (2, 4, "c5.large"),
+        (2, 8, "m5.large"),
+        (2, 16, "r5.large"),
+        (4, 8, "c5.xlarge"),
+        (4, 16, "m5.xlarge"),
+        (4, 32, "r5.xlarge"),
+        (8, 16, "c5.2xlarge"),
+        (8, 32, "m5.2xlarge"),
+        (8, 64, "r5.2xlarge"),
+        (16, 32, "c5.4xlarge"),
+        (16, 64, "m5.4xlarge"),
+        (16, 128, "r5.4xlarge"),
+        (32, 128, "m5.8xlarge"),
+        (32, 256, "r5.8xlarge"),
+        (36, 72, "c5.9xlarge"),
+        (48, 96, "c5.12xlarge"),
+        (48, 192, "m5.12xlarge"),
+        (48, 384, "r5.12xlarge"),
+        (64, 256, "m5.16xlarge"),
+        (64, 512, "r5.16xlarge"),
+        (72, 144, "c5.18xlarge"),
+        (96, 192, "c5.24xlarge"),
+        (96, 384, "m5.24xlarge"),
+        (96, 768, "r5.24xlarge"),
+    ],
+    key=lambda x: (x[0], x[1]),
+)
+
+
+def _resolve_gpu_instance_type(accelerators: str) -> str:
+    """Map an accelerator spec (e.g. 'A100:8') to an EC2 instance type.
+
+    Raises ValueError for unrecognized types or unsupported counts.
+    """
+    parts = accelerators.strip().split(":")
+    accel_type = parts[0].strip()
+    count = int(parts[1].strip()) if len(parts) > 1 else 1
+    key = (accel_type, count)
+    if key not in _GPU_INSTANCE_MAP:
+        valid = sorted(f"{t}:{c}" for t, c in _GPU_INSTANCE_MAP)
+        raise ValueError(f"Unsupported accelerator spec '{accelerators}'. Valid options: {', '.join(valid)}")
+    return _GPU_INSTANCE_MAP[key]
+
+
+def _parse_memory_gb(memory: Union[int, float, str, None]) -> float:
+    """Parse memory field (int GB, float GB, '16GB' string, or None) to float GB."""
+    if memory is None:
+        return 0.0
+    if isinstance(memory, (int, float)):
+        return float(memory)
+    stripped = str(memory).strip().upper()
+    for suffix in ("GB", "G", "MB", "M"):
+        if stripped.endswith(suffix):
+            stripped = stripped[: -len(suffix)].strip()
+            break
+    try:
+        return float(stripped)
+    except ValueError:
+        return 0.0
+
+
+def _resolve_cpu_instance_type(
+    cpus: Union[int, str, None],
+    memory: Union[int, float, str, None],
+) -> str:
+    """Select smallest EC2 CPU instance satisfying both vCPU and memory constraints.
+
+    Raises ValueError if the combination exceeds available options.
+    """
+    requested_cpus = int(cpus) if cpus else 0
+    requested_memory = _parse_memory_gb(memory)
+    for vcpus, mem_gb, instance_type in _CPU_INSTANCE_OPTIONS:
+        if vcpus >= requested_cpus and mem_gb >= requested_memory:
+            return instance_type
+    raise ValueError(
+        f"No EC2 CPU instance found for cpus={requested_cpus}, memory={requested_memory}GB. "
+        f"Maximum available: 96 vCPUs, 768 GB memory."
+    )
+
+
+# ---------------------------------------------------------------------------
+# EC2 state mapping
+# ---------------------------------------------------------------------------
+
+_EC2_STATE_TO_CLUSTER_STATE: Dict[str, ClusterState] = {
+    "pending": ClusterState.INIT,
+    "running": ClusterState.UP,
+    "stopping": ClusterState.STOPPED,
+    "stopped": ClusterState.STOPPED,
+    "shutting-down": ClusterState.DOWN,
+    "terminated": ClusterState.DOWN,
+}
+
+
+def _ssh_read_file(host: str, key_bytes: bytes, remote_path: str, tail_lines: int = 500) -> str:
+    """SSH to host and read a file. Returns string content or error message."""
+    import paramiko
+
+    pkey = None
+    key_file = io.StringIO(key_bytes.decode("utf-8"))
+    for key_class in (paramiko.Ed25519Key, paramiko.RSAKey):
+        try:
+            pkey = key_class.from_private_key(key_file)
+            break
+        except Exception:
+            key_file.seek(0)
+
+    if pkey is None:
+        return "Failed to load SSH key."
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        ssh.connect(hostname=host, port=22, username="ubuntu", pkey=pkey, timeout=15, banner_timeout=15)
+        cmd = f"tail -n {tail_lines} {remote_path} 2>/dev/null || echo 'No log file yet.'"
+        _, stdout, _ = ssh.exec_command(cmd, timeout=10)
+        return stdout.read().decode("utf-8", errors="replace").strip() or "No output yet."
+    except Exception as e:
+        return f"SSH failed: {e}"
+    finally:
+        ssh.close()
+
+
+class AWSProvider(ComputeProvider):
+    """Compute provider that launches ephemeral EC2 instances per job."""
+
+    def __init__(
+        self,
+        aws_profile: str,
+        region: str,
+        team_id: str,
+        extra_config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.aws_profile = aws_profile
+        self.region = region
+        self.team_id = team_id
+        self.extra_config = extra_config or {}
+
+    def _get_boto3_session(self):
+        import boto3
+
+        return boto3.Session(profile_name=self.aws_profile, region_name=self.region)
+
+    def _get_ec2_client(self):
+        return self._get_boto3_session().client("ec2")
+
+    def _get_sts_client(self):
+        return self._get_boto3_session().client("sts")
+
+    def check(self) -> bool:
+        try:
+            self._get_sts_client().get_caller_identity()
+            return True
+        except Exception as e:
+            print(f"AWS provider check failed: {e}")
+            return False
+
+    def _ensure_security_group(self, ec2) -> str:
+        sg_name = f"transformerlab-compute-{self.team_id}"
+        response = ec2.describe_security_groups(Filters=[{"Name": "group-name", "Values": [sg_name]}])
+        groups = response.get("SecurityGroups", [])
+        if groups:
+            return groups[0]["GroupId"]
+
+        sg_response = ec2.create_security_group(
+            GroupName=sg_name,
+            Description=f"TransformerLab compute provider for team {self.team_id}",
+        )
+        sg_id = sg_response["GroupId"]
+        ec2.authorize_security_group_ingress(
+            GroupId=sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        return sg_id
+
+    def _ensure_key_pair(self, ec2, public_key_bytes: bytes) -> str:
+        from botocore.exceptions import ClientError
+
+        key_name = f"transformerlab-{self.team_id}"
+        try:
+            ec2.describe_key_pairs(KeyNames=[key_name])
+            return key_name
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "InvalidKeyPair.NotFound":
+                raise
+        ec2.import_key_pair(KeyName=key_name, PublicKeyMaterial=public_key_bytes)
+        return key_name
+
+    def _get_latest_dl_ami(self, ec2) -> str:
+        response = ec2.describe_images(
+            Owners=["amazon"],
+            Filters=[
+                {"Name": "name", "Values": ["Deep Learning AMI GPU PyTorch*Ubuntu*"]},
+                {"Name": "state", "Values": ["available"]},
+                {"Name": "architecture", "Values": ["x86_64"]},
+            ],
+        )
+        images = sorted(response["Images"], key=lambda x: x["CreationDate"], reverse=True)
+        if not images:
+            raise RuntimeError(f"No Deep Learning AMI found in region {self.region}")
+        return images[0]["ImageId"]
+
+    def _resolve_instance_type(self, config: ClusterConfig) -> str:
+        if config.accelerators:
+            return _resolve_gpu_instance_type(config.accelerators)
+        return _resolve_cpu_instance_type(config.cpus, config.memory)
+
+    @staticmethod
+    def _build_user_data(config: ClusterConfig) -> str:
+        env_exports = "\n".join(f'export {k}="{v}"' for k, v in config.env_vars.items())
+        setup_block = config.setup or ""
+        run_cmd = config.run or ""
+        return f"""#!/bin/bash
+set -eo pipefail
+mkdir -p /workspace
+{env_exports}
+pip3 install transformerlab --quiet >> /workspace/install.log 2>&1
+{setup_block}
+({run_cmd}) 2>&1 | tee /workspace/run_logs.txt
+"""
+
+    # --- Cluster management methods ---
+
+    def _find_instance_by_cluster_name(self, ec2, cluster_name: str) -> Optional[Dict[str, Any]]:
+        response = ec2.describe_instances(
+            Filters=[
+                {"Name": "tag:transformerlab-cluster-name", "Values": [cluster_name]},
+                {"Name": "tag:transformerlab-team-id", "Values": [self.team_id]},
+                {"Name": "instance-state-name", "Values": ["pending", "running", "stopping", "stopped"]},
+            ]
+        )
+        for reservation in response.get("Reservations", []):
+            instances = reservation.get("Instances", [])
+            if instances:
+                return instances[0]
+        return None
+
+    def launch_cluster(self, cluster_name: str, config: ClusterConfig) -> Dict[str, Any]:
+        from transformerlab.services.ssh_key_service import (
+            get_or_create_org_ssh_key_pair,
+            get_org_ssh_public_key,
+        )
+
+        async def _ensure_and_get_public_key() -> str:
+            await get_or_create_org_ssh_key_pair(self.team_id)
+            return await get_org_ssh_public_key(self.team_id)
+
+        ec2 = self._get_ec2_client()
+        instance_type = self._resolve_instance_type(config)
+        sg_id = self._ensure_security_group(ec2)
+        public_key_str = asyncio.run(_ensure_and_get_public_key())
+        key_name = self._ensure_key_pair(ec2, public_key_str.encode("utf-8"))
+        ami_id = self._get_latest_dl_ami(ec2)
+        user_data = self._build_user_data(config)
+
+        launch_params: Dict[str, Any] = {
+            "ImageId": ami_id,
+            "InstanceType": instance_type,
+            "MinCount": 1,
+            "MaxCount": 1,
+            "KeyName": key_name,
+            "SecurityGroupIds": [sg_id],
+            "UserData": user_data,
+            "TagSpecifications": [
+                {
+                    "ResourceType": "instance",
+                    "Tags": [
+                        {"Key": "Name", "Value": cluster_name},
+                        {"Key": "transformerlab-team-id", "Value": self.team_id},
+                        {"Key": "transformerlab-cluster-name", "Value": cluster_name},
+                    ],
+                }
+            ],
+        }
+
+        if config.disk_size:
+            launch_params["BlockDeviceMappings"] = [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {"VolumeSize": config.disk_size, "VolumeType": "gp3"},
+                }
+            ]
+
+        try:
+            response = ec2.run_instances(**launch_params)
+            instance_id = response["Instances"][0]["InstanceId"]
+            return {"instance_id": instance_id, "request_id": instance_id}
+        except Exception as e:
+            raise RuntimeError(f"Failed to launch EC2 instance: {e}") from e
+
+    def stop_cluster(self, cluster_name: str) -> Dict[str, Any]:
+        ec2 = self._get_ec2_client()
+        instance = self._find_instance_by_cluster_name(ec2, cluster_name)
+        if not instance:
+            return {"status": "error", "message": f"Instance '{cluster_name}' not found", "cluster_name": cluster_name}
+        instance_id = instance["InstanceId"]
+        try:
+            ec2.terminate_instances(InstanceIds=[instance_id])
+            return {"status": "success", "message": f"Instance '{cluster_name}' terminated", "instance_id": instance_id}
+        except Exception as e:
+            return {"status": "error", "message": str(e), "cluster_name": cluster_name, "instance_id": instance_id}
+
+    def get_cluster_status(self, cluster_name: str) -> ClusterStatus:
+        ec2 = self._get_ec2_client()
+        instance = self._find_instance_by_cluster_name(ec2, cluster_name)
+        if not instance:
+            # Also check terminated instances
+            response = ec2.describe_instances(
+                Filters=[
+                    {"Name": "tag:transformerlab-cluster-name", "Values": [cluster_name]},
+                    {"Name": "tag:transformerlab-team-id", "Values": [self.team_id]},
+                ]
+            )
+            for reservation in response.get("Reservations", []):
+                instances = reservation.get("Instances", [])
+                if instances:
+                    instance = instances[0]
+                    break
+        if not instance:
+            return ClusterStatus(cluster_name=cluster_name, state=ClusterState.UNKNOWN)
+
+        ec2_state = instance.get("State", {}).get("Name", "unknown")
+        state = _EC2_STATE_TO_CLUSTER_STATE.get(ec2_state, ClusterState.UNKNOWN)
+        return ClusterStatus(
+            cluster_name=cluster_name,
+            state=state,
+            status_message=ec2_state,
+            provider_data=instance,
+        )
+
+    def get_job_logs(
+        self,
+        cluster_name: str,
+        job_id: Union[str, int],
+        tail_lines: Optional[int] = None,
+        follow: bool = False,
+    ) -> str:
+        from transformerlab.services.ssh_key_service import get_org_ssh_private_key
+
+        ec2 = self._get_ec2_client()
+        instance = self._find_instance_by_cluster_name(ec2, cluster_name)
+        if not instance:
+            return f"Instance '{cluster_name}' not found or not running."
+
+        public_ip = instance.get("PublicIpAddress")
+        if not public_ip:
+            return "Instance has no public IP yet (still starting)."
+
+        key_bytes = asyncio.run(get_org_ssh_private_key(self.team_id))
+        return _ssh_read_file(public_ip, key_bytes, "/workspace/run_logs.txt", tail_lines or 500)
+
+    def list_clusters(self) -> List[ClusterStatus]:
+        ec2 = self._get_ec2_client()
+        response = ec2.describe_instances(
+            Filters=[
+                {"Name": "tag:transformerlab-team-id", "Values": [self.team_id]},
+                {"Name": "instance-state-name", "Values": ["pending", "running", "stopping", "stopped"]},
+            ]
+        )
+        statuses = []
+        for reservation in response.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+                cluster_name = tags.get("transformerlab-cluster-name", instance["InstanceId"])
+                ec2_state = instance.get("State", {}).get("Name", "unknown")
+                state = _EC2_STATE_TO_CLUSTER_STATE.get(ec2_state, ClusterState.UNKNOWN)
+                statuses.append(
+                    ClusterStatus(
+                        cluster_name=cluster_name,
+                        state=state,
+                        status_message=ec2_state,
+                        provider_data=instance,
+                    )
+                )
+        return statuses
+
+    def get_cluster_resources(self, cluster_name: str) -> ResourceInfo:
+        ec2 = self._get_ec2_client()
+        instance = self._find_instance_by_cluster_name(ec2, cluster_name)
+        if not instance:
+            return ResourceInfo(cluster_name=cluster_name, gpus=[], num_nodes=1)
+        return ResourceInfo(
+            cluster_name=cluster_name,
+            gpus=[],
+            num_nodes=1,
+            provider_data=instance,
+        )
+
+    def get_clusters_detailed(self) -> List[Dict[str, Any]]:
+        clusters = self.list_clusters()
+        detailed = []
+        for status in clusters:
+            state_str = status.state.name if hasattr(status.state, "name") else str(status.state)
+            is_up = state_str.upper() in ("UP", "INIT")
+            detailed.append(
+                {
+                    "cluster_id": status.cluster_name,
+                    "cluster_name": status.cluster_name,
+                    "backend_type": "AWS EC2",
+                    "elastic_enabled": True,
+                    "max_nodes": 1,
+                    "head_node_ip": (status.provider_data or {}).get("PublicIpAddress"),
+                    "nodes": [
+                        {
+                            "node_name": status.cluster_name,
+                            "is_fixed": False,
+                            "is_active": is_up,
+                            "state": state_str.upper(),
+                            "reason": status.status_message or state_str,
+                            "resources": {
+                                "cpus_total": 0,
+                                "cpus_allocated": 0,
+                                "gpus": {},
+                                "gpus_free": {},
+                                "memory_gb_total": 0,
+                                "memory_gb_allocated": 0,
+                            },
+                        }
+                    ],
+                }
+            )
+        return detailed
+
+    def submit_job(self, cluster_name: str, job_config: JobConfig) -> Dict[str, Any]:
+        raise NotImplementedError("AWS EC2 provider uses tfl-remote-trap for job dispatch")
+
+    def list_jobs(self, cluster_name: str) -> List[JobInfo]:
+        raise NotImplementedError("AWS EC2 provider uses tfl-remote-trap for job dispatch")
+
+    def cancel_job(self, cluster_name: str, job_id: Union[str, int]) -> Dict[str, Any]:
+        raise NotImplementedError("AWS EC2 provider uses tfl-remote-trap for job dispatch")

--- a/api/transformerlab/compute_providers/config.py
+++ b/api/transformerlab/compute_providers/config.py
@@ -39,6 +39,11 @@ class ComputeProviderConfig(BaseModel):
     # Accelerators supported by this provider
     supported_accelerators: Optional[list[str]] = Field(default=None)
 
+    # AWS-specific config
+    aws_profile: Optional[str] = None  # e.g. "transformerlab-compute-{team_id}"
+    region: Optional[str] = None  # e.g. "us-east-1"
+    team_id: Optional[str] = None  # team identifier for resource naming
+
     # Additional provider-specific config
     extra_config: Dict[str, Any] = Field(default_factory=dict)
 
@@ -199,6 +204,19 @@ def create_compute_provider(config: ComputeProviderConfig):
             server_url=config.server_url,
             api_token=config.api_token,
             project_name=config.dstack_project or "main",
+            extra_config=config.extra_config,
+        )
+    elif config.type == "aws":
+        from .aws import AWSProvider
+
+        if not config.aws_profile:
+            raise ValueError("AWS provider requires aws_profile in config")
+        if not config.team_id:
+            raise ValueError("AWS provider requires team_id in config")
+        return AWSProvider(
+            aws_profile=config.aws_profile,
+            region=config.region or "us-east-1",
+            team_id=config.team_id,
             extra_config=config.extra_config,
         )
     else:

--- a/api/transformerlab/compute_providers/dstack.py
+++ b/api/transformerlab/compute_providers/dstack.py
@@ -397,5 +397,5 @@ class DstackProvider(ComputeProvider):
             return True, None
         except Exception as e:
             reason = f"dstack provider check failed: {type(e).__name__}: {str(e)}"
-            print(reason)
+            logger.warning(reason)
             return False, reason

--- a/api/transformerlab/compute_providers/local.py
+++ b/api/transformerlab/compute_providers/local.py
@@ -3,6 +3,7 @@
 import contextlib
 import fcntl
 import json
+import logging
 import os
 import re
 import signal
@@ -28,6 +29,8 @@ from .models import (
     JobState,
 )
 from .sandbox import make_seatbelt_preexec, wrap_command_with_bwrap, get_backend_name
+
+logger = logging.getLogger(__name__)
 
 
 def _read_local_provider_config() -> Optional[Dict[str, Any]]:
@@ -831,7 +834,7 @@ class LocalProvider(ComputeProvider):
         reason = (
             f"Local provider check failed: config file not found at {config_path} or legacy path {legacy_config_path}"
         )
-        print(reason)
+        logger.warning(reason)
         return False, reason
 
 

--- a/api/transformerlab/compute_providers/runpod.py
+++ b/api/transformerlab/compute_providers/runpod.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import io
+import logging
 from typing import Dict, Any, Optional, Union, List
 
 import requests
@@ -22,6 +23,7 @@ from .models import (
 
 # Path inside the RunPod container where we tee stdout/stderr for provider log retrieval via SSH
 RUNPOD_RUN_LOGS_PATH = "/workspace/run_logs.txt"
+logger = logging.getLogger(__name__)
 
 
 async def fetch_runpod_provider_logs(
@@ -762,5 +764,5 @@ class RunpodProvider(ComputeProvider):
             return True, None
         except Exception as e:
             reason = f"Runpod provider check failed: {e}"
-            print(reason)
+            logger.warning(reason)
             return False, reason

--- a/api/transformerlab/compute_providers/skypilot.py
+++ b/api/transformerlab/compute_providers/skypilot.py
@@ -23,6 +23,8 @@ from .models import (
     JobState,
 )
 
+logger = logging.getLogger(__name__)
+
 # SkyPilot SDK imports - try to import, but allow graceful failure if not available
 SKYPILOT_AVAILABLE = False
 SKYPILOT_IMPORT_ERROR = None
@@ -1918,7 +1920,7 @@ class SkyPilotProvider(ComputeProvider):
                 if status == "healthy":
                     return True, None
                 reason = f"SkyPilot provider check failed: health status is '{status}'"
-                print(reason)
+                logger.warning(reason)
                 return False, reason
             else:
                 # If response doesn't have json method, check status code
@@ -1926,20 +1928,20 @@ class SkyPilotProvider(ComputeProvider):
                     return True, None
                 status_code = getattr(response, "status_code", "unknown")
                 reason = f"SkyPilot provider check failed: unexpected health response status_code={status_code}"
-                print(reason)
+                logger.warning(reason)
                 return False, reason
         except requests.exceptions.ConnectionError as e:
             # Connection error means server is not accessible
             reason = f"SkyPilot provider check failed: connection error: {str(e)}"
-            print(reason)
+            logger.warning(reason)
             return False, reason
         except requests.exceptions.Timeout as e:
             # Timeout means server is not responding
             reason = f"SkyPilot provider check failed: timeout: {str(e)}"
-            print(reason)
+            logger.warning(reason)
             return False, reason
         except Exception as e:
             # For any other exceptions, assume provider is not active
             reason = f"SkyPilot provider check failed: {type(e).__name__}: {str(e)}"
-            print(reason)
+            logger.warning(reason)
             return False, reason

--- a/api/transformerlab/compute_providers/slurm.py
+++ b/api/transformerlab/compute_providers/slurm.py
@@ -1,6 +1,7 @@
 """SLURM provider implementation."""
 
 import asyncio
+import logging
 import requests
 import os
 import re
@@ -17,6 +18,8 @@ from .models import (
     JobState,
 )
 from transformerlab.shared.ssh_policy import get_add_if_verified_policy
+
+logger = logging.getLogger(__name__)
 
 
 class SLURMProvider(ComputeProvider):
@@ -1011,5 +1014,5 @@ class SLURMProvider(ComputeProvider):
                 return True, None
         except Exception as e:
             reason = f"SLURM provider check failed: {type(e).__name__}: {str(e)}"
-            print(reason)
+            logger.warning(reason)
             return False, reason

--- a/api/transformerlab/routers/compute_provider/providers.py
+++ b/api/transformerlab/routers/compute_provider/providers.py
@@ -1,10 +1,14 @@
 from typing import Any, Dict, List
+import json
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, HTTPException
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from transformerlab.shared.models.user_model import get_async_session
 from transformerlab.routers.auth import require_team_owner, get_user_and_team
 from transformerlab.services.compute_provider import team_provider_endpoints
+from transformerlab.services.compute_provider.launch_credentials import write_aws_credentials_to_profile
+from transformerlab.services.provider_service import get_team_provider
 from transformerlab.services.cache_service import cached
 from transformerlab.schemas.compute_providers import (
     ProviderCreate,
@@ -101,3 +105,31 @@ async def check_provider(
     team_id = user_and_team["team_id"]
     user_id_str = str(user_and_team["user"].id)
     return await team_provider_endpoints.check_provider_accessible(session, team_id, provider_id, user_id_str)
+
+
+class AwsCredentialsRequest(BaseModel):
+    access_key_id: str
+    secret_access_key: str
+
+
+@router.post("/{provider_id}/aws/credentials")
+async def set_aws_credentials(
+    provider_id: str,
+    body: AwsCredentialsRequest,
+    owner_info=Depends(require_team_owner),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Write AWS credentials for an AWS compute provider to ~/.aws/credentials."""
+    provider = await get_team_provider(session, owner_info["team_id"], provider_id)
+    if not provider:
+        raise HTTPException(status_code=404, detail="Provider not found")
+    if provider.type != "aws":
+        raise HTTPException(status_code=400, detail="Provider is not of type 'aws'")
+
+    config = json.loads(provider.config) if isinstance(provider.config, str) else (provider.config or {})
+    profile = config.get("aws_profile")
+    if not profile:
+        raise HTTPException(status_code=400, detail="Provider has no aws_profile configured")
+
+    write_aws_credentials_to_profile(profile, body.access_key_id, body.secret_access_key)
+    return {"status": "ok", "profile": profile}

--- a/api/transformerlab/schemas/compute_providers.py
+++ b/api/transformerlab/schemas/compute_providers.py
@@ -36,6 +36,9 @@ class ProviderConfigBase(BaseModel):
     ssh_key_path: Optional[str] = None
     ssh_port: int = 22
 
+    # AWS-specific config
+    region: Optional[str] = None  # AWS region (e.g. "us-east-1")
+
     # Runpod-specific config
     api_key: Optional[str] = None  # Runpod API key (sensitive)
     api_base_url: Optional[str] = None  # Defaults to https://rest.runpod.io/v1

--- a/api/transformerlab/services/compute_provider/launch_credentials.py
+++ b/api/transformerlab/services/compute_provider/launch_credentials.py
@@ -109,3 +109,34 @@ def generate_azure_credentials_setup(
 
     exports.append("echo 'Azure storage credentials configured successfully'")
     return "; ".join(exports)
+
+
+def _aws_credentials_path() -> str:
+    return os.path.join(os.path.expanduser("~"), ".aws", "credentials")
+
+
+def write_aws_credentials_to_profile(
+    profile_name: str,
+    access_key_id: str,
+    secret_access_key: str,
+) -> None:
+    """Write AWS credentials to ~/.aws/credentials under the given profile name.
+
+    Creates the file and directory if they don't exist. Overwrites the profile
+    if it already exists, preserving all other profiles.
+    """
+    creds_path = _aws_credentials_path()
+    os.makedirs(os.path.dirname(creds_path), exist_ok=True)
+
+    config = configparser.ConfigParser()
+    if os.path.exists(creds_path):
+        config.read(creds_path)
+
+    config[profile_name] = {
+        "aws_access_key_id": access_key_id,
+        "aws_secret_access_key": secret_access_key,
+    }
+
+    with open(creds_path, "w", encoding="utf-8") as f:
+        config.write(f)
+    os.chmod(creds_path, 0o600)

--- a/api/transformerlab/services/compute_provider/launch_credentials.py
+++ b/api/transformerlab/services/compute_provider/launch_credentials.py
@@ -131,7 +131,9 @@ def write_aws_credentials_to_profile(
     if it already exists, preserving all other profiles.
     """
     creds_path = _aws_credentials_path()
-    os.makedirs(os.path.dirname(creds_path), exist_ok=True)
+    creds_dir = os.path.dirname(creds_path)
+    os.makedirs(creds_dir, exist_ok=True)
+    os.chmod(creds_dir, 0o700)
 
     config = configparser.ConfigParser()
     if os.path.exists(creds_path):

--- a/api/transformerlab/services/compute_provider/launch_sweep.py
+++ b/api/transformerlab/services/compute_provider/launch_sweep.py
@@ -220,7 +220,7 @@ async def launch_sweep_jobs(
                 if tfl_storage_uri:
                     env_vars["TFL_STORAGE_URI"] = tfl_storage_uri
 
-                if provider.type in (ProviderType.RUNPOD.value, ProviderType.AWS.value):
+                if provider.type == ProviderType.RUNPOD.value:
                     env_vars["UV_SYSTEM_PYTHON"] = "1"
 
                 if provider.type == ProviderType.LOCAL.value and team_id:

--- a/api/transformerlab/services/compute_provider/launch_sweep.py
+++ b/api/transformerlab/services/compute_provider/launch_sweep.py
@@ -220,7 +220,7 @@ async def launch_sweep_jobs(
                 if tfl_storage_uri:
                     env_vars["TFL_STORAGE_URI"] = tfl_storage_uri
 
-                if provider.type == ProviderType.RUNPOD.value:
+                if provider.type in (ProviderType.RUNPOD.value, ProviderType.AWS.value):
                     env_vars["UV_SYSTEM_PYTHON"] = "1"
 
                 if provider.type == ProviderType.LOCAL.value and team_id:

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -270,9 +270,8 @@ async def launch_template_on_provider(
             setup_commands.append("pip install -q torch")
     if request.file_mounts is True and request.task_id:
         setup_commands.append(COPY_FILE_MOUNTS_SETUP)
-    # For RunPod/AWS providers, tell uv to use system Python.
-    # This allows user commands to invoke `uv` directly without a dedicated venv.
-    if provider.type in (ProviderType.RUNPOD.value, ProviderType.AWS.value):
+    # For RunPod providers, tell uv to use system Python.
+    if provider.type == ProviderType.RUNPOD.value:
         env_vars["UV_SYSTEM_PYTHON"] = "1"
     # RunPod still needs explicit uv install in setup. AWS bootstrap handles it in user-data.
     if provider.type == ProviderType.RUNPOD.value:

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -270,10 +270,12 @@ async def launch_template_on_provider(
             setup_commands.append("pip install -q torch")
     if request.file_mounts is True and request.task_id:
         setup_commands.append(COPY_FILE_MOUNTS_SETUP)
-    # For RunPod providers, ensure uv is available and configured to use the
-    # system Python. This allows user commands to invoke `uv` directly.
-    if provider.type == ProviderType.RUNPOD.value:
+    # For RunPod/AWS providers, tell uv to use system Python.
+    # This allows user commands to invoke `uv` directly without a dedicated venv.
+    if provider.type in (ProviderType.RUNPOD.value, ProviderType.AWS.value):
         env_vars["UV_SYSTEM_PYTHON"] = "1"
+    # RunPod still needs explicit uv install in setup. AWS bootstrap handles it in user-data.
+    if provider.type == ProviderType.RUNPOD.value:
         setup_commands.append("curl -LsSf https://astral.sh/uv/install.sh | sh")
 
     # If GitHub repo fields are missing, fall back to the stored task's fields.

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -272,11 +272,9 @@ async def launch_template_on_provider(
             setup_commands.append("pip install -q torch")
     if request.file_mounts is True and request.task_id:
         setup_commands.append(COPY_FILE_MOUNTS_SETUP)
-    # For RunPod providers, tell uv to use system Python.
+    # For RunPod providers, tell uv to use system Python and also install uv.
     if provider.type == ProviderType.RUNPOD.value:
         env_vars["UV_SYSTEM_PYTHON"] = "1"
-    # RunPod still needs explicit uv install in setup. AWS bootstrap handles it in user-data.
-    if provider.type == ProviderType.RUNPOD.value:
         setup_commands.append("curl -LsSf https://astral.sh/uv/install.sh | sh")
 
     # If GitHub repo fields are missing, fall back to the stored task's fields.

--- a/api/transformerlab/services/compute_provider/remote_job_endpoints_service.py
+++ b/api/transformerlab/services/compute_provider/remote_job_endpoints_service.py
@@ -266,8 +266,9 @@ async def resume_remote_job_from_checkpoint(
         )
         setup_commands.append(github_setup)
 
-    if provider.type == ProviderType.RUNPOD.value:
+    if provider.type in (ProviderType.RUNPOD.value, ProviderType.AWS.value):
         env_vars["UV_SYSTEM_PYTHON"] = "1"
+    if provider.type == ProviderType.RUNPOD.value:
         setup_commands.append("curl -LsSf https://astral.sh/uv/install.sh | sh")
 
     original_setup = job_data.get("setup")

--- a/api/transformerlab/services/compute_provider/remote_job_endpoints_service.py
+++ b/api/transformerlab/services/compute_provider/remote_job_endpoints_service.py
@@ -266,7 +266,7 @@ async def resume_remote_job_from_checkpoint(
         )
         setup_commands.append(github_setup)
 
-    if provider.type in (ProviderType.RUNPOD.value, ProviderType.AWS.value):
+    if provider.type == ProviderType.RUNPOD.value:
         env_vars["UV_SYSTEM_PYTHON"] = "1"
     if provider.type == ProviderType.RUNPOD.value:
         setup_commands.append("curl -LsSf https://astral.sh/uv/install.sh | sh")

--- a/api/transformerlab/services/compute_provider/team_provider_endpoints.py
+++ b/api/transformerlab/services/compute_provider/team_provider_endpoints.py
@@ -17,6 +17,7 @@ from transformerlab.services.compute_provider.local_setup_service import (
 )
 from transformerlab.services.provider_service import (
     _local_providers_disabled,
+    build_aws_profile_name,
     create_team_provider,
     delete_team_provider,
     detect_local_supported_accelerators,
@@ -103,9 +104,8 @@ async def create_provider_for_team(
 
     config_dict = provider_data.config.model_dump(exclude_none=True)
 
-    # Auto-inject aws_profile and team_id for AWS providers
+    # Auto-inject team_id for AWS providers; aws_profile is finalized after provider ID exists.
     if provider_data.type == ProviderType.AWS:
-        config_dict.setdefault("aws_profile", f"transformerlab-compute-{team_id}")
         config_dict["team_id"] = team_id
 
     provider = await create_team_provider(
@@ -118,6 +118,20 @@ async def create_provider_for_team(
         config=config_dict,
         created_by_user_id=str(user.id),
     )
+
+    if provider.type == ProviderType.AWS.value:
+        provider_config = dict(provider.config or {})
+        if not provider_config.get("aws_profile"):
+            provider_config["aws_profile"] = build_aws_profile_name(team_id, str(provider.id))
+            provider_config["team_id"] = team_id
+            provider = await update_team_provider(
+                session=session,
+                provider=provider,
+                name=None,
+                config=provider_config,
+                disabled=None,
+                is_default=None,
+            )
 
     await cache.invalidate("providers")
 
@@ -198,7 +212,6 @@ async def update_provider_for_team(
             new_config.pop("api_key", None)
         update_config = {**existing_config, **new_config}
         if provider.type == ProviderType.AWS.value:
-            update_config.setdefault("aws_profile", f"transformerlab-compute-{team_id}")
             update_config["team_id"] = team_id
 
     update_disabled = provider_data.disabled if provider_data.disabled is not None else None

--- a/api/transformerlab/services/compute_provider/team_provider_endpoints.py
+++ b/api/transformerlab/services/compute_provider/team_provider_endpoints.py
@@ -197,6 +197,9 @@ async def update_provider_for_team(
         if new_config.get("api_key") == "***":
             new_config.pop("api_key", None)
         update_config = {**existing_config, **new_config}
+        if provider.type == ProviderType.AWS.value:
+            update_config.setdefault("aws_profile", f"transformerlab-compute-{team_id}")
+            update_config["team_id"] = team_id
 
     update_disabled = provider_data.disabled if provider_data.disabled is not None else None
     update_is_default = provider_data.is_default if provider_data.is_default is not None else None

--- a/api/transformerlab/services/compute_provider/team_provider_endpoints.py
+++ b/api/transformerlab/services/compute_provider/team_provider_endpoints.py
@@ -82,6 +82,7 @@ async def create_provider_for_team(
         ProviderType.RUNPOD,
         ProviderType.LOCAL,
         ProviderType.DSTACK,
+        ProviderType.AWS,
     ]
     if provider_data.type not in allowed_provider_types:
         allowed_values = ", ".join(provider_type.value for provider_type in allowed_provider_types)
@@ -101,6 +102,11 @@ async def create_provider_for_team(
             )
 
     config_dict = provider_data.config.model_dump(exclude_none=True)
+
+    # Auto-inject aws_profile and team_id for AWS providers
+    if provider_data.type == ProviderType.AWS:
+        config_dict.setdefault("aws_profile", f"transformerlab-compute-{team_id}")
+        config_dict["team_id"] = team_id
 
     provider = await create_team_provider(
         session=session,

--- a/api/transformerlab/services/provider_service.py
+++ b/api/transformerlab/services/provider_service.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import platform
+import re
 import sys
 from typing import List, Optional
 
@@ -17,6 +18,24 @@ from transformerlab.compute_providers.local import _check_amd_gpu, _check_nvidia
 from transformerlab.shared.models.models import AcceleratorType, ProviderType, Team, TeamComputeProvider, User, UserTeam
 
 logger = logging.getLogger(__name__)
+
+
+def _short_identifier(value: str, max_len: int = 8) -> str:
+    """Return a compact, stable identifier segment for names like AWS profiles."""
+    normalized = re.sub(r"[^A-Za-z0-9_-]", "-", str(value).lower())
+    normalized = re.sub(r"-+", "-", normalized).strip("-")
+    if not normalized:
+        return "id"
+    if len(normalized) <= max_len:
+        return normalized
+    return normalized[:max_len].rstrip("-") or normalized[:max_len]
+
+
+def build_aws_profile_name(team_id: str, provider_identifier: str) -> str:
+    """Generate a stable AWS profile name unique per org/provider."""
+    short_team = _short_identifier(team_id)
+    short_provider = _short_identifier(provider_identifier)
+    return f"tlab-compute-{short_team}-{short_provider}"
 
 
 def _local_providers_disabled() -> bool:
@@ -257,9 +276,7 @@ def db_record_to_provider_config(
         default_template_id=config_dict.get("default_template_id"),
         default_network_volume_id=config_dict.get("default_network_volume_id"),
         supported_accelerators=config_dict.get("supported_accelerators"),
-        aws_profile=config_dict.get("aws_profile")
-        if config_dict.get("aws_profile")
-        else (f"transformerlab-compute-{record.team_id}" if record.type == ProviderType.AWS.value else None),
+        aws_profile=config_dict.get("aws_profile"),
         region=config_dict.get("region"),
         team_id=config_dict.get("team_id") or (record.team_id if record.type == ProviderType.AWS.value else None),
         extra_config=extra_config,

--- a/api/transformerlab/services/provider_service.py
+++ b/api/transformerlab/services/provider_service.py
@@ -257,6 +257,11 @@ def db_record_to_provider_config(
         default_template_id=config_dict.get("default_template_id"),
         default_network_volume_id=config_dict.get("default_network_volume_id"),
         supported_accelerators=config_dict.get("supported_accelerators"),
+        aws_profile=config_dict.get("aws_profile")
+        if config_dict.get("aws_profile")
+        else (f"transformerlab-compute-{record.team_id}" if record.type == ProviderType.AWS.value else None),
+        region=config_dict.get("region"),
+        team_id=config_dict.get("team_id") or (record.team_id if record.type == ProviderType.AWS.value else None),
         extra_config=extra_config,
     )
     # Local provider has no extra required config; workspace_dir is set at launch from get_workspace_dir()

--- a/api/transformerlab/services/remote_job_status_service.py
+++ b/api/transformerlab/services/remote_job_status_service.py
@@ -223,8 +223,8 @@ async def _check_job_via_provider(
 
     is_interactive = _is_interactive_subtype_job(job)
 
-    if provider_type in (ProviderType.LOCAL.value, ProviderType.RUNPOD.value):
-        # LOCAL and RUNPOD: the pod/process itself is the job — check cluster state.
+    if provider_type in (ProviderType.LOCAL.value, ProviderType.RUNPOD.value, ProviderType.AWS.value):
+        # LOCAL/RUNPOD/AWS: cluster state directly represents job lifecycle.
         if provider_type == ProviderType.LOCAL.value and job_data.get("workspace_dir"):
             if hasattr(provider_instance, "extra_config"):
                 provider_instance.extra_config["workspace_dir"] = job_data["workspace_dir"]

--- a/api/transformerlab/shared/models/models.py
+++ b/api/transformerlab/shared/models/models.py
@@ -132,6 +132,7 @@ class ProviderType(str, enum.Enum):
     RUNPOD = "runpod"
     LOCAL = "local"
     DSTACK = "dstack"
+    AWS = "aws"
 
 
 class AcceleratorType(str, enum.Enum):

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -1022,14 +1022,29 @@ export default function ProviderDetailsModal({
                         </Option>
                       ))}
                     </Select>
-                    <Typography
-                      level="body-sm"
-                      sx={{ mt: 0.5, color: 'text.tertiary' }}
-                    >
-                      {providerId
-                        ? 'Provider type cannot be changed after creation'
-                        : ''}
-                    </Typography>
+                    {providerId ? (
+                      <Typography
+                        level="body-sm"
+                        sx={{ mt: 0.5, color: 'text.tertiary' }}
+                      >
+                        Provider type cannot be changed after creation
+                      </Typography>
+                    ) : (
+                      <Box sx={{ mt: 0.5 }}>
+                        <Button
+                          variant="plain"
+                          size="sm"
+                          onClick={() => {
+                            setType('');
+                            setNameError(null);
+                          }}
+                          disabled={loading || isSetupInProgress}
+                          sx={{ px: 0 }}
+                        >
+                          Change
+                        </Button>
+                      </Box>
+                    )}
                   </FormControl>
                   <FormControl required error={!!nameError} sx={{ mt: 1 }}>
                     <FormLabel>Compute Provider Name</FormLabel>
@@ -1255,18 +1270,6 @@ export default function ProviderDetailsModal({
                   {setupStatus}
                 </Typography>
               )}
-              {!providerId && type ? (
-                <Button
-                  variant="plain"
-                  onClick={() => {
-                    setType('');
-                    setNameError(null);
-                  }}
-                  disabled={loading || isSetupInProgress}
-                >
-                  Change Provider Type
-                </Button>
-              ) : null}
               <Button variant="outlined" onClick={onClose}>
                 Cancel
               </Button>

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -64,6 +64,9 @@ const DEFAULT_CONFIGS = {
   "dstack_project": "<Your dstack project name e.g. main>"
 }`,
   local: `{}`,
+  aws: `{
+  "region": "us-east-1"
+}`,
 } as const;
 
 const DEFAULT_SUPPORTED_ACCELERATORS: Record<string, string[]> = {
@@ -72,6 +75,7 @@ const DEFAULT_SUPPORTED_ACCELERATORS: Record<string, string[]> = {
   runpod: ['NVIDIA'],
   dstack: ['NVIDIA'],
   local: ['AppleSilicon', 'cpu'],
+  aws: ['NVIDIA'],
 };
 
 export default function ProviderDetailsModal({
@@ -127,6 +131,14 @@ export default function ProviderDetailsModal({
   const [runpodApiKey, setRunpodApiKey] = useState('');
   const [runpodApiKeyChanged, setRunpodApiKeyChanged] = useState(false);
   const [runpodApiBaseUrl, setRunpodApiBaseUrl] = useState('');
+
+  // AWS-specific form fields
+  const [awsRegion, setAwsRegion] = useState('us-east-1');
+  const [awsAccessKeyId, setAwsAccessKeyId] = useState('');
+  const [awsSecretAccessKey, setAwsSecretAccessKey] = useState('');
+  const [awsCredsSaved, setAwsCredsSaved] = useState(false);
+  const [awsCredsSaving, setAwsCredsSaving] = useState(false);
+  const [awsCredsExpanded, setAwsCredsExpanded] = useState(false);
 
   const { fetchWithAuth } = useAuth();
   const { data: providerData, isLoading: providerDataLoading } = useAPI(
@@ -324,6 +336,23 @@ export default function ProviderDetailsModal({
     providerId,
   ]);
 
+  const parseAwsConfig = (configObj: any) => {
+    if (configObj && typeof configObj === 'object') {
+      setAwsRegion(configObj.region || 'us-east-1');
+      if (configObj.supported_accelerators) {
+        setSupportedAccelerators(configObj.supported_accelerators);
+      }
+    }
+  };
+
+  const buildAwsConfig = useCallback(() => {
+    const configObj: any = { region: awsRegion };
+    if (supportedAccelerators.length > 0) {
+      configObj.supported_accelerators = supportedAccelerators;
+    }
+    return configObj;
+  }, [awsRegion, supportedAccelerators]);
+
   // if a providerId is passed then we are editing an existing provider
   // Otherwise we are creating a new provider
   useEffect(() => {
@@ -373,6 +402,9 @@ export default function ProviderDetailsModal({
       if (providerData.type === 'runpod') {
         parseRunpodConfig(rawConfigObj);
       }
+      if (providerData.type === 'aws') {
+        parseAwsConfig(rawConfigObj);
+      }
       setConfig(JSON.stringify(rawConfigObj, null, 2));
     } else if (!providerId) {
       // Reset form when in "add" mode (no providerId)
@@ -407,6 +439,11 @@ export default function ProviderDetailsModal({
       setRunpodApiKey('');
       setRunpodApiKeyChanged(false);
       setRunpodApiBaseUrl('');
+      setAwsRegion('us-east-1');
+      setAwsAccessKeyId('');
+      setAwsSecretAccessKey('');
+      setAwsCredsSaved(false);
+      setAwsCredsExpanded(false);
     }
   }, [providerId, providerData]);
 
@@ -447,6 +484,11 @@ export default function ProviderDetailsModal({
       setRunpodApiKey('');
       setRunpodApiKeyChanged(false);
       setRunpodApiBaseUrl('');
+      setAwsRegion('us-east-1');
+      setAwsAccessKeyId('');
+      setAwsSecretAccessKey('');
+      setAwsCredsSaved(false);
+      setAwsCredsExpanded(false);
     }
   }, [open]);
 
@@ -530,6 +572,14 @@ export default function ProviderDetailsModal({
           // Ignore parse errors
         }
       }
+      if (type === 'aws') {
+        try {
+          const configObj = JSON.parse(DEFAULT_CONFIGS['aws']);
+          parseAwsConfig(configObj);
+        } catch (e) {
+          // Ignore parse errors
+        }
+      }
     }
   }, [type, providerId]);
 
@@ -553,12 +603,17 @@ export default function ProviderDetailsModal({
         const configObj = buildRunpodConfig();
         setConfig(JSON.stringify(configObj, null, 2));
       }
+      if (type === 'aws') {
+        const configObj = buildAwsConfig();
+        setConfig(JSON.stringify(configObj, null, 2));
+      }
     }
   }, [
     buildSlurmConfig,
     buildSkypilotConfig,
     buildDstackConfig,
     buildRunpodConfig,
+    buildAwsConfig,
     type,
     providerId,
   ]);
@@ -690,6 +745,8 @@ export default function ProviderDetailsModal({
         parsedConfig = buildDstackConfig();
       } else if (type === 'runpod') {
         parsedConfig = buildRunpodConfig();
+      } else if (type === 'aws') {
+        parsedConfig = buildAwsConfig();
       } else if (type === 'local') {
         // Local providers are configured via supported accelerators only
         parsedConfig = {};
@@ -847,6 +904,7 @@ export default function ProviderDetailsModal({
                   <Option value="slurm">SLURM</Option>
                   <Option value="runpod">Runpod</Option>
                   <Option value="dstack">dstack</Option>
+                  <Option value="aws">AWS (beta)</Option>
                   {!hasLocalProvider && !providerId && (
                     <Option value="local">Local</Option>
                   )}
@@ -1241,12 +1299,169 @@ export default function ProviderDetailsModal({
                 </>
               )}
 
+              {type === 'aws' && (
+                <>
+                  <FormControl sx={{ mt: 2 }}>
+                    <FormLabel>Region *</FormLabel>
+                    <Input
+                      value={awsRegion}
+                      onChange={(event) =>
+                        setAwsRegion(event.currentTarget.value)
+                      }
+                      placeholder="us-east-1"
+                      fullWidth
+                    />
+                    <Typography
+                      level="body-sm"
+                      sx={{ mt: 0.5, color: 'text.tertiary' }}
+                    >
+                      AWS region where instances will be launched.
+                    </Typography>
+                  </FormControl>
+
+                  {providerId &&
+                    (() => {
+                      const cfg =
+                        typeof providerData?.config === 'string'
+                          ? (() => {
+                              try {
+                                return JSON.parse(providerData.config);
+                              } catch {
+                                return {};
+                              }
+                            })()
+                          : providerData?.config || {};
+                      return cfg?.aws_profile ? (
+                        <FormControl sx={{ mt: 1 }}>
+                          <FormLabel>AWS Profile</FormLabel>
+                          <Typography
+                            level="body-sm"
+                            sx={{
+                              color: 'text.secondary',
+                              fontFamily: 'monospace',
+                            }}
+                          >
+                            {cfg.aws_profile}
+                          </Typography>
+                          <Typography
+                            level="body-sm"
+                            sx={{ mt: 0.5, color: 'text.tertiary' }}
+                          >
+                            Configure this profile in your AWS CLI or use the
+                            section below.
+                          </Typography>
+                        </FormControl>
+                      ) : null;
+                    })()}
+
+                  {providerId && (
+                    <Box sx={{ mt: 1 }}>
+                      <Button
+                        variant="plain"
+                        size="sm"
+                        onClick={() => setAwsCredsExpanded((v) => !v)}
+                        endDecorator={
+                          awsCredsExpanded ? (
+                            <ChevronDownIcon size={14} />
+                          ) : (
+                            <ChevronRightIcon size={14} />
+                          )
+                        }
+                        sx={{ pl: 0 }}
+                      >
+                        Configure AWS Credentials
+                      </Button>
+                      {awsCredsExpanded && (
+                        <Box
+                          sx={{
+                            mt: 1,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 1,
+                          }}
+                        >
+                          <FormControl>
+                            <FormLabel>Access Key ID</FormLabel>
+                            <Input
+                              value={awsAccessKeyId}
+                              onChange={(e) =>
+                                setAwsAccessKeyId(e.currentTarget.value)
+                              }
+                              placeholder="AKIA..."
+                              fullWidth
+                            />
+                          </FormControl>
+                          <FormControl>
+                            <FormLabel>Secret Access Key</FormLabel>
+                            <Input
+                              value={awsSecretAccessKey}
+                              onChange={(e) =>
+                                setAwsSecretAccessKey(e.currentTarget.value)
+                              }
+                              type="password"
+                              placeholder="Your AWS secret access key"
+                              fullWidth
+                            />
+                          </FormControl>
+                          <Button
+                            size="sm"
+                            variant="outlined"
+                            loading={awsCredsSaving}
+                            color={awsCredsSaved ? 'success' : 'primary'}
+                            onClick={async () => {
+                              setAwsCredsSaving(true);
+                              try {
+                                const resp = await fetchWithAuth(
+                                  Endpoints.ComputeProvider.AwsCredentials(
+                                    providerId,
+                                  ),
+                                  {
+                                    method: 'POST',
+                                    headers: {
+                                      'Content-Type': 'application/json',
+                                    },
+                                    body: JSON.stringify({
+                                      access_key_id: awsAccessKeyId,
+                                      secret_access_key: awsSecretAccessKey,
+                                    }),
+                                  },
+                                );
+                                if (resp.ok) {
+                                  setAwsCredsSaved(true);
+                                  addNotification({
+                                    type: 'success',
+                                    message: 'AWS credentials saved.',
+                                  });
+                                } else {
+                                  addNotification({
+                                    type: 'danger',
+                                    message: 'Failed to save AWS credentials.',
+                                  });
+                                }
+                              } finally {
+                                setAwsCredsSaving(false);
+                              }
+                            }}
+                            sx={{ alignSelf: 'flex-start' }}
+                          >
+                            {awsCredsSaved
+                              ? 'Credentials Saved'
+                              : 'Save Credentials'}
+                          </Button>
+                        </Box>
+                      )}
+                    </Box>
+                  )}
+                </>
+              )}
+
               {/* Generic JSON config for non-structured providers or advanced editing */}
               {type !== 'slurm' &&
                 type !== 'skypilot' &&
                 type !== 'dstack' &&
                 type !== 'runpod' &&
-                type !== 'local' && (
+                type !== 'local' &&
+                type !== 'aws' && (
                   <FormControl sx={{ mt: 1 }}>
                     <FormLabel>Configuration</FormLabel>
                     <Textarea

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/require-default-props */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
@@ -18,14 +18,21 @@ import {
   FormLabel,
   FormHelperText,
   Textarea,
-  Alert,
   Chip,
-  Switch,
 } from '@mui/joy';
 import { useAPI, useAuth } from 'renderer/lib/authContext';
 import { getPath } from 'renderer/lib/api-client/urls';
 import { Endpoints } from 'renderer/lib/api-client/endpoints';
 import { useNotification } from 'renderer/components/Shared/NotificationSystem';
+import ProviderTypePicker, {
+  ProviderTypeOption,
+} from './providerForms/ProviderTypePicker';
+import SlurmProviderFields from './providerForms/SlurmProviderFields';
+import SkypilotProviderFields from './providerForms/SkypilotProviderFields';
+import DstackProviderFields from './providerForms/DstackProviderFields';
+import RunpodProviderFields from './providerForms/RunpodProviderFields';
+import AwsProviderFields from './providerForms/AwsProviderFields';
+import LocalProviderFields from './providerForms/LocalProviderFields';
 
 interface ProviderDetailsModalProps {
   open: boolean;
@@ -100,7 +107,6 @@ export default function ProviderDetailsModal({
   const [postTaskHook, setPostTaskHook] = useState<string>('');
   const [preSetupHook, setPreSetupHook] = useState<string>('');
   const [postSetupHook, setPostSetupHook] = useState<string>('');
-  const [hooksExpanded, setHooksExpanded] = useState(false);
   const [forceRefresh, setForceRefresh] = useState(false);
 
   // SLURM-specific form fields
@@ -147,6 +153,61 @@ export default function ProviderDetailsModal({
       skip: !providerId,
     },
   );
+
+  const providerTypeOptions = useMemo<ProviderTypeOption[]>(() => {
+    const baseOptions: ProviderTypeOption[] = [
+      {
+        value: 'skypilot',
+        label: 'SkyPilot',
+        description: 'Remote cloud orchestration through a SkyPilot server.',
+      },
+      {
+        value: 'slurm',
+        label: 'SLURM',
+        description: 'Use a SLURM cluster through SSH or REST.',
+      },
+      {
+        value: 'runpod',
+        label: 'RunPod',
+        description: 'Run workloads on RunPod infrastructure.',
+      },
+      {
+        value: 'dstack',
+        label: 'dstack',
+        description: 'Connect to your dstack control plane.',
+      },
+      {
+        value: 'aws',
+        label: 'AWS (beta)',
+        description: 'Launch and manage compute on AWS.',
+      },
+    ];
+
+    if (!hasLocalProvider || providerId) {
+      baseOptions.push({
+        value: 'local',
+        label: 'Local',
+        description: 'Run jobs on this machine using local resources.',
+      });
+    }
+
+    return baseOptions;
+  }, [hasLocalProvider, providerId]);
+
+  const awsProfile = useMemo(() => {
+    if (!providerId) return undefined;
+    const configObj =
+      typeof providerData?.config === 'string'
+        ? (() => {
+            try {
+              return JSON.parse(providerData.config);
+            } catch {
+              return {};
+            }
+          })()
+        : providerData?.config || {};
+    return configObj?.aws_profile;
+  }, [providerData?.config, providerId]);
 
   // Helper to parse config and extract SkyPilot fields
   const parseSkypilotConfig = (configObj: any) => {
@@ -495,7 +556,7 @@ export default function ProviderDetailsModal({
       // out of the raw JSON configuration.
       if (type === 'local') {
         // Optimistic defaults while we query the backend for real detection.
-        setSupportedAccelerators(DEFAULT_SUPPORTED_ACCELERATORS['local'] || []);
+        setSupportedAccelerators(DEFAULT_SUPPORTED_ACCELERATORS.local || []);
 
         let cancelled = false;
         const detectLocal = async () => {
@@ -566,14 +627,15 @@ export default function ProviderDetailsModal({
       }
       if (type === 'aws') {
         try {
-          const configObj = JSON.parse(DEFAULT_CONFIGS['aws']);
+          const configObj = JSON.parse(DEFAULT_CONFIGS.aws);
           parseAwsConfig(configObj);
         } catch (e) {
           // Ignore parse errors
         }
       }
     }
-  }, [type, providerId]);
+    return undefined;
+  }, [type, providerId, fetchWithAuth]);
 
   // Update config JSON when form fields change
   useEffect(() => {
@@ -778,9 +840,14 @@ export default function ProviderDetailsModal({
       const hasAwsCreds = Boolean(
         trimmedAwsAccessKeyId && trimmedAwsSecretAccessKey,
       );
+      const hasOnlyAccessKeyId = Boolean(
+        trimmedAwsAccessKeyId && !trimmedAwsSecretAccessKey,
+      );
+      const hasOnlySecretAccessKey = Boolean(
+        !trimmedAwsAccessKeyId && trimmedAwsSecretAccessKey,
+      );
       const hasPartialAwsCreds = Boolean(
-        (trimmedAwsAccessKeyId && !trimmedAwsSecretAccessKey) ||
-        (!trimmedAwsAccessKeyId && trimmedAwsSecretAccessKey),
+        hasOnlyAccessKeyId || hasOnlySecretAccessKey,
       );
       if (type === 'aws' && hasPartialAwsCreds) {
         addNotification({
@@ -870,7 +937,7 @@ export default function ProviderDetailsModal({
         // eslint-disable-next-line no-console
         console.error('Error updating provider:', errorData);
         let message = 'Could not save compute provider.';
-        const detail = (errorData as { detail?: unknown }).detail;
+        const { detail } = errorData as { detail?: unknown };
         let nameValidationMessage: string | null = null;
         if (typeof detail === 'string') {
           message = detail;
@@ -910,12 +977,20 @@ export default function ProviderDetailsModal({
     }
   };
 
+  const selectedProviderLabel =
+    providerTypeOptions.find((option) => option.value === type)?.label ||
+    'Compute Provider';
+  let dialogTitle = 'Add Compute Provider';
+  if (providerId) {
+    dialogTitle = 'Edit Compute Provider';
+  } else if (type) {
+    dialogTitle = `Add ${selectedProviderLabel}`;
+  }
+
   return (
     <Modal open={open} onClose={onClose}>
       <ModalDialog sx={{ gap: 0, width: 600, height: 700, overflow: 'auto' }}>
-        <DialogTitle>
-          {providerId ? 'Edit Compute Provider' : 'Add Compute Provider'}
-        </DialogTitle>
+        <DialogTitle>{dialogTitle}</DialogTitle>
         <DialogContent>
           {providerId && providerDataLoading ? (
             <Box
@@ -931,541 +1006,206 @@ export default function ProviderDetailsModal({
             </Box>
           ) : (
             <>
-              <FormControl sx={{ mt: 2 }}>
-                <FormLabel>Compute Provider Type</FormLabel>
-                <Select
-                  value={type}
-                  onChange={(event, value) => setType(value ?? 'skypilot')}
-                  disabled={!!providerId}
-                  sx={{ width: '100%' }}
-                >
-                  <Option value="skypilot">Skypilot</Option>
-                  <Option value="slurm">SLURM</Option>
-                  <Option value="runpod">Runpod</Option>
-                  <Option value="dstack">dstack</Option>
-                  <Option value="aws">AWS (beta)</Option>
-                  {!hasLocalProvider && !providerId && (
-                    <Option value="local">Local</Option>
-                  )}
-                </Select>
-                {providerId && (
-                  <Typography
-                    level="body-sm"
-                    sx={{ mt: 0.5, color: 'text.tertiary' }}
-                  >
-                    Provider type cannot be changed after creation
-                  </Typography>
-                )}
-              </FormControl>
-              <FormControl required error={!!nameError} sx={{ mt: 1 }}>
-                <FormLabel>Compute Provider Name</FormLabel>
-                <Input
-                  value={name}
-                  onChange={(event) => {
-                    setName(event.currentTarget.value);
-                    setNameError(null);
-                  }}
-                  placeholder="Enter friendly name for compute provider"
-                  fullWidth
-                  color={nameError ? 'danger' : undefined}
+              {!providerId && !type ? (
+                <ProviderTypePicker
+                  options={providerTypeOptions}
+                  onSelect={(selectedType) => setType(selectedType)}
                 />
-                {nameError ? (
-                  <FormHelperText>{nameError}</FormHelperText>
-                ) : null}
-              </FormControl>
-
-              {type === 'local' && !providerId && (
-                <FormControl
-                  orientation="horizontal"
-                  sx={{ mt: 1, alignItems: 'center', gap: 1 }}
-                >
-                  <Box>
-                    <FormLabel>Force fresh install</FormLabel>
-                    <Typography level="body-sm" sx={{ color: 'text.tertiary' }}>
-                      Delete the existing conda environment, install log, and
-                      config and run a clean install from scratch.
-                    </Typography>
-                  </Box>
-                  <Switch
-                    checked={forceRefresh}
-                    onChange={(e) => setForceRefresh(e.target.checked)}
-                  />
-                </FormControl>
-              )}
-
-              <FormControl sx={{ mt: 1 }}>
-                <FormLabel>Supported Accelerators</FormLabel>
-                <Select
-                  multiple
-                  value={supportedAccelerators}
-                  onChange={(event, newValue) =>
-                    setSupportedAccelerators(newValue)
-                  }
-                  renderValue={(selected) => (
-                    <Box sx={{ display: 'flex', gap: '0.25rem' }}>
-                      {selected.map((selectedOption) => (
-                        <Chip
-                          key={selectedOption.value}
-                          variant="soft"
-                          color="primary"
-                        >
-                          {selectedOption.label}
-                        </Chip>
+              ) : (
+                <>
+                  <FormControl sx={{ mt: 2 }}>
+                    <FormLabel>Compute Provider Type</FormLabel>
+                    <Select value={type} disabled sx={{ width: '100%' }}>
+                      {providerTypeOptions.map((option) => (
+                        <Option key={option.value} value={option.value}>
+                          {option.label}
+                        </Option>
                       ))}
-                    </Box>
-                  )}
-                  placeholder="Select supported accelerators"
-                  sx={{ width: '100%' }}
-                  slotProps={{
-                    listbox: {
-                      sx: {
-                        width: '100%',
-                      },
-                    },
-                  }}
-                >
-                  {ACCELERATOR_OPTIONS.map((option) => (
-                    <Option key={option} value={option}>
-                      {option}
-                    </Option>
-                  ))}
-                </Select>
-                <Typography
-                  level="body-sm"
-                  sx={{ mt: 0.5, color: 'text.tertiary' }}
-                >
-                  Select the types of hardware this provider supports.
-                </Typography>
-              </FormControl>
-
-              {/* SLURM-specific form fields */}
-              {type === 'slurm' && (
-                <>
-                  <Alert color="primary" variant="soft" sx={{ mt: 2 }}>
-                    <Typography level="body-sm">
-                      <strong>SLURM User ID:</strong> All jobs launched through
-                      this provider will run as the specified SLURM user. Make
-                      sure your team&apos;s SSH key (from Team Settings → SSH
-                      Key) is added to that user&apos;s authorized_keys on the
-                      SLURM login node.
-                    </Typography>
-                  </Alert>
-
-                  <FormControl sx={{ mt: 2 }}>
-                    <FormLabel>Connection Mode</FormLabel>
-                    <Select
-                      value={slurmMode}
-                      onChange={(event, value) => setSlurmMode(value ?? 'ssh')}
-                      sx={{ width: '100%' }}
-                    >
-                      <Option value="ssh">SSH</Option>
-                      <Option value="rest">REST API</Option>
                     </Select>
+                    <Typography
+                      level="body-sm"
+                      sx={{ mt: 0.5, color: 'text.tertiary' }}
+                    >
+                      {providerId
+                        ? 'Provider type cannot be changed after creation'
+                        : 'Use Cancel to close and choose a different provider type.'}
+                    </Typography>
                   </FormControl>
+                  <FormControl required error={!!nameError} sx={{ mt: 1 }}>
+                    <FormLabel>Compute Provider Name</FormLabel>
+                    <Input
+                      value={name}
+                      onChange={(event) => {
+                        setName(event.currentTarget.value);
+                        setNameError(null);
+                      }}
+                      placeholder="Enter friendly name for compute provider"
+                      fullWidth
+                      color={nameError ? 'danger' : undefined}
+                    />
+                    {nameError ? (
+                      <FormHelperText>{nameError}</FormHelperText>
+                    ) : null}
+                  </FormControl>
+                </>
+              )}
 
-                  {slurmMode === 'ssh' ? (
-                    <>
-                      <FormControl sx={{ mt: 1 }}>
-                        <FormLabel>SSH Host *</FormLabel>
-                        <Input
-                          value={slurmSshHost}
-                          onChange={(event) =>
-                            setSlurmSshHost(event.currentTarget.value)
-                          }
-                          placeholder="slurm-login.example.com"
-                          fullWidth
-                        />
-                      </FormControl>
-                      <FormControl sx={{ mt: 1 }}>
-                        <FormLabel>SLURM User ID *</FormLabel>
-                        <Input
-                          value={slurmSshUser}
-                          onChange={(event) =>
-                            setSlurmSshUser(event.currentTarget.value)
-                          }
-                          placeholder="your_slurm_username"
-                          fullWidth
-                        />
-                        <Typography
-                          level="body-sm"
-                          sx={{ mt: 0.5, color: 'text.tertiary' }}
-                        >
-                          All jobs will run as this user on SLURM
-                        </Typography>
-                      </FormControl>
-                      <FormControl sx={{ mt: 1 }}>
-                        <FormLabel>SSH Port</FormLabel>
-                        <Input
-                          value={slurmSshPort}
-                          onChange={(event) =>
-                            setSlurmSshPort(event.currentTarget.value)
-                          }
-                          placeholder="22"
-                          type="number"
-                          fullWidth
-                        />
-                      </FormControl>
-                      <FormControl sx={{ mt: 1 }}>
-                        <FormLabel>SSH Key Path (Optional)</FormLabel>
-                        <Input
-                          value={slurmSshKeyPath}
-                          onChange={(event) =>
-                            setSlurmSshKeyPath(event.currentTarget.value)
-                          }
-                          placeholder="Leave empty to use team SSH key"
-                          fullWidth
-                        />
-                        <Typography
-                          level="body-sm"
-                          sx={{ mt: 0.5, color: 'text.tertiary' }}
-                        >
-                          Path to private key on API server. If empty, will use
-                          your team&apos;s SSH key.
-                        </Typography>
-                      </FormControl>
-                    </>
-                  ) : (
-                    <>
-                      <FormControl sx={{ mt: 1 }}>
-                        <FormLabel>REST API URL *</FormLabel>
-                        <Input
-                          value={slurmRestUrl}
-                          onChange={(event) =>
-                            setSlurmRestUrl(event.currentTarget.value)
-                          }
-                          placeholder="https://slurm-api.example.com"
-                          fullWidth
-                        />
-                      </FormControl>
-                      <FormControl sx={{ mt: 1 }}>
-                        <FormLabel>SLURM User ID *</FormLabel>
-                        <Input
-                          value={slurmSshUser}
-                          onChange={(event) =>
-                            setSlurmSshUser(event.currentTarget.value)
-                          }
-                          placeholder="your_slurm_username"
-                          fullWidth
-                        />
-                        <Typography
-                          level="body-sm"
-                          sx={{ mt: 0.5, color: 'text.tertiary' }}
-                        >
-                          All jobs will run as this user on SLURM
-                        </Typography>
-                      </FormControl>
-                      <FormControl sx={{ mt: 1 }}>
-                        <FormLabel>API Token (Optional)</FormLabel>
-                        <Input
-                          value={slurmApiToken}
-                          onChange={(event) => {
-                            setSlurmApiTokenChanged(true);
-                            setSlurmApiToken(event.currentTarget.value);
-                          }}
-                          placeholder={
-                            providerId
-                              ? 'Leave blank to keep existing token'
-                              : 'Your SLURM REST API token'
-                          }
-                          type="password"
-                          fullWidth
-                        />
-                      </FormControl>
-                    </>
+              {(providerId || type) && (
+                <>
+                  {type === 'local' && !providerId && (
+                    <LocalProviderFields
+                      forceRefresh={forceRefresh}
+                      setForceRefresh={setForceRefresh}
+                    />
                   )}
-                </>
-              )}
 
-              {/* SkyPilot-specific form fields */}
-              {type === 'skypilot' && (
-                <>
-                  <FormControl sx={{ mt: 2 }}>
-                    <FormLabel>SkyPilot Server URL *</FormLabel>
-                    <Input
-                      value={skypilotServerUrl}
-                      onChange={(event) =>
-                        setSkypilotServerUrl(event.currentTarget.value)
-                      }
-                      placeholder="http://localhost:46580"
-                      fullWidth
-                    />
-                  </FormControl>
                   <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>SkyPilot User ID</FormLabel>
-                    <Input
-                      value={skypilotUserId}
-                      onChange={(event) =>
-                        setSkypilotUserId(event.currentTarget.value)
+                    <FormLabel>Supported Accelerators</FormLabel>
+                    <Select
+                      multiple
+                      value={supportedAccelerators}
+                      onChange={(event, newValue) =>
+                        setSupportedAccelerators(newValue)
                       }
-                      placeholder="Your SkyPilot user ID"
-                      fullWidth
-                    />
-                  </FormControl>
-                  <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>SkyPilot User Name</FormLabel>
-                    <Input
-                      value={skypilotUserName}
-                      onChange={(event) =>
-                        setSkypilotUserName(event.currentTarget.value)
-                      }
-                      placeholder="Your SkyPilot user name"
-                      fullWidth
-                    />
-                  </FormControl>
-                  <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>Docker Image (optional)</FormLabel>
-                    <Input
-                      value={skypilotDockerImage}
-                      onChange={(event) =>
-                        setSkypilotDockerImage(event.currentTarget.value)
-                      }
-                      placeholder="docker:nvcr.io/nvidia/pytorch:23.10-py3"
-                      fullWidth
-                      sx={{ fontFamily: 'monospace', fontSize: 'sm' }}
-                    />
-                    <Typography
-                      level="body-sm"
-                      sx={{ mt: 0.5, color: 'text.tertiary' }}
-                    >
-                      Prefix with &quot;docker:&quot; to run inside a container
-                      on the provisioned VM. Must be Debian/Ubuntu-based. Leave
-                      empty to run directly on the VM.
-                    </Typography>
-                  </FormControl>
-                  <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>Default Region (optional)</FormLabel>
-                    <Input
-                      value={skypilotDefaultRegion}
-                      onChange={(event) =>
-                        setSkypilotDefaultRegion(event.currentTarget.value)
-                      }
-                      placeholder="e.g. us-east-1"
-                      fullWidth
-                    />
-                  </FormControl>
-                  <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>Default Zone (optional)</FormLabel>
-                    <Input
-                      value={skypilotDefaultZone}
-                      onChange={(event) =>
-                        setSkypilotDefaultZone(event.currentTarget.value)
-                      }
-                      placeholder="e.g. us-east-1a"
-                      fullWidth
-                    />
-                  </FormControl>
-                  <FormControl
-                    sx={{ mt: 1, flexDirection: 'row', alignItems: 'center' }}
-                  >
-                    <Switch
-                      checked={skypilotUseSpot}
-                      onChange={(event) =>
-                        setSkypilotUseSpot(event.target.checked)
-                      }
-                      sx={{ mr: 1 }}
-                    />
-                    <FormLabel sx={{ m: 0 }}>
-                      Use Spot / Preemptible Instances
-                    </FormLabel>
-                  </FormControl>
-                </>
-              )}
-
-              {type === 'dstack' && (
-                <>
-                  <FormControl sx={{ mt: 2 }}>
-                    <FormLabel>dstack Server URL *</FormLabel>
-                    <Input
-                      value={dstackServerUrl}
-                      onChange={(event) =>
-                        setDstackServerUrl(event.currentTarget.value)
-                      }
-                      placeholder="http://0.0.0.0:3000"
-                      fullWidth
-                    />
-                  </FormControl>
-                  <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>dstack API Token *</FormLabel>
-                    <Input
-                      value={dstackApiToken}
-                      onChange={(event) => {
-                        setDstackApiTokenChanged(true);
-                        setDstackApiToken(event.currentTarget.value);
+                      renderValue={(selected) => (
+                        <Box sx={{ display: 'flex', gap: '0.25rem' }}>
+                          {selected.map((selectedOption) => (
+                            <Chip
+                              key={selectedOption.value}
+                              variant="soft"
+                              color="primary"
+                            >
+                              {selectedOption.label}
+                            </Chip>
+                          ))}
+                        </Box>
+                      )}
+                      placeholder="Select supported accelerators"
+                      sx={{ width: '100%' }}
+                      slotProps={{
+                        listbox: {
+                          sx: {
+                            width: '100%',
+                          },
+                        },
                       }}
-                      placeholder={
-                        providerId
-                          ? 'Leave blank to keep existing token'
-                          : 'Your dstack API token'
-                      }
-                      type="password"
-                      fullWidth
-                    />
-                  </FormControl>
-                  <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>dstack Project Name *</FormLabel>
-                    <Input
-                      value={dstackProjectName}
-                      onChange={(event) =>
-                        setDstackProjectName(event.currentTarget.value)
-                      }
-                      placeholder="main"
-                      fullWidth
-                    />
-                  </FormControl>
-                </>
-              )}
-
-              {type === 'runpod' && (
-                <>
-                  <FormControl sx={{ mt: 2 }}>
-                    <FormLabel>RunPod API Key *</FormLabel>
-                    <Input
-                      value={runpodApiKey}
-                      onChange={(event) => {
-                        setRunpodApiKeyChanged(true);
-                        setRunpodApiKey(event.currentTarget.value);
-                      }}
-                      placeholder={
-                        providerId
-                          ? 'Leave blank to keep existing key'
-                          : 'Your RunPod API key'
-                      }
-                      type="password"
-                      fullWidth
-                    />
-                  </FormControl>
-                  <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>API Base URL</FormLabel>
-                    <Input
-                      value={runpodApiBaseUrl}
-                      onChange={(event) =>
-                        setRunpodApiBaseUrl(event.currentTarget.value)
-                      }
-                      placeholder="https://rest.runpod.io/v1"
-                      fullWidth
-                    />
+                    >
+                      {ACCELERATOR_OPTIONS.map((option) => (
+                        <Option key={option} value={option}>
+                          {option}
+                        </Option>
+                      ))}
+                    </Select>
                     <Typography
                       level="body-sm"
                       sx={{ mt: 0.5, color: 'text.tertiary' }}
                     >
-                      Leave blank to use the default RunPod API endpoint.
-                    </Typography>
-                  </FormControl>
-                </>
-              )}
-
-              {type === 'aws' && (
-                <>
-                  <FormControl sx={{ mt: 2 }}>
-                    <FormLabel>Region *</FormLabel>
-                    <Input
-                      value={awsRegion}
-                      onChange={(event) =>
-                        setAwsRegion(event.currentTarget.value)
-                      }
-                      placeholder="us-east-1"
-                      fullWidth
-                    />
-                    <Typography
-                      level="body-sm"
-                      sx={{ mt: 0.5, color: 'text.tertiary' }}
-                    >
-                      AWS region where instances will be launched.
+                      Select the types of hardware this provider supports.
                     </Typography>
                   </FormControl>
 
-                  {providerId &&
-                    (() => {
-                      const cfg =
-                        typeof providerData?.config === 'string'
-                          ? (() => {
-                              try {
-                                return JSON.parse(providerData.config);
-                              } catch {
-                                return {};
-                              }
-                            })()
-                          : providerData?.config || {};
-                      return cfg?.aws_profile ? (
-                        <FormControl sx={{ mt: 1 }}>
-                          <FormLabel>AWS Profile</FormLabel>
-                          <Typography
-                            level="body-sm"
-                            sx={{
-                              color: 'text.secondary',
-                              fontFamily: 'monospace',
-                            }}
-                          >
-                            {cfg.aws_profile}
-                          </Typography>
-                          <Typography
-                            level="body-sm"
-                            sx={{ mt: 0.5, color: 'text.tertiary' }}
-                          >
-                            Credentials entered below are saved to this profile
-                            when you click Save.
-                          </Typography>
-                        </FormControl>
-                      ) : null;
-                    })()}
+                  {type === 'slurm' && (
+                    <SlurmProviderFields
+                      slurmMode={slurmMode}
+                      setSlurmMode={setSlurmMode}
+                      slurmSshHost={slurmSshHost}
+                      setSlurmSshHost={setSlurmSshHost}
+                      slurmSshUser={slurmSshUser}
+                      setSlurmSshUser={setSlurmSshUser}
+                      slurmSshPort={slurmSshPort}
+                      setSlurmSshPort={setSlurmSshPort}
+                      slurmSshKeyPath={slurmSshKeyPath}
+                      setSlurmSshKeyPath={setSlurmSshKeyPath}
+                      slurmRestUrl={slurmRestUrl}
+                      setSlurmRestUrl={setSlurmRestUrl}
+                      slurmApiToken={slurmApiToken}
+                      setSlurmApiToken={setSlurmApiToken}
+                      providerId={providerId}
+                      setSlurmApiTokenChanged={setSlurmApiTokenChanged}
+                    />
+                  )}
 
-                  <Box
-                    sx={{
-                      mt: 1,
-                      display: 'flex',
-                      flexDirection: 'column',
-                      gap: 1,
-                    }}
-                  >
-                    <FormControl>
-                      <FormLabel>Access Key ID</FormLabel>
-                      <Input
-                        value={awsAccessKeyId}
-                        onChange={(e) =>
-                          setAwsAccessKeyId(e.currentTarget.value)
-                        }
-                        placeholder="AKIA..."
-                        fullWidth
-                      />
-                    </FormControl>
-                    <FormControl>
-                      <FormLabel>Secret Access Key</FormLabel>
-                      <Input
-                        value={awsSecretAccessKey}
-                        onChange={(e) =>
-                          setAwsSecretAccessKey(e.currentTarget.value)
-                        }
-                        type="password"
-                        placeholder="Your AWS secret access key"
-                        fullWidth
-                      />
-                    </FormControl>
-                  </Box>
+                  {type === 'skypilot' && (
+                    <SkypilotProviderFields
+                      skypilotServerUrl={skypilotServerUrl}
+                      setSkypilotServerUrl={setSkypilotServerUrl}
+                      skypilotUserId={skypilotUserId}
+                      setSkypilotUserId={setSkypilotUserId}
+                      skypilotUserName={skypilotUserName}
+                      setSkypilotUserName={setSkypilotUserName}
+                      skypilotDockerImage={skypilotDockerImage}
+                      setSkypilotDockerImage={setSkypilotDockerImage}
+                      skypilotDefaultRegion={skypilotDefaultRegion}
+                      setSkypilotDefaultRegion={setSkypilotDefaultRegion}
+                      skypilotDefaultZone={skypilotDefaultZone}
+                      setSkypilotDefaultZone={setSkypilotDefaultZone}
+                      skypilotUseSpot={skypilotUseSpot}
+                      setSkypilotUseSpot={setSkypilotUseSpot}
+                    />
+                  )}
+
+                  {type === 'dstack' && (
+                    <DstackProviderFields
+                      dstackServerUrl={dstackServerUrl}
+                      setDstackServerUrl={setDstackServerUrl}
+                      dstackApiToken={dstackApiToken}
+                      setDstackApiToken={setDstackApiToken}
+                      dstackProjectName={dstackProjectName}
+                      setDstackProjectName={setDstackProjectName}
+                      providerId={providerId}
+                      setDstackApiTokenChanged={setDstackApiTokenChanged}
+                    />
+                  )}
+
+                  {type === 'runpod' && (
+                    <RunpodProviderFields
+                      runpodApiKey={runpodApiKey}
+                      setRunpodApiKey={setRunpodApiKey}
+                      runpodApiBaseUrl={runpodApiBaseUrl}
+                      setRunpodApiBaseUrl={setRunpodApiBaseUrl}
+                      providerId={providerId}
+                      setRunpodApiKeyChanged={setRunpodApiKeyChanged}
+                    />
+                  )}
+
+                  {type === 'aws' && (
+                    <AwsProviderFields
+                      awsRegion={awsRegion}
+                      setAwsRegion={setAwsRegion}
+                      awsAccessKeyId={awsAccessKeyId}
+                      setAwsAccessKeyId={setAwsAccessKeyId}
+                      awsSecretAccessKey={awsSecretAccessKey}
+                      setAwsSecretAccessKey={setAwsSecretAccessKey}
+                      awsProfile={awsProfile}
+                    />
+                  )}
+
+                  {/* Generic JSON config for non-structured providers or advanced editing */}
+                  {type !== 'slurm' &&
+                    type !== 'skypilot' &&
+                    type !== 'dstack' &&
+                    type !== 'runpod' &&
+                    type !== 'local' &&
+                    type !== 'aws' && (
+                      <FormControl sx={{ mt: 1 }}>
+                        <FormLabel>Configuration</FormLabel>
+                        <Textarea
+                          value={
+                            typeof config === 'string'
+                              ? config
+                              : JSON.stringify(config)
+                          }
+                          onChange={(event) =>
+                            setConfig(event.currentTarget.value)
+                          }
+                          placeholder="JSON sent to provider"
+                          minRows={5}
+                          maxRows={10}
+                        />
+                      </FormControl>
+                    )}
                 </>
               )}
-
-              {/* Generic JSON config for non-structured providers or advanced editing */}
-              {type !== 'slurm' &&
-                type !== 'skypilot' &&
-                type !== 'dstack' &&
-                type !== 'runpod' &&
-                type !== 'local' &&
-                type !== 'aws' && (
-                  <FormControl sx={{ mt: 1 }}>
-                    <FormLabel>Configuration</FormLabel>
-                    <Textarea
-                      value={
-                        typeof config === 'string'
-                          ? config
-                          : JSON.stringify(config)
-                      }
-                      onChange={(event) => setConfig(event.currentTarget.value)}
-                      placeholder="JSON sent to provider"
-                      minRows={5}
-                      maxRows={10}
-                    />
-                  </FormControl>
-                )}
             </>
           )}
         </DialogContent>

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -1028,7 +1028,7 @@ export default function ProviderDetailsModal({
                     >
                       {providerId
                         ? 'Provider type cannot be changed after creation'
-                        : 'Use Cancel to close and choose a different provider type.'}
+                        : ''}
                     </Typography>
                   </FormControl>
                   <FormControl required error={!!nameError} sx={{ mt: 1 }}>
@@ -1255,6 +1255,18 @@ export default function ProviderDetailsModal({
                   {setupStatus}
                 </Typography>
               )}
+              {!providerId && type ? (
+                <Button
+                  variant="plain"
+                  onClick={() => {
+                    setType('');
+                    setNameError(null);
+                  }}
+                  disabled={loading || isSetupInProgress}
+                >
+                  Back to provider type selection
+                </Button>
+              ) : null}
               <Button variant="outlined" onClick={onClose}>
                 Cancel
               </Button>

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -26,7 +26,6 @@ import { useAPI, useAuth } from 'renderer/lib/authContext';
 import { getPath } from 'renderer/lib/api-client/urls';
 import { Endpoints } from 'renderer/lib/api-client/endpoints';
 import { useNotification } from 'renderer/components/Shared/NotificationSystem';
-import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 
 interface ProviderDetailsModalProps {
   open: boolean;
@@ -136,9 +135,6 @@ export default function ProviderDetailsModal({
   const [awsRegion, setAwsRegion] = useState('us-east-1');
   const [awsAccessKeyId, setAwsAccessKeyId] = useState('');
   const [awsSecretAccessKey, setAwsSecretAccessKey] = useState('');
-  const [awsCredsSaved, setAwsCredsSaved] = useState(false);
-  const [awsCredsSaving, setAwsCredsSaving] = useState(false);
-  const [awsCredsExpanded, setAwsCredsExpanded] = useState(false);
 
   const { fetchWithAuth } = useAuth();
   const { data: providerData, isLoading: providerDataLoading } = useAPI(
@@ -442,8 +438,6 @@ export default function ProviderDetailsModal({
       setAwsRegion('us-east-1');
       setAwsAccessKeyId('');
       setAwsSecretAccessKey('');
-      setAwsCredsSaved(false);
-      setAwsCredsExpanded(false);
     }
   }, [providerId, providerData]);
 
@@ -487,8 +481,6 @@ export default function ProviderDetailsModal({
       setAwsRegion('us-east-1');
       setAwsAccessKeyId('');
       setAwsSecretAccessKey('');
-      setAwsCredsSaved(false);
-      setAwsCredsExpanded(false);
     }
   }, [open]);
 
@@ -725,6 +717,23 @@ export default function ProviderDetailsModal({
     );
   }
 
+  function saveAwsCredentials(
+    providerIdToSave: string,
+    accessKeyId: string,
+    secretAccessKey: string,
+  ) {
+    return fetchWithAuth(Endpoints.ComputeProvider.AwsCredentials(providerIdToSave), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        access_key_id: accessKeyId,
+        secret_access_key: secretAccessKey,
+      }),
+    });
+  }
+
   const saveProvider = async () => {
     const trimmedName = name.trim();
     if (!trimmedName) {
@@ -760,6 +769,23 @@ export default function ProviderDetailsModal({
         if (supportedAccelerators.length > 0) {
           parsedConfig.supported_accelerators = supportedAccelerators;
         }
+      }
+      const trimmedAwsAccessKeyId = awsAccessKeyId.trim();
+      const trimmedAwsSecretAccessKey = awsSecretAccessKey.trim();
+      const hasAwsCreds = Boolean(
+        trimmedAwsAccessKeyId && trimmedAwsSecretAccessKey,
+      );
+      const hasPartialAwsCreds = Boolean(
+        (trimmedAwsAccessKeyId && !trimmedAwsSecretAccessKey) ||
+          (!trimmedAwsAccessKeyId && trimmedAwsSecretAccessKey),
+      );
+      if (type === 'aws' && hasPartialAwsCreds) {
+        addNotification({
+          type: 'danger',
+          message:
+            'Enter both AWS Access Key ID and Secret Access Key, or leave both blank.',
+        });
+        return;
       }
 
       if (
@@ -797,9 +823,35 @@ export default function ProviderDetailsModal({
         : await createProvider(trimmedName, type, parsedConfig, forceRefresh);
 
       if (response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const savedProviderId = providerId || String(data?.id || '');
+
+        if (type === 'aws' && hasAwsCreds) {
+          if (!savedProviderId) {
+            addNotification({
+              type: 'danger',
+              message:
+                'Provider was saved, but could not determine provider ID to save AWS credentials.',
+            });
+            return;
+          }
+          const awsCredsResponse = await saveAwsCredentials(
+            savedProviderId,
+            trimmedAwsAccessKeyId,
+            trimmedAwsSecretAccessKey,
+          );
+          if (!awsCredsResponse.ok) {
+            addNotification({
+              type: 'danger',
+              message:
+                'Provider was saved, but saving AWS credentials failed. Open the provider and try again.',
+            });
+            return;
+          }
+        }
+
         // For newly created LOCAL providers, keep the modal open and show setup progress.
         if (!providerId && type === 'local') {
-          const data = await response.json().catch(() => ({}));
           const newId = String(data?.id || '');
           if (newId) {
             pollLocalSetupStatus(newId);
@@ -1347,111 +1399,50 @@ export default function ProviderDetailsModal({
                             level="body-sm"
                             sx={{ mt: 0.5, color: 'text.tertiary' }}
                           >
-                            Configure this profile in your AWS CLI or use the
-                            section below.
+                            Credentials entered below are saved to this profile
+                            when you click Save.
                           </Typography>
                         </FormControl>
                       ) : null;
                     })()}
 
-                  {providerId && (
-                    <Box sx={{ mt: 1 }}>
-                      <Button
-                        variant="plain"
-                        size="sm"
-                        onClick={() => setAwsCredsExpanded((v) => !v)}
-                        endDecorator={
-                          awsCredsExpanded ? (
-                            <ChevronDownIcon size={14} />
-                          ) : (
-                            <ChevronRightIcon size={14} />
-                          )
+                  <Box
+                    sx={{
+                      mt: 1,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 1,
+                    }}
+                  >
+                    <FormControl>
+                      <FormLabel>Access Key ID</FormLabel>
+                      <Input
+                        value={awsAccessKeyId}
+                        onChange={(e) => setAwsAccessKeyId(e.currentTarget.value)}
+                        placeholder="AKIA..."
+                        fullWidth
+                      />
+                    </FormControl>
+                    <FormControl>
+                      <FormLabel>Secret Access Key</FormLabel>
+                      <Input
+                        value={awsSecretAccessKey}
+                        onChange={(e) =>
+                          setAwsSecretAccessKey(e.currentTarget.value)
                         }
-                        sx={{ pl: 0 }}
-                      >
-                        Configure AWS Credentials
-                      </Button>
-                      {awsCredsExpanded && (
-                        <Box
-                          sx={{
-                            mt: 1,
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 1,
-                          }}
-                        >
-                          <FormControl>
-                            <FormLabel>Access Key ID</FormLabel>
-                            <Input
-                              value={awsAccessKeyId}
-                              onChange={(e) =>
-                                setAwsAccessKeyId(e.currentTarget.value)
-                              }
-                              placeholder="AKIA..."
-                              fullWidth
-                            />
-                          </FormControl>
-                          <FormControl>
-                            <FormLabel>Secret Access Key</FormLabel>
-                            <Input
-                              value={awsSecretAccessKey}
-                              onChange={(e) =>
-                                setAwsSecretAccessKey(e.currentTarget.value)
-                              }
-                              type="password"
-                              placeholder="Your AWS secret access key"
-                              fullWidth
-                            />
-                          </FormControl>
-                          <Button
-                            size="sm"
-                            variant="outlined"
-                            loading={awsCredsSaving}
-                            color={awsCredsSaved ? 'success' : 'primary'}
-                            onClick={async () => {
-                              setAwsCredsSaving(true);
-                              try {
-                                const resp = await fetchWithAuth(
-                                  Endpoints.ComputeProvider.AwsCredentials(
-                                    providerId,
-                                  ),
-                                  {
-                                    method: 'POST',
-                                    headers: {
-                                      'Content-Type': 'application/json',
-                                    },
-                                    body: JSON.stringify({
-                                      access_key_id: awsAccessKeyId,
-                                      secret_access_key: awsSecretAccessKey,
-                                    }),
-                                  },
-                                );
-                                if (resp.ok) {
-                                  setAwsCredsSaved(true);
-                                  addNotification({
-                                    type: 'success',
-                                    message: 'AWS credentials saved.',
-                                  });
-                                } else {
-                                  addNotification({
-                                    type: 'danger',
-                                    message: 'Failed to save AWS credentials.',
-                                  });
-                                }
-                              } finally {
-                                setAwsCredsSaving(false);
-                              }
-                            }}
-                            sx={{ alignSelf: 'flex-start' }}
-                          >
-                            {awsCredsSaved
-                              ? 'Credentials Saved'
-                              : 'Save Credentials'}
-                          </Button>
-                        </Box>
-                      )}
-                    </Box>
-                  )}
+                        type="password"
+                        placeholder="Your AWS secret access key"
+                        fullWidth
+                      />
+                    </FormControl>
+                    <Typography
+                      level="body-sm"
+                      sx={{ mt: 0.5, color: 'text.tertiary' }}
+                    >
+                      Optional. If provided, credentials are saved along with the
+                      provider when you click Save.
+                    </Typography>
+                  </Box>
                 </>
               )}
 

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -168,8 +168,8 @@ export default function ProviderDetailsModal({
       },
       {
         value: 'runpod',
-        label: 'RunPod',
-        description: 'Run workloads on RunPod infrastructure.',
+        label: 'Runpod',
+        description: 'Run workloads on Runpod infrastructure.',
       },
       {
         value: 'dstack',

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -931,23 +931,7 @@ export default function ProviderDetailsModal({
             </Box>
           ) : (
             <>
-              <FormControl required error={!!nameError} sx={{ mt: 2 }}>
-                <FormLabel>Compute Provider Name</FormLabel>
-                <Input
-                  value={name}
-                  onChange={(event) => {
-                    setName(event.currentTarget.value);
-                    setNameError(null);
-                  }}
-                  placeholder="Enter friendly name for compute provider"
-                  fullWidth
-                  color={nameError ? 'danger' : undefined}
-                />
-                {nameError ? (
-                  <FormHelperText>{nameError}</FormHelperText>
-                ) : null}
-              </FormControl>
-              <FormControl sx={{ mt: 1 }}>
+              <FormControl sx={{ mt: 2 }}>
                 <FormLabel>Compute Provider Type</FormLabel>
                 <Select
                   value={type}
@@ -972,6 +956,22 @@ export default function ProviderDetailsModal({
                     Provider type cannot be changed after creation
                   </Typography>
                 )}
+              </FormControl>
+              <FormControl required error={!!nameError} sx={{ mt: 1 }}>
+                <FormLabel>Compute Provider Name</FormLabel>
+                <Input
+                  value={name}
+                  onChange={(event) => {
+                    setName(event.currentTarget.value);
+                    setNameError(null);
+                  }}
+                  placeholder="Enter friendly name for compute provider"
+                  fullWidth
+                  color={nameError ? 'danger' : undefined}
+                />
+                {nameError ? (
+                  <FormHelperText>{nameError}</FormHelperText>
+                ) : null}
               </FormControl>
 
               {type === 'local' && !providerId && (
@@ -1440,13 +1440,6 @@ export default function ProviderDetailsModal({
                         fullWidth
                       />
                     </FormControl>
-                    <Typography
-                      level="body-sm"
-                      sx={{ mt: 0.5, color: 'text.tertiary' }}
-                    >
-                      Optional. If provided, credentials are saved along with
-                      the provider when you click Save.
-                    </Typography>
                   </Box>
                 </>
               )}

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -722,16 +722,19 @@ export default function ProviderDetailsModal({
     accessKeyId: string,
     secretAccessKey: string,
   ) {
-    return fetchWithAuth(Endpoints.ComputeProvider.AwsCredentials(providerIdToSave), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
+    return fetchWithAuth(
+      Endpoints.ComputeProvider.AwsCredentials(providerIdToSave),
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          access_key_id: accessKeyId,
+          secret_access_key: secretAccessKey,
+        }),
       },
-      body: JSON.stringify({
-        access_key_id: accessKeyId,
-        secret_access_key: secretAccessKey,
-      }),
-    });
+    );
   }
 
   const saveProvider = async () => {
@@ -777,7 +780,7 @@ export default function ProviderDetailsModal({
       );
       const hasPartialAwsCreds = Boolean(
         (trimmedAwsAccessKeyId && !trimmedAwsSecretAccessKey) ||
-          (!trimmedAwsAccessKeyId && trimmedAwsSecretAccessKey),
+        (!trimmedAwsAccessKeyId && trimmedAwsSecretAccessKey),
       );
       if (type === 'aws' && hasPartialAwsCreds) {
         addNotification({
@@ -1418,7 +1421,9 @@ export default function ProviderDetailsModal({
                       <FormLabel>Access Key ID</FormLabel>
                       <Input
                         value={awsAccessKeyId}
-                        onChange={(e) => setAwsAccessKeyId(e.currentTarget.value)}
+                        onChange={(e) =>
+                          setAwsAccessKeyId(e.currentTarget.value)
+                        }
                         placeholder="AKIA..."
                         fullWidth
                       />
@@ -1439,8 +1444,8 @@ export default function ProviderDetailsModal({
                       level="body-sm"
                       sx={{ mt: 0.5, color: 'text.tertiary' }}
                     >
-                      Optional. If provided, credentials are saved along with the
-                      provider when you click Save.
+                      Optional. If provided, credentials are saved along with
+                      the provider when you click Save.
                     </Typography>
                   </Box>
                 </>

--- a/src/renderer/components/Team/ProviderDetailsModal.tsx
+++ b/src/renderer/components/Team/ProviderDetailsModal.tsx
@@ -1264,7 +1264,7 @@ export default function ProviderDetailsModal({
                   }}
                   disabled={loading || isSetupInProgress}
                 >
-                  Back to provider type selection
+                  Change Provider Type
                 </Button>
               ) : null}
               <Button variant="outlined" onClick={onClose}>

--- a/src/renderer/components/Team/providerForms/AwsProviderFields.tsx
+++ b/src/renderer/components/Team/providerForms/AwsProviderFields.tsx
@@ -35,22 +35,6 @@ export default function AwsProviderFields({
         </Typography>
       </FormControl>
 
-      {awsProfile ? (
-        <FormControl sx={{ mt: 1 }}>
-          <FormLabel>AWS Profile</FormLabel>
-          <Typography
-            level="body-sm"
-            sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
-          >
-            {awsProfile}
-          </Typography>
-          <Typography level="body-sm" sx={{ mt: 0.5, color: 'text.tertiary' }}>
-            Credentials entered below are saved to this profile when you click
-            Save.
-          </Typography>
-        </FormControl>
-      ) : null}
-
       <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
         <FormControl>
           <FormLabel>Access Key ID</FormLabel>

--- a/src/renderer/components/Team/providerForms/AwsProviderFields.tsx
+++ b/src/renderer/components/Team/providerForms/AwsProviderFields.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Box, FormControl, FormLabel, Input, Typography } from '@mui/joy';
+
+interface AwsProviderFieldsProps {
+  awsRegion: string;
+  setAwsRegion: (value: string) => void;
+  awsAccessKeyId: string;
+  setAwsAccessKeyId: (value: string) => void;
+  awsSecretAccessKey: string;
+  setAwsSecretAccessKey: (value: string) => void;
+  awsProfile?: string;
+}
+
+export default function AwsProviderFields({
+  awsRegion,
+  setAwsRegion,
+  awsAccessKeyId,
+  setAwsAccessKeyId,
+  awsSecretAccessKey,
+  setAwsSecretAccessKey,
+  awsProfile,
+}: AwsProviderFieldsProps) {
+  return (
+    <>
+      <FormControl sx={{ mt: 2 }}>
+        <FormLabel>Region *</FormLabel>
+        <Input
+          value={awsRegion}
+          onChange={(event) => setAwsRegion(event.currentTarget.value)}
+          placeholder="us-east-1"
+          fullWidth
+        />
+        <Typography level="body-sm" sx={{ mt: 0.5, color: 'text.tertiary' }}>
+          AWS region where instances will be launched.
+        </Typography>
+      </FormControl>
+
+      {awsProfile ? (
+        <FormControl sx={{ mt: 1 }}>
+          <FormLabel>AWS Profile</FormLabel>
+          <Typography
+            level="body-sm"
+            sx={{ color: 'text.secondary', fontFamily: 'monospace' }}
+          >
+            {awsProfile}
+          </Typography>
+          <Typography level="body-sm" sx={{ mt: 0.5, color: 'text.tertiary' }}>
+            Credentials entered below are saved to this profile when you click
+            Save.
+          </Typography>
+        </FormControl>
+      ) : null}
+
+      <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <FormControl>
+          <FormLabel>Access Key ID</FormLabel>
+          <Input
+            value={awsAccessKeyId}
+            onChange={(event) => setAwsAccessKeyId(event.currentTarget.value)}
+            placeholder="AKIA..."
+            fullWidth
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Secret Access Key</FormLabel>
+          <Input
+            value={awsSecretAccessKey}
+            onChange={(event) =>
+              setAwsSecretAccessKey(event.currentTarget.value)
+            }
+            type="password"
+            placeholder="Your AWS secret access key"
+            fullWidth
+          />
+        </FormControl>
+      </Box>
+    </>
+  );
+}

--- a/src/renderer/components/Team/providerForms/DstackProviderFields.tsx
+++ b/src/renderer/components/Team/providerForms/DstackProviderFields.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { FormControl, FormLabel, Input } from '@mui/joy';
+
+interface DstackProviderFieldsProps {
+  dstackServerUrl: string;
+  setDstackServerUrl: (value: string) => void;
+  dstackApiToken: string;
+  setDstackApiToken: (value: string) => void;
+  dstackProjectName: string;
+  setDstackProjectName: (value: string) => void;
+  providerId?: string;
+  setDstackApiTokenChanged: (changed: boolean) => void;
+}
+
+export default function DstackProviderFields({
+  dstackServerUrl,
+  setDstackServerUrl,
+  dstackApiToken,
+  setDstackApiToken,
+  dstackProjectName,
+  setDstackProjectName,
+  providerId,
+  setDstackApiTokenChanged,
+}: DstackProviderFieldsProps) {
+  return (
+    <>
+      <FormControl sx={{ mt: 2 }}>
+        <FormLabel>dstack Server URL *</FormLabel>
+        <Input
+          value={dstackServerUrl}
+          onChange={(event) => setDstackServerUrl(event.currentTarget.value)}
+          placeholder="http://0.0.0.0:3000"
+          fullWidth
+        />
+      </FormControl>
+      <FormControl sx={{ mt: 1 }}>
+        <FormLabel>dstack API Token *</FormLabel>
+        <Input
+          value={dstackApiToken}
+          onChange={(event) => {
+            setDstackApiTokenChanged(true);
+            setDstackApiToken(event.currentTarget.value);
+          }}
+          placeholder={
+            providerId
+              ? 'Leave blank to keep existing token'
+              : 'Your dstack API token'
+          }
+          type="password"
+          fullWidth
+        />
+      </FormControl>
+      <FormControl sx={{ mt: 1 }}>
+        <FormLabel>dstack Project Name *</FormLabel>
+        <Input
+          value={dstackProjectName}
+          onChange={(event) => setDstackProjectName(event.currentTarget.value)}
+          placeholder="main"
+          fullWidth
+        />
+      </FormControl>
+    </>
+  );
+}

--- a/src/renderer/components/Team/providerForms/LocalProviderFields.tsx
+++ b/src/renderer/components/Team/providerForms/LocalProviderFields.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Box, FormControl, FormLabel, Switch, Typography } from '@mui/joy';
+
+interface LocalProviderFieldsProps {
+  forceRefresh: boolean;
+  setForceRefresh: (value: boolean) => void;
+}
+
+export default function LocalProviderFields({
+  forceRefresh,
+  setForceRefresh,
+}: LocalProviderFieldsProps) {
+  return (
+    <FormControl
+      orientation="horizontal"
+      sx={{ mt: 1, alignItems: 'center', gap: 1 }}
+    >
+      <Box>
+        <FormLabel>Force fresh install</FormLabel>
+        <Typography level="body-sm" sx={{ color: 'text.tertiary' }}>
+          Delete the existing conda environment, install log, and config and run
+          a clean install from scratch.
+        </Typography>
+      </Box>
+      <Switch
+        checked={forceRefresh}
+        onChange={(event) => setForceRefresh(event.target.checked)}
+      />
+    </FormControl>
+  );
+}

--- a/src/renderer/components/Team/providerForms/ProviderTypePicker.tsx
+++ b/src/renderer/components/Team/providerForms/ProviderTypePicker.tsx
@@ -1,11 +1,5 @@
 import React, { useState } from 'react';
-import {
-  FormControl,
-  FormLabel,
-  Option,
-  Select,
-  Typography,
-} from '@mui/joy';
+import { FormControl, FormLabel, Option, Select, Typography } from '@mui/joy';
 
 export interface ProviderTypeOption {
   value: string;

--- a/src/renderer/components/Team/providerForms/ProviderTypePicker.tsx
+++ b/src/renderer/components/Team/providerForms/ProviderTypePicker.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Box, Button, FormControl, FormLabel, Typography } from '@mui/joy';
+
+export interface ProviderTypeOption {
+  value: string;
+  label: string;
+  description: string;
+}
+
+interface ProviderTypePickerProps {
+  options: ProviderTypeOption[];
+  onSelect: (providerType: string) => void;
+}
+
+export default function ProviderTypePicker({
+  options,
+  onSelect,
+}: ProviderTypePickerProps) {
+  return (
+    <FormControl sx={{ mt: 2 }}>
+      <FormLabel>Choose Compute Provider Type</FormLabel>
+      <Typography level="body-sm" sx={{ mt: 0.5, color: 'text.tertiary' }}>
+        Select a provider type to open its dedicated setup form.
+      </Typography>
+      <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {options.map((option) => (
+          <Button
+            key={option.value}
+            variant="outlined"
+            onClick={() => onSelect(option.value)}
+            sx={{
+              justifyContent: 'flex-start',
+              textAlign: 'left',
+              py: 1.2,
+            }}
+          >
+            <Box>
+              <Typography level="title-sm">{option.label}</Typography>
+              <Typography level="body-sm" sx={{ color: 'text.tertiary' }}>
+                {option.description}
+              </Typography>
+            </Box>
+          </Button>
+        ))}
+      </Box>
+    </FormControl>
+  );
+}

--- a/src/renderer/components/Team/providerForms/ProviderTypePicker.tsx
+++ b/src/renderer/components/Team/providerForms/ProviderTypePicker.tsx
@@ -1,5 +1,11 @@
-import React from 'react';
-import { Box, Button, FormControl, FormLabel, Typography } from '@mui/joy';
+import React, { useState } from 'react';
+import {
+  FormControl,
+  FormLabel,
+  Option,
+  Select,
+  Typography,
+} from '@mui/joy';
 
 export interface ProviderTypeOption {
   value: string;
@@ -16,33 +22,35 @@ export default function ProviderTypePicker({
   options,
   onSelect,
 }: ProviderTypePickerProps) {
+  const [selectedType, setSelectedType] = useState<string | null>(null);
+
   return (
     <FormControl sx={{ mt: 2 }}>
       <FormLabel>Choose Compute Provider Type</FormLabel>
       <Typography level="body-sm" sx={{ mt: 0.5, color: 'text.tertiary' }}>
         Select a provider type to open its dedicated setup form.
       </Typography>
-      <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+      <Select
+        value={selectedType}
+        placeholder="Select provider type"
+        sx={{ mt: 1 }}
+        onChange={(event, value) => {
+          if (!value) return;
+          setSelectedType(value);
+          onSelect(value);
+        }}
+      >
         {options.map((option) => (
-          <Button
-            key={option.value}
-            variant="outlined"
-            onClick={() => onSelect(option.value)}
-            sx={{
-              justifyContent: 'flex-start',
-              textAlign: 'left',
-              py: 1.2,
-            }}
-          >
-            <Box>
+          <Option key={option.value} value={option.value}>
+            <div>
               <Typography level="title-sm">{option.label}</Typography>
               <Typography level="body-sm" sx={{ color: 'text.tertiary' }}>
                 {option.description}
               </Typography>
-            </Box>
-          </Button>
+            </div>
+          </Option>
         ))}
-      </Box>
+      </Select>
     </FormControl>
   );
 }

--- a/src/renderer/components/Team/providerForms/RunpodProviderFields.tsx
+++ b/src/renderer/components/Team/providerForms/RunpodProviderFields.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { FormControl, FormLabel, Input, Typography } from '@mui/joy';
+
+interface RunpodProviderFieldsProps {
+  runpodApiKey: string;
+  setRunpodApiKey: (value: string) => void;
+  runpodApiBaseUrl: string;
+  setRunpodApiBaseUrl: (value: string) => void;
+  providerId?: string;
+  setRunpodApiKeyChanged: (changed: boolean) => void;
+}
+
+export default function RunpodProviderFields({
+  runpodApiKey,
+  setRunpodApiKey,
+  runpodApiBaseUrl,
+  setRunpodApiBaseUrl,
+  providerId,
+  setRunpodApiKeyChanged,
+}: RunpodProviderFieldsProps) {
+  return (
+    <>
+      <FormControl sx={{ mt: 2 }}>
+        <FormLabel>RunPod API Key *</FormLabel>
+        <Input
+          value={runpodApiKey}
+          onChange={(event) => {
+            setRunpodApiKeyChanged(true);
+            setRunpodApiKey(event.currentTarget.value);
+          }}
+          placeholder={
+            providerId
+              ? 'Leave blank to keep existing key'
+              : 'Your RunPod API key'
+          }
+          type="password"
+          fullWidth
+        />
+      </FormControl>
+      <FormControl sx={{ mt: 1 }}>
+        <FormLabel>API Base URL</FormLabel>
+        <Input
+          value={runpodApiBaseUrl}
+          onChange={(event) => setRunpodApiBaseUrl(event.currentTarget.value)}
+          placeholder="https://rest.runpod.io/v1"
+          fullWidth
+        />
+        <Typography level="body-sm" sx={{ mt: 0.5, color: 'text.tertiary' }}>
+          Leave blank to use the default RunPod API endpoint.
+        </Typography>
+      </FormControl>
+    </>
+  );
+}

--- a/src/renderer/components/Team/providerForms/SkypilotProviderFields.tsx
+++ b/src/renderer/components/Team/providerForms/SkypilotProviderFields.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { FormControl, FormLabel, Input, Switch, Typography } from '@mui/joy';
+
+interface SkypilotProviderFieldsProps {
+  skypilotServerUrl: string;
+  setSkypilotServerUrl: (value: string) => void;
+  skypilotUserId: string;
+  setSkypilotUserId: (value: string) => void;
+  skypilotUserName: string;
+  setSkypilotUserName: (value: string) => void;
+  skypilotDockerImage: string;
+  setSkypilotDockerImage: (value: string) => void;
+  skypilotDefaultRegion: string;
+  setSkypilotDefaultRegion: (value: string) => void;
+  skypilotDefaultZone: string;
+  setSkypilotDefaultZone: (value: string) => void;
+  skypilotUseSpot: boolean;
+  setSkypilotUseSpot: (value: boolean) => void;
+}
+
+export default function SkypilotProviderFields({
+  skypilotServerUrl,
+  setSkypilotServerUrl,
+  skypilotUserId,
+  setSkypilotUserId,
+  skypilotUserName,
+  setSkypilotUserName,
+  skypilotDockerImage,
+  setSkypilotDockerImage,
+  skypilotDefaultRegion,
+  setSkypilotDefaultRegion,
+  skypilotDefaultZone,
+  setSkypilotDefaultZone,
+  skypilotUseSpot,
+  setSkypilotUseSpot,
+}: SkypilotProviderFieldsProps) {
+  return (
+    <>
+      <FormControl sx={{ mt: 2 }}>
+        <FormLabel>SkyPilot Server URL *</FormLabel>
+        <Input
+          value={skypilotServerUrl}
+          onChange={(event) => setSkypilotServerUrl(event.currentTarget.value)}
+          placeholder="http://localhost:46580"
+          fullWidth
+        />
+      </FormControl>
+      <FormControl sx={{ mt: 1 }}>
+        <FormLabel>SkyPilot User ID</FormLabel>
+        <Input
+          value={skypilotUserId}
+          onChange={(event) => setSkypilotUserId(event.currentTarget.value)}
+          placeholder="Your SkyPilot user ID"
+          fullWidth
+        />
+      </FormControl>
+      <FormControl sx={{ mt: 1 }}>
+        <FormLabel>SkyPilot User Name</FormLabel>
+        <Input
+          value={skypilotUserName}
+          onChange={(event) => setSkypilotUserName(event.currentTarget.value)}
+          placeholder="Your SkyPilot user name"
+          fullWidth
+        />
+      </FormControl>
+      <FormControl sx={{ mt: 1 }}>
+        <FormLabel>Docker Image (optional)</FormLabel>
+        <Input
+          value={skypilotDockerImage}
+          onChange={(event) =>
+            setSkypilotDockerImage(event.currentTarget.value)
+          }
+          placeholder="docker:nvcr.io/nvidia/pytorch:23.10-py3"
+          fullWidth
+          sx={{ fontFamily: 'monospace', fontSize: 'sm' }}
+        />
+        <Typography level="body-sm" sx={{ mt: 0.5, color: 'text.tertiary' }}>
+          Prefix with &quot;docker:&quot; to run inside a container on the
+          provisioned VM. Must be Debian/Ubuntu-based. Leave empty to run
+          directly on the VM.
+        </Typography>
+      </FormControl>
+      <FormControl sx={{ mt: 1 }}>
+        <FormLabel>Default Region (optional)</FormLabel>
+        <Input
+          value={skypilotDefaultRegion}
+          onChange={(event) =>
+            setSkypilotDefaultRegion(event.currentTarget.value)
+          }
+          placeholder="e.g. us-east-1"
+          fullWidth
+        />
+      </FormControl>
+      <FormControl sx={{ mt: 1 }}>
+        <FormLabel>Default Zone (optional)</FormLabel>
+        <Input
+          value={skypilotDefaultZone}
+          onChange={(event) =>
+            setSkypilotDefaultZone(event.currentTarget.value)
+          }
+          placeholder="e.g. us-east-1a"
+          fullWidth
+        />
+      </FormControl>
+      <FormControl sx={{ mt: 1, flexDirection: 'row', alignItems: 'center' }}>
+        <Switch
+          checked={skypilotUseSpot}
+          onChange={(event) => setSkypilotUseSpot(event.target.checked)}
+          sx={{ mr: 1 }}
+        />
+        <FormLabel sx={{ m: 0 }}>Use Spot / Preemptible Instances</FormLabel>
+      </FormControl>
+    </>
+  );
+}

--- a/src/renderer/components/Team/providerForms/SlurmProviderFields.tsx
+++ b/src/renderer/components/Team/providerForms/SlurmProviderFields.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import {
+  Alert,
+  FormControl,
+  FormLabel,
+  Input,
+  Option,
+  Select,
+  Typography,
+} from '@mui/joy';
+
+interface SlurmProviderFieldsProps {
+  slurmMode: 'ssh' | 'rest';
+  setSlurmMode: (value: 'ssh' | 'rest') => void;
+  slurmSshHost: string;
+  setSlurmSshHost: (value: string) => void;
+  slurmSshUser: string;
+  setSlurmSshUser: (value: string) => void;
+  slurmSshPort: string;
+  setSlurmSshPort: (value: string) => void;
+  slurmSshKeyPath: string;
+  setSlurmSshKeyPath: (value: string) => void;
+  slurmRestUrl: string;
+  setSlurmRestUrl: (value: string) => void;
+  slurmApiToken: string;
+  setSlurmApiToken: (value: string) => void;
+  providerId?: string;
+  setSlurmApiTokenChanged: (changed: boolean) => void;
+}
+
+export default function SlurmProviderFields({
+  slurmMode,
+  setSlurmMode,
+  slurmSshHost,
+  setSlurmSshHost,
+  slurmSshUser,
+  setSlurmSshUser,
+  slurmSshPort,
+  setSlurmSshPort,
+  slurmSshKeyPath,
+  setSlurmSshKeyPath,
+  slurmRestUrl,
+  setSlurmRestUrl,
+  slurmApiToken,
+  setSlurmApiToken,
+  providerId,
+  setSlurmApiTokenChanged,
+}: SlurmProviderFieldsProps) {
+  return (
+    <>
+      <Alert color="primary" variant="soft" sx={{ mt: 2 }}>
+        <Typography level="body-sm">
+          <strong>SLURM User ID:</strong> All jobs launched through this
+          provider will run as the specified SLURM user. Make sure your
+          team&apos;s SSH key (from Team Settings → SSH Key) is added to that
+          user&apos;s authorized_keys on the SLURM login node.
+        </Typography>
+      </Alert>
+
+      <FormControl sx={{ mt: 2 }}>
+        <FormLabel>Connection Mode</FormLabel>
+        <Select
+          value={slurmMode}
+          onChange={(event, value) => setSlurmMode(value ?? 'ssh')}
+          sx={{ width: '100%' }}
+        >
+          <Option value="ssh">SSH</Option>
+          <Option value="rest">REST API</Option>
+        </Select>
+      </FormControl>
+
+      {slurmMode === 'ssh' ? (
+        <>
+          <FormControl sx={{ mt: 1 }}>
+            <FormLabel>SSH Host *</FormLabel>
+            <Input
+              value={slurmSshHost}
+              onChange={(event) => setSlurmSshHost(event.currentTarget.value)}
+              placeholder="slurm-login.example.com"
+              fullWidth
+            />
+          </FormControl>
+          <FormControl sx={{ mt: 1 }}>
+            <FormLabel>SLURM User ID *</FormLabel>
+            <Input
+              value={slurmSshUser}
+              onChange={(event) => setSlurmSshUser(event.currentTarget.value)}
+              placeholder="your_slurm_username"
+              fullWidth
+            />
+            <Typography
+              level="body-sm"
+              sx={{ mt: 0.5, color: 'text.tertiary' }}
+            >
+              All jobs will run as this user on SLURM
+            </Typography>
+          </FormControl>
+          <FormControl sx={{ mt: 1 }}>
+            <FormLabel>SSH Port</FormLabel>
+            <Input
+              value={slurmSshPort}
+              onChange={(event) => setSlurmSshPort(event.currentTarget.value)}
+              placeholder="22"
+              type="number"
+              fullWidth
+            />
+          </FormControl>
+          <FormControl sx={{ mt: 1 }}>
+            <FormLabel>SSH Key Path (Optional)</FormLabel>
+            <Input
+              value={slurmSshKeyPath}
+              onChange={(event) =>
+                setSlurmSshKeyPath(event.currentTarget.value)
+              }
+              placeholder="Leave empty to use team SSH key"
+              fullWidth
+            />
+            <Typography
+              level="body-sm"
+              sx={{ mt: 0.5, color: 'text.tertiary' }}
+            >
+              Path to private key on API server. If empty, will use your
+              team&apos;s SSH key.
+            </Typography>
+          </FormControl>
+        </>
+      ) : (
+        <>
+          <FormControl sx={{ mt: 1 }}>
+            <FormLabel>REST API URL *</FormLabel>
+            <Input
+              value={slurmRestUrl}
+              onChange={(event) => setSlurmRestUrl(event.currentTarget.value)}
+              placeholder="https://slurm-api.example.com"
+              fullWidth
+            />
+          </FormControl>
+          <FormControl sx={{ mt: 1 }}>
+            <FormLabel>SLURM User ID *</FormLabel>
+            <Input
+              value={slurmSshUser}
+              onChange={(event) => setSlurmSshUser(event.currentTarget.value)}
+              placeholder="your_slurm_username"
+              fullWidth
+            />
+            <Typography
+              level="body-sm"
+              sx={{ mt: 0.5, color: 'text.tertiary' }}
+            >
+              All jobs will run as this user on SLURM
+            </Typography>
+          </FormControl>
+          <FormControl sx={{ mt: 1 }}>
+            <FormLabel>API Token (Optional)</FormLabel>
+            <Input
+              value={slurmApiToken}
+              onChange={(event) => {
+                setSlurmApiTokenChanged(true);
+                setSlurmApiToken(event.currentTarget.value);
+              }}
+              placeholder={
+                providerId
+                  ? 'Leave blank to keep existing token'
+                  : 'Your SLURM REST API token'
+              }
+              type="password"
+              fullWidth
+            />
+          </FormControl>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/renderer/lib/api-client/endpoints.ts
+++ b/src/renderer/lib/api-client/endpoints.ts
@@ -122,6 +122,8 @@ Endpoints.ComputeProvider = {
     `${API_URL()}compute_provider/providers/${providerId}/launch/${taskId}/file-upload`, // Deprecated: use UploadTemplateFile
   Check: (providerId: string) =>
     `${API_URL()}compute_provider/providers/${providerId}/check`,
+  AwsCredentials: (providerId: string) =>
+    `${API_URL()}compute_provider/providers/${providerId}/aws/credentials`,
   Setup: (providerId: string) =>
     `${API_URL()}compute_provider/providers/${providerId}/setup/`,
   SetupStatus: (providerId: string) =>


### PR DESCRIPTION
- Adds AWS as a provider
- Refer to [this](https://github.com/transformerlab/transformerlab-app/blob/add/aws-provider/api/transformerlab/compute_providers/aws-iam-requirements.md) document for permissions you need to attach to your AWS credentials so it works with Transformer Lab
- Also enables auto-shutdown upon exit for AWS instances so that there are no lingering instances on AWS
- Also refactors `ProviderDetailsModal` and breaks it down into provider-specific forms