### PR TITLE
Fix discrepancies in id and interactive_type for interactive gallery

### DIFF
--- a/api/test/shared/test_galleries.py
+++ b/api/test/shared/test_galleries.py
@@ -36,19 +36,3 @@ def test_local_channel_path_uses_selected_channel(monkeypatch, tmp_path):
 
     resolved = galleries.get_local_gallery_path(galleries.TASKS_GALLERY_FILE)
     assert resolved.endswith("channels/beta/latest/task-gallery.json")
-
-
-def test_get_interactive_gallery_backfills_interactive_type_from_id(monkeypatch):
-    async def fake_get_gallery_file(_filename: str):
-        return [
-            {"id": "comfy_ui", "name": "ComfyUI"},
-            {"id": "ssh", "interactive_type": "ssh", "name": "SSH"},
-        ]
-
-    monkeypatch.setattr(galleries, "get_gallery_file", fake_get_gallery_file)
-
-    import asyncio
-
-    result = asyncio.run(galleries.get_interactive_gallery())
-    assert result[0]["interactive_type"] == "comfy_ui"
-    assert result[1]["interactive_type"] == "ssh"

--- a/api/transformerlab/galleries/channels/stable/latest/interactive-gallery.json
+++ b/api/transformerlab/galleries/channels/stable/latest/interactive-gallery.json
@@ -266,6 +266,7 @@
   },
   {
     "id": "ollama_gradio",
+    "interactive_type": "ollama",
     "name": "Ollama + Gradio",
     "description": "Ollama model server with Gradio chat UI via ngrok tunnel",
     "github_repo_url": "https://github.com/transformerlab/transformerlab-app",
@@ -321,6 +322,7 @@
   },
   {
     "id": "comfy_ui",
+    "interactive_type": "comfyui",
     "name": "ComfyUI",
     "description": "ComfyUI server via ngrok tunnel",
     "github_repo_url": "https://github.com/transformerlab/transformerlab-app",
@@ -440,6 +442,7 @@
   },
   {
     "id": "mlx_gradio",
+    "interactive_type": "mlx",
     "name": "MLX LM + Gradio",
     "description": "MLX LM inference server with Gradio chat UI for Apple Silicon",
     "github_repo_url": "https://github.com/transformerlab/transformerlab-app",
@@ -492,6 +495,7 @@
   },
   {
     "id": "mlx_audio_tts",
+    "interactive_type": "mlx",
     "name": "MLX Audio TTS + Gradio",
     "description": "Text-to-Speech using MLX Audio with Gradio UI for Apple Silicon",
     "github_repo_url": "https://github.com/transformerlab/transformerlab-app",

--- a/api/transformerlab/galleries/channels/stable/latest/manifest.json
+++ b/api/transformerlab/galleries/channels/stable/latest/manifest.json
@@ -1,7 +1,7 @@
 {
-  "bundle_version": "20260424160054",
+  "bundle_version": "20260428184235",
   "channel": "stable",
-  "released_at": "2026-04-24T16:00:54.223569+00:00",
+  "released_at": "2026-04-28T18:42:35.366571+00:00",
   "files": {
     "task-gallery.json": 25,
     "interactive-gallery.json": 9,

--- a/api/transformerlab/galleries/combine_subset_galleries.py
+++ b/api/transformerlab/galleries/combine_subset_galleries.py
@@ -75,9 +75,7 @@ def _assert_interactive_schema(items: list[dict[str, Any]]) -> None:
         if not isinstance(entry_id, str) or not entry_id.strip():
             raise ValueError(f"Interactive entry at index {idx} missing required string field: id")
         if not isinstance(interactive_type, str) or not interactive_type.strip():
-            raise ValueError(
-                f"Interactive entry '{entry_id}' missing required string field: interactive_type"
-            )
+            raise ValueError(f"Interactive entry '{entry_id}' missing required string field: interactive_type")
 
 
 def build_galleries() -> dict[str, list[dict[str, Any]]]:

--- a/api/transformerlab/galleries/combine_subset_galleries.py
+++ b/api/transformerlab/galleries/combine_subset_galleries.py
@@ -66,11 +66,27 @@ def _assert_no_duplicate_ids(items: list[dict[str, Any]], gallery_name: str) -> 
         seen_ids.add(normalized)
 
 
+def _assert_interactive_schema(items: list[dict[str, Any]]) -> None:
+    for idx, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise ValueError(f"Invalid interactive entry at index {idx}: expected object")
+        entry_id = item.get("id")
+        interactive_type = item.get("interactive_type")
+        if not isinstance(entry_id, str) or not entry_id.strip():
+            raise ValueError(f"Interactive entry at index {idx} missing required string field: id")
+        if not isinstance(interactive_type, str) or not interactive_type.strip():
+            raise ValueError(
+                f"Interactive entry '{entry_id}' missing required string field: interactive_type"
+            )
+
+
 def build_galleries() -> dict[str, list[dict[str, Any]]]:
     combined: dict[str, list[dict[str, Any]]] = {}
     for source_dir, output_filename in GALLERY_SPECS.items():
         source_folder = SOURCE_ROOT / source_dir
         entries = _combine_folder(source_folder)
+        if output_filename == "interactive-gallery.json":
+            _assert_interactive_schema(entries)
         combined[output_filename] = entries
     return combined
 

--- a/api/transformerlab/galleries/src/interactive/interactive.json
+++ b/api/transformerlab/galleries/src/interactive/interactive.json
@@ -266,6 +266,7 @@
   },
   {
     "id": "ollama_gradio",
+    "interactive_type": "ollama",
     "name": "Ollama + Gradio",
     "description": "Ollama model server with Gradio chat UI via ngrok tunnel",
     "github_repo_url": "https://github.com/transformerlab/transformerlab-app",
@@ -321,6 +322,7 @@
   },
   {
     "id": "comfy_ui",
+    "interactive_type": "comfyui",
     "name": "ComfyUI",
     "description": "ComfyUI server via ngrok tunnel",
     "github_repo_url": "https://github.com/transformerlab/transformerlab-app",
@@ -440,6 +442,7 @@
   },
   {
     "id": "mlx_gradio",
+    "interactive_type": "mlx",
     "name": "MLX LM + Gradio",
     "description": "MLX LM inference server with Gradio chat UI for Apple Silicon",
     "github_repo_url": "https://github.com/transformerlab/transformerlab-app",
@@ -492,6 +495,7 @@
   },
   {
     "id": "mlx_audio_tts",
+    "interactive_type": "mlx",
     "name": "MLX Audio TTS + Gradio",
     "description": "Text-to-Speech using MLX Audio with Gradio UI for Apple Silicon",
     "github_repo_url": "https://github.com/transformerlab/transformerlab-app",

--- a/api/transformerlab/routers/experiment/task.py
+++ b/api/transformerlab/routers/experiment/task.py
@@ -1033,7 +1033,7 @@ async def import_task_from_gallery(
         # Create interactive task template (store interactive_gallery_id for launch-time run resolution)
         requested_name = (request.name or "").strip()
         task_name = requested_name or gallery_entry.get("name", "Interactive Task")
-        interactive_type = gallery_entry.get("interactive_type") or gallery_entry.get("id") or "custom"
+        interactive_type = gallery_entry.get("interactive_type") or "custom"
         interactive_gallery_id = gallery_entry.get("id")
 
         # Resolve task setup/command from the gallery entry's source:
@@ -1480,11 +1480,8 @@ async def import_task_from_team_gallery(
     interactive_gallery_id = gallery_entry.get("interactive_gallery_id") or (
         inline_config.get("interactive_gallery_id") if inline_config else None
     )
-    interactive_type = (
-        gallery_entry.get("interactive_type")
-        or (inline_config.get("interactive_type") if inline_config else None)
-        or gallery_entry.get("id")
-        or interactive_gallery_id
+    interactive_type = gallery_entry.get("interactive_type") or (
+        inline_config.get("interactive_type") if inline_config else None
     )
 
     # --- 1) Filesystem-backed entry: read task.yaml and copy whole directory ---

--- a/api/transformerlab/shared/galleries.py
+++ b/api/transformerlab/shared/galleries.py
@@ -67,22 +67,7 @@ async def get_interactive_gallery():
     This contains templates for interactive task types (vscode, jupyter, vllm, ssh).
     Task run/setup resolve from task.yaml; gallery metadata augments for tunnels; see resolve_interactive_command.
     """
-    raw_gallery = await get_gallery_file(INTERACTIVE_GALLERY_FILE)
-    if not isinstance(raw_gallery, list):
-        return []
-
-    # Backward compatibility: older gallery entries may not include interactive_type.
-    # Use the entry id as a stable interactive_type so imported tasks/jobs do not
-    # collapse to the generic "custom" parser path.
-    normalized: list[dict] = []
-    for entry in raw_gallery:
-        if not isinstance(entry, dict):
-            continue
-        normalized_entry = dict(entry)
-        if not normalized_entry.get("interactive_type") and normalized_entry.get("id"):
-            normalized_entry["interactive_type"] = normalized_entry.get("id")
-        normalized.append(normalized_entry)
-    return normalized
+    return await get_gallery_file(INTERACTIVE_GALLERY_FILE)
 
 
 async def get_announcements_gallery():

--- a/src/renderer/components/Experiment/Interactive/Interactive.tsx
+++ b/src/renderer/components/Experiment/Interactive/Interactive.tsx
@@ -635,15 +635,12 @@ export default function Interactive() {
 
         if (galleryResponse.ok) {
           const galleryData = await galleryResponse.json();
-          template = galleryData.data?.find((t: any) => {
-            if (data.template_id) {
-              return t.id === data.template_id;
-            }
-            return (
-              data.interactive_type &&
-              t.interactive_type === data.interactive_type
-            );
-          });
+          if (!data.template_id) {
+            throw new Error('Interactive template id is required');
+          }
+          template = galleryData.data?.find(
+            (t: any) => t.id === data.template_id,
+          );
 
           if (!template) {
             throw new Error(

--- a/src/renderer/components/Experiment/Interactive/InteractiveJobCard.tsx
+++ b/src/renderer/components/Experiment/Interactive/InteractiveJobCard.tsx
@@ -151,8 +151,8 @@ export default function InteractiveJobCard({
   const TypeIcon = typeConfig?.icon;
 
   // Resolve a richer display name/icon from the interactive gallery entry.
-  // This avoids hard-coding per-interactive-type UI logic and lets new gallery
-  // entries render correctly even if `interactive_type` is missing.
+  // Entry lookup is by gallery id first; interactive type is used as the shared
+  // display type key.
   const interactiveGalleryUrl =
     experimentInfo?.id && (interactiveGalleryId || interactiveType)
       ? chatAPI.Endpoints.Task.InteractiveGallery(experimentInfo.id)
@@ -171,8 +171,7 @@ export default function InteractiveJobCard({
       ? galleryEntries.find((e) => e?.id === interactiveGalleryId)
       : null) ||
     (interactiveType
-      ? galleryEntries.find((e) => e?.interactive_type === interactiveType) ||
-        galleryEntries.find((e) => e?.id === interactiveType)
+      ? galleryEntries.find((e) => e?.interactive_type === interactiveType)
       : null);
 
   let boxBg = 'var(--joy-palette-neutral-softBg)';

--- a/src/renderer/components/Experiment/Tasks/EditInteractiveTaskModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/EditInteractiveTaskModal.tsx
@@ -109,16 +109,15 @@ export default function EditInteractiveTaskModal({
     return [];
   }, [galleryData]);
 
-  // Resolve gallery entry by interactive_gallery_id first, then interactive_type
+  // Resolve gallery entry by interactive_gallery_id.
   const galleryId = (task as any)?.interactive_gallery_id;
 
   // Update templateConfigFields when gallery loads
   React.useEffect(() => {
     if (gallery.length > 0) {
-      const template =
-        (galleryId && gallery.find((t) => (t as any).id === galleryId)) ||
-        (interactiveType &&
-          gallery.find((t) => t.interactive_type === interactiveType));
+      const template = galleryId
+        ? gallery.find((t) => (t as any).id === galleryId)
+        : undefined;
       if (template?.env_parameters) {
         setTemplateConfigFields(template.env_parameters);
       } else {
@@ -400,9 +399,8 @@ export default function EditInteractiveTaskModal({
       }
 
       // Persist all model-type fields to history before saving
-      const taskTypeOrId = interactiveType || galleryId;
-      if (taskTypeOrId) {
-        const historyKey = getModelHistoryKey(taskTypeOrId);
+      if (interactiveType) {
+        const historyKey = getModelHistoryKey(interactiveType);
         templateConfigFields
           .filter((field) => field.field_type === 'model')
           .forEach((field) => {
@@ -562,7 +560,7 @@ export default function EditInteractiveTaskModal({
                             onChange={(v) =>
                               handleConfigFieldChange(field.env_var, v)
                             }
-                            taskTypeOrId={interactiveType || galleryId}
+                            taskTypeOrId={interactiveType}
                             placeholder={field.placeholder}
                             disabled={false}
                             required={!!field.required}

--- a/src/renderer/components/Experiment/Tasks/NewInteractiveTaskModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/NewInteractiveTaskModal.tsx
@@ -470,9 +470,10 @@ export default function NewInteractiveTaskModal({
     // Persist model name to history before submitting
     const modelName = configFieldValues['MODEL_NAME'];
     if (modelName?.trim() && selectedTemplate) {
-      const taskTypeOrId =
-        selectedTemplate.interactive_type || selectedTemplate.id;
-      saveModelToHistory(getModelHistoryKey(taskTypeOrId), modelName.trim());
+      saveModelToHistory(
+        getModelHistoryKey(selectedTemplate.interactive_type),
+        modelName.trim(),
+      );
     }
 
     onSubmit(
@@ -772,8 +773,7 @@ export default function NewInteractiveTaskModal({
                                       handleConfigFieldChange(field.env_var, v)
                                     }
                                     taskTypeOrId={
-                                      selectedTemplate?.interactive_type ||
-                                      selectedTemplate?.id
+                                      selectedTemplate?.interactive_type
                                     }
                                     placeholder={field.placeholder}
                                     disabled={isSubmitting}

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -831,15 +831,12 @@ export default function Tasks({ subtype }: { subtype?: string }) {
 
         if (galleryResponse.ok) {
           const galleryData = await galleryResponse.json();
-          template = galleryData.data?.find((t: any) => {
-            if (data.template_id) {
-              return t.id === data.template_id;
-            }
-            return (
-              data.interactive_type &&
-              t.interactive_type === data.interactive_type
-            );
-          });
+          if (!data.template_id) {
+            throw new Error('Interactive template id is required');
+          }
+          template = galleryData.data?.find(
+            (t: any) => t.id === data.template_id,
+          );
 
           if (!template) {
             throw new Error(

--- a/src/renderer/components/Shared/ModelNameInput.tsx
+++ b/src/renderer/components/Shared/ModelNameInput.tsx
@@ -14,20 +14,12 @@ import { XIcon } from 'lucide-react';
 const MAX_HISTORY_SIZE = 10;
 const STORAGE_KEY_PREFIX = 'tlab:modelHistory:';
 
-/** Map interactive_type values to stable storage-key suffixes. */
-const TASK_TYPE_KEY_MAP: Record<string, string> = {
-  vllm: 'vllm',
-  ollama: 'ollama',
-  mlx: 'mlx',
-};
-
 /** Derive the localStorage key for a given interactive_type. */
 export function getModelHistoryKey(
   taskTypeOrId: string | undefined | null,
 ): string {
   if (!taskTypeOrId) return `${STORAGE_KEY_PREFIX}default`;
-  const mapped = TASK_TYPE_KEY_MAP[taskTypeOrId];
-  return `${STORAGE_KEY_PREFIX}${mapped ?? taskTypeOrId}`;
+  return `${STORAGE_KEY_PREFIX}${taskTypeOrId}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/components/Shared/ModelNameInput.tsx
+++ b/src/renderer/components/Shared/ModelNameInput.tsx
@@ -14,19 +14,14 @@ import { XIcon } from 'lucide-react';
 const MAX_HISTORY_SIZE = 10;
 const STORAGE_KEY_PREFIX = 'tlab:modelHistory:';
 
-/**
- * Map interactive_type / gallery id values to a stable storage-key suffix.
- * Gallery entries without an interactive_type use their id directly.
- */
+/** Map interactive_type values to stable storage-key suffixes. */
 const TASK_TYPE_KEY_MAP: Record<string, string> = {
   vllm: 'vllm',
   ollama: 'ollama',
-  ollama_gradio: 'ollama',
-  mlx_gradio: 'mlx',
-  mlx_audio_tts: 'mlx',
+  mlx: 'mlx',
 };
 
-/** Derive the localStorage key for a given task type / gallery id. */
+/** Derive the localStorage key for a given interactive_type. */
 export function getModelHistoryKey(
   taskTypeOrId: string | undefined | null,
 ): string {
@@ -98,8 +93,8 @@ export interface ModelNameInputProps {
   /** Called whenever the input value changes (free-form typing or selection). */
   onChange: (value: string) => void;
   /**
-   * The interactive_type or gallery id used to scope the history.
-   * e.g. 'vllm', 'ollama', 'mlx_gradio'. Pass `undefined` to use the
+   * The interactive_type used to scope the history.
+   * e.g. 'vllm', 'ollama', 'mlx'. Pass `undefined` to use the
    * default (shared) bucket.
    */
   taskTypeOrId?: string | null;


### PR DESCRIPTION
- `interactive_type` can be common among interactive tasks
- `id` is common for every interactive tasks
- We are now using `interactive_type` and `id` correctly based on what's needed where