### PR TITLE
Remove cluster name format dependency to infer job id

### DIFF
--- a/api/test/api/test_request_logs.py
+++ b/api/test/api/test_request_logs.py
@@ -63,7 +63,7 @@ class MinimalProvider(ComputeProvider):
 
 
 def _make_job_dict(
-    job_id: str = "test-job-1",
+    job_id: str = "test-1",
     experiment_id: str = "exp-1",
     provider_id: str = "prov-1",
     provider_type: str = "skypilot",
@@ -221,7 +221,7 @@ class TestSkyPilotGetRequestLogs:
 class TestRequestLogsEndpoint:
     def test_nonexistent_job_returns_404(self, client):
         """Request logs for a non-existent job should return 404."""
-        resp = client.get("/experiment/alpha/jobs/nonexistent-job-id/request_logs")
+        resp = client.get("/experiment/alpha/jobs/nonexistent-id/request_logs")
         assert resp.status_code == 404
 
     @patch("transformerlab.routers.experiment.jobs.job_service.job_get_cached", new_callable=AsyncMock)
@@ -261,7 +261,7 @@ class TestRequestLogsEndpoint:
         mock_provider.get_request_logs.side_effect = NotImplementedError("not supported")
         mock_instance.return_value = mock_provider
 
-        resp = client.get("/experiment/exp-1/jobs/test-job-1/request_logs")
+        resp = client.get("/experiment/exp-1/jobs/test-1/request_logs")
         assert resp.status_code == 400
         assert "does not support request logs" in resp.json()["detail"]
 
@@ -276,7 +276,7 @@ class TestRequestLogsEndpoint:
         mock_provider.get_request_logs.return_value = "Provisioning cluster...\nCluster ready."
         mock_instance.return_value = mock_provider
 
-        resp = client.get("/experiment/exp-1/jobs/test-job-1/request_logs")
+        resp = client.get("/experiment/exp-1/jobs/test-1/request_logs")
         assert resp.status_code == 200
         data = resp.json()
         assert data["request_id"] == "req-abc-123"
@@ -293,7 +293,7 @@ class TestRequestLogsEndpoint:
         mock_provider.get_request_logs.side_effect = RuntimeError("connection timed out")
         mock_instance.return_value = mock_provider
 
-        resp = client.get("/experiment/exp-1/jobs/test-job-1/request_logs")
+        resp = client.get("/experiment/exp-1/jobs/test-1/request_logs")
         assert resp.status_code == 502
         assert "connection timed out" in resp.json()["detail"]
 
@@ -311,7 +311,7 @@ class TestRequestLogsEndpoint:
         mock_provider.get_request_logs.return_value = "fallback logs"
         mock_instance.return_value = mock_provider
 
-        resp = client.get("/experiment/exp-1/jobs/test-job-1/request_logs")
+        resp = client.get("/experiment/exp-1/jobs/test-1/request_logs")
         assert resp.status_code == 200
         assert resp.json()["request_id"] == "orch-fallback-id"
         mock_provider.get_request_logs.assert_called_once_with("orch-fallback-id", tail_lines=400)
@@ -327,6 +327,6 @@ class TestRequestLogsEndpoint:
         mock_provider.get_request_logs.return_value = "logs"
         mock_instance.return_value = mock_provider
 
-        resp = client.get("/experiment/exp-1/jobs/test-job-1/request_logs?tail_lines=1000")
+        resp = client.get("/experiment/exp-1/jobs/test-1/request_logs?tail_lines=1000")
         assert resp.status_code == 200
         mock_provider.get_request_logs.assert_called_once_with("req-abc-123", tail_lines=1000)

--- a/api/transformerlab/compute_providers/slurm.py
+++ b/api/transformerlab/compute_providers/slurm.py
@@ -761,7 +761,7 @@ class SLURMProvider(ComputeProvider):
         script_content += "#SBATCH --requeue\n"
 
         # Extract partition name from cluster_name or use provider config
-        # cluster_name might be a job identifier like "slurm-test-job-15"
+        # cluster_name might be a job identifier like "slurm-test-15"
         # Check if we have a partition specified in provider_config
         partition = job_config.provider_config.get("partition") if job_config.provider_config else None
 

--- a/api/transformerlab/routers/compute_provider/clusters.py
+++ b/api/transformerlab/routers/compute_provider/clusters.py
@@ -62,13 +62,23 @@ async def get_cluster_resources(
 async def stop_cluster(
     provider_id: str,
     cluster_name: str,
+    job_id: Optional[Union[str, int]] = Query(
+        None, description="Job ID used by local provider to resolve job workspace"
+    ),
     user_and_team=Depends(get_user_and_team),
     session: AsyncSession = Depends(get_async_session),
 ):
     """Stop a running cluster."""
     team_id = user_and_team["team_id"]
     user_id_str = str(user_and_team["user"].id)
-    return await cluster_management_service.stop_cluster(session, team_id, user_id_str, provider_id, cluster_name)
+    return await cluster_management_service.stop_cluster(
+        session,
+        team_id,
+        user_id_str,
+        provider_id,
+        cluster_name,
+        job_id=job_id,
+    )
 
 
 @router.post("/{cluster_name}/jobs")

--- a/api/transformerlab/services/compute_provider/cluster_management_service.py
+++ b/api/transformerlab/services/compute_provider/cluster_management_service.py
@@ -59,7 +59,12 @@ async def get_cluster_resources(
 
 
 async def stop_cluster(
-    session: AsyncSession, team_id: str, user_id_str: str, provider_id: str, cluster_name: str
+    session: AsyncSession,
+    team_id: str,
+    user_id_str: str,
+    provider_id: str,
+    cluster_name: str,
+    job_id: Optional[Union[str, int]] = None,
 ) -> Any:
     provider = await get_team_provider(session, team_id, provider_id)
     if not provider:
@@ -69,13 +74,16 @@ async def stop_cluster(
         provider_instance = await get_provider_instance(provider, user_id=user_id_str, team_id=team_id)
 
         if provider.type == ProviderType.LOCAL.value and hasattr(provider_instance, "extra_config"):
-            job_id_segment = None
-            if "-job-" in cluster_name:
-                job_id_segment = cluster_name.rsplit("-job-", 1)[-1] or None
-            if job_id_segment is not None:
-                job_dir = await asyncio.to_thread(resolve_local_provider_job_dir, job_id_segment, org_id=team_id)
+            if job_id is not None:
+                job_dir = await asyncio.to_thread(resolve_local_provider_job_dir, str(job_id), org_id=team_id)
                 if job_dir:
                     provider_instance.extra_config["workspace_dir"] = job_dir
+            else:
+                logger.warning(
+                    "Local stop_cluster called without job_id for provider_id=%s, cluster_name=%s",
+                    provider_id,
+                    cluster_name,
+                )
 
         return await asyncio.to_thread(provider_instance.stop_cluster, cluster_name)
     except Exception as e:

--- a/api/transformerlab/services/compute_provider/cluster_naming.py
+++ b/api/transformerlab/services/compute_provider/cluster_naming.py
@@ -6,7 +6,7 @@ from typing import Optional
 # Cap cluster names to 41 characters to stay withing the limit of
 # the strictest provider (dstack).
 # This means capping the basename portion to 28 characters (use 25 to be safe)
-# to leave room for a ``-job-<short_id>`` suffix (13 chars).
+# to leave room for a ``-<short_id>`` suffix.
 _MAX_BASENAME_LENGTH = 25
 
 

--- a/api/transformerlab/services/compute_provider/launch_sweep.py
+++ b/api/transformerlab/services/compute_provider/launch_sweep.py
@@ -164,9 +164,7 @@ async def launch_sweep_jobs(
 
                 run_suffix = f"sweep-{i + 1}"
                 parent_job_short_id = job_service.get_short_job_id(parent_job_id)
-                formatted_cluster_name = (
-                    f"{sanitize_cluster_basename(base_name)}-{run_suffix}-job-{parent_job_short_id}"
-                )
+                formatted_cluster_name = f"{sanitize_cluster_basename(base_name)}-{run_suffix}-{parent_job_short_id}"
 
                 child_job_id = await job_service.job_create(
                     type="REMOTE",

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -199,7 +199,7 @@ async def launch_template_on_provider(
 
     base_name = request.cluster_name or request.task_name or provider.name
     job_short_id = job_service.get_short_job_id(job_id)
-    formatted_cluster_name = f"{sanitize_cluster_basename(base_name)}-job-{job_short_id}"
+    formatted_cluster_name = f"{sanitize_cluster_basename(base_name)}-{job_short_id}"
 
     user_info = {}
     if getattr(user, "first_name", None) or getattr(user, "last_name", None):

--- a/api/transformerlab/services/compute_provider/remote_job_endpoints_service.py
+++ b/api/transformerlab/services/compute_provider/remote_job_endpoints_service.py
@@ -180,7 +180,7 @@ async def resume_remote_job_from_checkpoint(
 
     base_name = job_data.get("task_name") or provider.name
     new_job_short_id = job_service.get_short_job_id(new_job_id)
-    formatted_cluster_name = f"{sanitize_cluster_basename(base_name)}-job-{new_job_short_id}"
+    formatted_cluster_name = f"{sanitize_cluster_basename(base_name)}-{new_job_short_id}"
 
     user = user_and_team.get("user")
     user_info: Dict[str, Any] = {}

--- a/api/transformerlab/services/compute_provider/trackio_launch.py
+++ b/api/transformerlab/services/compute_provider/trackio_launch.py
@@ -12,7 +12,7 @@ def resolve_trackio_project_name(experiment_id: str | int, requested_project_nam
 
 
 def build_trackio_run_name(task_name: str | None, job_short_id: str) -> str:
-    return f"{task_name or 'task'}-job-{job_short_id}"
+    return f"{task_name or 'task'}-{job_short_id}"
 
 
 async def apply_trackio_launch_env(

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.36"
+version = "0.0.37"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.35"
+version = "0.0.36"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/tests/integration/test_live_cli_routes.py
+++ b/cli/tests/integration/test_live_cli_routes.py
@@ -314,7 +314,7 @@ def test_cli_task_routes_live_server(live_context: dict[str, str]) -> None:
 def test_cli_job_and_artifact_routes_live_server(live_context: dict[str, str]) -> None:
     headers = live_context["headers"]
     experiment_id = live_context["experiment_id"]
-    fake_job_id = "route-smoke-job-id"
+    fake_job_id = "route-smoke-id"
 
     with httpx.Client(timeout=30.0) as client:
         _assert_status_in(

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.36"
+version = "0.0.37"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.35"
+version = "0.0.36"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/docs/demos/playwright/mnist-demo.spec.ts
+++ b/docs/demos/playwright/mnist-demo.spec.ts
@@ -276,8 +276,8 @@ test.describe('MNIST Train Task Demo', () => {
     await page.waitForTimeout(CONTENT_LOAD_PAUSE); // Let runs list populate
 
     // Scroll down to find run #43 — look for the static text "43"
-    // followed by "trl-train-task-job-43"
-    const run43Text = page.getByText('trl-train-task-job-43');
+    // followed by "trl-train-task-43"
+    const run43Text = page.getByText('trl-train-task-43');
     await smoothScrollTo(page, run43Text);
     await expect(run43Text).toBeVisible({ timeout: 60_000 });
     await page.waitForTimeout(TRANSITION_PAUSE);
@@ -301,7 +301,7 @@ test.describe('MNIST Train Task Demo', () => {
     // ── Step 7: Click Checkpoints ───────────────────────────────────────
     await narrate(page, script, 'Step 7');
     // Re-scroll to run #43 area and click Checkpoints
-    const run43TextAgain = page.getByText('trl-train-task-job-43');
+    const run43TextAgain = page.getByText('trl-train-task-43');
     await smoothScrollTo(page, run43TextAgain);
 
     const run43RowAgain = run43TextAgain.locator('xpath=ancestor::tr');
@@ -320,7 +320,7 @@ test.describe('MNIST Train Task Demo', () => {
 
     // ── Step 8: Click W&B Tracking ──────────────────────────────────────
     await narrate(page, script, 'Step 8');
-    const run43TextWandb = page.getByText('trl-train-task-job-43');
+    const run43TextWandb = page.getByText('trl-train-task-43');
     await smoothScrollTo(page, run43TextWandb);
 
     const run43RowWandb = run43TextWandb.locator('xpath=ancestor::tr');

--- a/src/renderer/components/Experiment/Tasks/JobProgress.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobProgress.tsx
@@ -82,6 +82,7 @@ export default function JobProgress({
           chatAPI.Endpoints.ComputeProvider.StopCluster(
             providerId,
             clusterName,
+            job.id,
           ),
           { method: 'POST' },
         );

--- a/src/renderer/lib/api-client/endpoints.ts
+++ b/src/renderer/lib/api-client/endpoints.ts
@@ -114,8 +114,13 @@ Endpoints.ComputeProvider = {
   },
   GetSweepResults: (jobId: string) =>
     `${API_URL()}compute_provider/sweep/${jobId}/results`,
-  StopCluster: (providerId: string, clusterName: string) =>
-    `${API_URL()}compute_provider/providers/${providerId}/clusters/${clusterName}/stop`,
+  StopCluster: (providerId: string, clusterName: string, jobId?: string | number) => {
+    const base = `${API_URL()}compute_provider/providers/${providerId}/clusters/${clusterName}/stop`;
+    if (jobId === undefined || jobId === null) {
+      return base;
+    }
+    return `${base}?job_id=${encodeURIComponent(String(jobId))}`;
+  },
   UploadTemplateFile: (providerId: string, taskId: string | number) =>
     `${API_URL()}compute_provider/providers/${providerId}/launch/${taskId}/file-upload`,
   UploadTaskFile: (providerId: string, taskId: string | number) =>

--- a/src/renderer/lib/api-client/endpoints.ts
+++ b/src/renderer/lib/api-client/endpoints.ts
@@ -114,7 +114,11 @@ Endpoints.ComputeProvider = {
   },
   GetSweepResults: (jobId: string) =>
     `${API_URL()}compute_provider/sweep/${jobId}/results`,
-  StopCluster: (providerId: string, clusterName: string, jobId?: string | number) => {
+  StopCluster: (
+    providerId: string,
+    clusterName: string,
+    jobId?: string | number,
+  ) => {
     const base = `${API_URL()}compute_provider/providers/${providerId}/clusters/${clusterName}/stop`;
     if (jobId === undefined || jobId === null) {
       return base;

--- a/test/playwright/dataset-generate-task-github.spec.ts
+++ b/test/playwright/dataset-generate-task-github.spec.ts
@@ -81,7 +81,7 @@ test.describe('Dataset Generation Task From GitHub', () => {
       queueDialog.getByRole('combobox', { name: 'Compute Provider' }),
     ).toHaveText('Local', { timeout: 5000 });
     await queueDialog.getByRole('button', { name: 'Submit' }).click();
-    const jobNamePrefix = `${taskName}-job-`;
+    const jobNamePrefix = `${taskName}-`;
     const queuedJobRow = page.locator('tr', {
       has: page.getByRole('button', { name: 'Output' }),
       hasText: jobNamePrefix,

--- a/test/playwright/dataset-generate-task.spec.ts
+++ b/test/playwright/dataset-generate-task.spec.ts
@@ -93,7 +93,7 @@ run: "python ~/demo-generate-task/fake_generate.py"
       queueDialog.getByRole('combobox', { name: 'Compute Provider' }),
     ).toHaveText('Local', { timeout: 5000 });
     await queueDialog.getByRole('button', { name: 'Submit' }).click();
-    const jobNamePrefix = `${taskName}-job-`;
+    const jobNamePrefix = `${taskName}-`;
     const queuedJobRow = page.locator('tr', {
       has: page.getByRole('button', { name: 'Output' }),
       hasText: jobNamePrefix,


### PR DESCRIPTION
This fixes the blocker for removing the `-job-`  format for cluster names (currently partly done in https://github.com/transformerlab/transformerlab-app/pull/1914)