### PR TITLE
Adds per-task jobs page

### DIFF
--- a/api/transformerlab/services/compute_provider/launch_sweep.py
+++ b/api/transformerlab/services/compute_provider/launch_sweep.py
@@ -346,7 +346,7 @@ async def launch_sweep_jobs(
                     "user_info": user_info or None,
                     "start_time": time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime()),
                 }
-                if request.file_mounts is True and request.task_id:
+                if request.task_id:
                     child_job_data["task_id"] = request.task_id
                 if trackio_project_name_for_child is not None:
                     child_job_data["trackio_project_name"] = trackio_project_name_for_child

--- a/api/transformerlab/services/compute_provider/launch_template.py
+++ b/api/transformerlab/services/compute_provider/launch_template.py
@@ -601,7 +601,7 @@ async def launch_template_on_provider(
     }
     if provider.type == ProviderType.LOCAL.value and provider_config_dict.get("workspace_dir"):
         job_data["workspace_dir"] = provider_config_dict["workspace_dir"]
-    if request.file_mounts is True and request.task_id:
+    if request.task_id:
         job_data["task_id"] = request.task_id
     if trackio_project_name_for_job is not None:
         job_data["trackio_project_name"] = trackio_project_name_for_job

--- a/src/renderer/components/Experiment/Jobs/JobDetailPage.tsx
+++ b/src/renderer/components/Experiment/Jobs/JobDetailPage.tsx
@@ -69,10 +69,11 @@ export default function JobDetailPage() {
     experimentInfo?.id ? chatAPI.Endpoints.Task.List(experimentInfo.id) : null,
   );
 
-  const { backHref, backLabel } = useMemo(() => {
+  const { backHref, backLabel, taskCrumb } = useMemo(() => {
     const fallback = {
       backHref: `/experiment/${experimentName}/tasks`,
       backLabel: `Back to ${experimentName} tasks`,
+      taskCrumb: null as { name: string; href: string } | null,
     };
     if (!job) return fallback;
     const jd: any = job.job_data ?? {};
@@ -97,9 +98,11 @@ export default function JobDetailPage() {
     }
     if (!taskId) return fallback;
     const label = taskName || 'task';
+    const href = `/experiment/${experimentName}/tasks/${taskId}/runs`;
     return {
-      backHref: `/experiment/${experimentName}/tasks/${taskId}/runs`,
+      backHref: href,
       backLabel: `Back to ${label} runs`,
+      taskCrumb: { name: label, href },
     };
   }, [job, allTemplates, experimentInfo?.id, experimentName]);
 
@@ -180,6 +183,24 @@ export default function JobDetailPage() {
           <Typography level="title-sm" sx={{ color: 'text.secondary' }}>
             {experimentName}
           </Typography>
+          {taskCrumb && (
+            <>
+              <Typography level="title-sm" sx={{ color: 'text.tertiary' }}>
+                /
+              </Typography>
+              <Typography
+                level="title-sm"
+                sx={{
+                  color: 'text.secondary',
+                  cursor: 'pointer',
+                  '&:hover': { textDecoration: 'underline' },
+                }}
+                onClick={() => navigate(taskCrumb.href)}
+              >
+                {taskCrumb.name}
+              </Typography>
+            </>
+          )}
           <Typography level="title-sm" sx={{ color: 'text.tertiary' }}>
             /
           </Typography>

--- a/src/renderer/components/Experiment/Jobs/JobDetailPage.tsx
+++ b/src/renderer/components/Experiment/Jobs/JobDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import Box from '@mui/joy/Box';
 import CircularProgress from '@mui/joy/CircularProgress';
@@ -65,6 +65,44 @@ export default function JobDetailPage() {
     : ['overview', 'logs'];
   const [activeSection, setActiveSection] = useState<SectionKey | null>(null);
 
+  const { data: allTemplates } = useSWRWithAuth(
+    experimentInfo?.id ? chatAPI.Endpoints.Task.List(experimentInfo.id) : null,
+  );
+
+  const { backHref, backLabel } = useMemo(() => {
+    const fallback = {
+      backHref: `/experiment/${experimentName}/tasks`,
+      backLabel: `Back to ${experimentName} tasks`,
+    };
+    if (!job) return fallback;
+    const jd: any = job.job_data ?? {};
+    const taskName: string =
+      (jd.task_name && String(jd.task_name).trim()) ||
+      (jd.template_name && String(jd.template_name).trim()) ||
+      '';
+    const list = Array.isArray(allTemplates)
+      ? allTemplates
+      : ((allTemplates as any)?.data ?? []);
+    let taskId: string | null = null;
+    const directId = jd.task_id ? String(jd.task_id) : '';
+    if (directId && (list as any[]).some((t) => String(t.id) === directId)) {
+      taskId = directId;
+    } else if (taskName) {
+      const match = (list as any[]).find(
+        (t) =>
+          String(t?.name ?? '').trim() === taskName &&
+          t.experiment_id === experimentInfo?.id,
+      );
+      if (match) taskId = String(match.id);
+    }
+    if (!taskId) return fallback;
+    const label = taskName || 'task';
+    return {
+      backHref: `/experiment/${experimentName}/tasks/${taskId}/runs`,
+      backLabel: `Back to ${label} runs`,
+    };
+  }, [job, allTemplates, experimentInfo?.id, experimentName]);
+
   const effectiveSection: SectionKey =
     activeSection ?? (job ? getDefaultSection(job.status ?? '') : 'overview');
 
@@ -130,11 +168,11 @@ export default function JobDetailPage() {
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Tooltip title={`Back to ${experimentName} tasks`}>
+          <Tooltip title={backLabel}>
             <IconButton
               size="sm"
               variant="plain"
-              onClick={() => navigate(`/experiment/${experimentName}/tasks`)}
+              onClick={() => navigate(backHref)}
             >
               <ArrowLeftIcon size={16} />
             </IconButton>

--- a/src/renderer/components/Experiment/Jobs/JobDetailPage.tsx
+++ b/src/renderer/components/Experiment/Jobs/JobDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import Box from '@mui/joy/Box';
 import CircularProgress from '@mui/joy/CircularProgress';
 import Typography from '@mui/joy/Typography';
@@ -37,12 +37,26 @@ const SECTION_LABELS: Record<SectionKey, string> = {
   sweepResults: 'Sweep Results',
 };
 
+const VALID_SECTIONS = new Set<SectionKey>([
+  'overview',
+  'logs',
+  'checkpoints',
+  'artifacts',
+  'evalResults',
+  'sweepResults',
+]);
+
 export default function JobDetailPage() {
   const { experimentName = '', jobId = '' } = useParams<{
     experimentName: string;
     jobId: string;
   }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const initialSectionFromUrl = (() => {
+    const s = searchParams.get('section');
+    return s && VALID_SECTIONS.has(s as SectionKey) ? (s as SectionKey) : null;
+  })();
   const { experimentInfo, setExperimentId } = useExperimentInfo();
 
   useEffect(() => {
@@ -63,7 +77,9 @@ export default function JobDetailPage() {
   const visibleSections: SectionKey[] = job
     ? getVisibleSections(job)
     : ['overview', 'logs'];
-  const [activeSection, setActiveSection] = useState<SectionKey | null>(null);
+  const [activeSection, setActiveSection] = useState<SectionKey | null>(
+    initialSectionFromUrl,
+  );
 
   const { data: allTemplates } = useSWRWithAuth(
     experimentInfo?.id ? chatAPI.Endpoints.Task.List(experimentInfo.id) : null,

--- a/src/renderer/components/Experiment/Jobs/jobDetailUtils.test.ts
+++ b/src/renderer/components/Experiment/Jobs/jobDetailUtils.test.ts
@@ -2,6 +2,7 @@ import {
   getDefaultSection,
   getVisibleSections,
   generateJobPermalink,
+  generateTaskRunsPermalink,
   type SectionKey,
 } from './jobDetailUtils';
 
@@ -76,5 +77,12 @@ describe('generateJobPermalink', () => {
   it('builds a hash URL with experiment and job id', () => {
     const link = generateJobPermalink('my-exp', 'abc-123');
     expect(link).toBe('#/experiment/my-exp/jobs/abc-123');
+  });
+});
+
+describe('generateTaskRunsPermalink', () => {
+  it('builds a hash URL with experiment and task id', () => {
+    const link = generateTaskRunsPermalink('my-exp', 'task-42');
+    expect(link).toBe('#/experiment/my-exp/tasks/task-42/runs');
   });
 });

--- a/src/renderer/components/Experiment/Jobs/jobDetailUtils.ts
+++ b/src/renderer/components/Experiment/Jobs/jobDetailUtils.ts
@@ -48,3 +48,10 @@ export function generateJobPermalink(
 ): string {
   return `#/experiment/${experimentName}/jobs/${jobId}`;
 }
+
+export function generateTaskRunsPermalink(
+  experimentName: string,
+  taskId: string,
+): string {
+  return `#/experiment/${experimentName}/tasks/${taskId}/runs`;
+}

--- a/src/renderer/components/Experiment/Tasks/JobsList.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsList.tsx
@@ -68,7 +68,6 @@ interface JobsListProps {
   showFilesButton?: boolean;
   forceArtifactsButtonVisible?: boolean;
   onStopPendingChange?: (jobId: string, stopPending: boolean) => void;
-  consolidatedActions?: boolean;
 }
 
 const JobsList: React.FC<JobsListProps> = ({
@@ -98,7 +97,6 @@ const JobsList: React.FC<JobsListProps> = ({
   showFilesButton = true,
   forceArtifactsButtonVisible = false,
   onStopPendingChange,
-  consolidatedActions = false,
 }) => {
   const { experimentInfo } = useExperimentInfo();
 
@@ -394,18 +392,7 @@ const JobsList: React.FC<JobsListProps> = ({
                           Trackio
                         </Button>
                       )}
-                    {consolidatedActions && !job?.placeholder && (
-                      <Button
-                        size="sm"
-                        variant="plain"
-                        onClick={() => onViewOutput?.(job?.id)}
-                        disabled={stopPending}
-                        startDecorator={<LogsIcon />}
-                      >
-                        Logs
-                      </Button>
-                    )}
-                    {!consolidatedActions && !hideOutputButton && (
+                    {!hideOutputButton && (
                       <Button
                         size="sm"
                         variant="plain"
@@ -416,7 +403,7 @@ const JobsList: React.FC<JobsListProps> = ({
                         Output
                       </Button>
                     )}
-                    {!consolidatedActions && job?.job_data?.eval_images_dir && (
+                    {job?.job_data?.eval_images_dir && (
                       <Button
                         size="sm"
                         variant="plain"
@@ -426,8 +413,7 @@ const JobsList: React.FC<JobsListProps> = ({
                         View Eval Images
                       </Button>
                     )}
-                    {!consolidatedActions &&
-                      job?.job_data?.eval_results &&
+                    {job?.job_data?.eval_results &&
                       Array.isArray(job.job_data.eval_results) &&
                       job.job_data.eval_results.length > 0 && (
                         <Button
@@ -440,13 +426,12 @@ const JobsList: React.FC<JobsListProps> = ({
                           Eval Results
                         </Button>
                       )}
-                    {!consolidatedActions &&
-                      (forceArtifactsButtonVisible ||
-                        job?.job_data?.artifacts ||
-                        job?.job_data?.artifacts_dir ||
-                        job?.job_data?.generated_datasets ||
-                        job?.job_data?.models ||
-                        job?.job_data?.has_profiling) &&
+                    {(forceArtifactsButtonVisible ||
+                      job?.job_data?.artifacts ||
+                      job?.job_data?.artifacts_dir ||
+                      job?.job_data?.generated_datasets ||
+                      job?.job_data?.models ||
+                      job?.job_data?.has_profiling) &&
                       !job?.placeholder && (
                         <Button
                           size="sm"
@@ -458,8 +443,7 @@ const JobsList: React.FC<JobsListProps> = ({
                           Artifacts
                         </Button>
                       )}
-                    {!consolidatedActions &&
-                      (job?.type === 'SWEEP' || job?.job_data?.sweep_parent) &&
+                    {(job?.type === 'SWEEP' || job?.job_data?.sweep_parent) &&
                       job?.status === 'COMPLETE' && (
                         <Button
                           size="sm"
@@ -471,19 +455,17 @@ const JobsList: React.FC<JobsListProps> = ({
                           Sweep Results
                         </Button>
                       )}
-                    {!consolidatedActions &&
-                      job?.job_data?.sweep_output_file && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => onViewSweepOutput?.(job?.id)}
-                          disabled={stopPending}
-                        >
-                          Sweep Output
-                        </Button>
-                      )}
-                    {!consolidatedActions &&
-                      job?.status === 'INTERACTIVE' &&
+                    {job?.job_data?.sweep_output_file && (
+                      <Button
+                        size="sm"
+                        variant="plain"
+                        onClick={() => onViewSweepOutput?.(job?.id)}
+                        disabled={stopPending}
+                      >
+                        Sweep Output
+                      </Button>
+                    )}
+                    {job?.status === 'INTERACTIVE' &&
                       job?.job_data?.subtype === 'interactive' && (
                         <>
                           <Button
@@ -507,7 +489,7 @@ const JobsList: React.FC<JobsListProps> = ({
                           )}
                         </>
                       )}
-                    {!consolidatedActions && job?.job_data?.checkpoints && (
+                    {job?.job_data?.checkpoints && (
                       <Button
                         size="sm"
                         variant="plain"
@@ -518,19 +500,17 @@ const JobsList: React.FC<JobsListProps> = ({
                         Checkpoints
                       </Button>
                     )}
-                    {!consolidatedActions &&
-                      showFilesButton &&
-                      !job?.placeholder && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => onViewFileBrowser?.(job?.id)}
-                          disabled={stopPending}
-                          startDecorator={<FolderOpenIcon />}
-                        >
-                          Files
-                        </Button>
-                      )}
+                    {showFilesButton && !job?.placeholder && (
+                      <Button
+                        size="sm"
+                        variant="plain"
+                        onClick={() => onViewFileBrowser?.(job?.id)}
+                        disabled={stopPending}
+                        startDecorator={<FolderOpenIcon />}
+                      >
+                        Files
+                      </Button>
+                    )}
                     {!job?.placeholder && (
                       <Tooltip title="Copy permalink" variant="outlined">
                         <IconButton

--- a/src/renderer/components/Experiment/Tasks/JobsList.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsList.tsx
@@ -68,6 +68,7 @@ interface JobsListProps {
   showFilesButton?: boolean;
   forceArtifactsButtonVisible?: boolean;
   onStopPendingChange?: (jobId: string, stopPending: boolean) => void;
+  consolidatedActions?: boolean;
 }
 
 const JobsList: React.FC<JobsListProps> = ({
@@ -97,6 +98,7 @@ const JobsList: React.FC<JobsListProps> = ({
   showFilesButton = true,
   forceArtifactsButtonVisible = false,
   onStopPendingChange,
+  consolidatedActions = false,
 }) => {
   const { experimentInfo } = useExperimentInfo();
 
@@ -392,7 +394,18 @@ const JobsList: React.FC<JobsListProps> = ({
                           Trackio
                         </Button>
                       )}
-                    {!hideOutputButton && (
+                    {consolidatedActions && !job?.placeholder && (
+                      <Button
+                        size="sm"
+                        variant="plain"
+                        onClick={() => onViewOutput?.(job?.id)}
+                        disabled={stopPending}
+                        startDecorator={<LogsIcon />}
+                      >
+                        Logs
+                      </Button>
+                    )}
+                    {!consolidatedActions && !hideOutputButton && (
                       <Button
                         size="sm"
                         variant="plain"
@@ -403,7 +416,7 @@ const JobsList: React.FC<JobsListProps> = ({
                         Output
                       </Button>
                     )}
-                    {job?.job_data?.eval_images_dir && (
+                    {!consolidatedActions && job?.job_data?.eval_images_dir && (
                       <Button
                         size="sm"
                         variant="plain"
@@ -413,7 +426,8 @@ const JobsList: React.FC<JobsListProps> = ({
                         View Eval Images
                       </Button>
                     )}
-                    {job?.job_data?.eval_results &&
+                    {!consolidatedActions &&
+                      job?.job_data?.eval_results &&
                       Array.isArray(job.job_data.eval_results) &&
                       job.job_data.eval_results.length > 0 && (
                         <Button
@@ -426,12 +440,13 @@ const JobsList: React.FC<JobsListProps> = ({
                           Eval Results
                         </Button>
                       )}
-                    {(forceArtifactsButtonVisible ||
-                      job?.job_data?.artifacts ||
-                      job?.job_data?.artifacts_dir ||
-                      job?.job_data?.generated_datasets ||
-                      job?.job_data?.models ||
-                      job?.job_data?.has_profiling) &&
+                    {!consolidatedActions &&
+                      (forceArtifactsButtonVisible ||
+                        job?.job_data?.artifacts ||
+                        job?.job_data?.artifacts_dir ||
+                        job?.job_data?.generated_datasets ||
+                        job?.job_data?.models ||
+                        job?.job_data?.has_profiling) &&
                       !job?.placeholder && (
                         <Button
                           size="sm"
@@ -443,7 +458,8 @@ const JobsList: React.FC<JobsListProps> = ({
                           Artifacts
                         </Button>
                       )}
-                    {(job?.type === 'SWEEP' || job?.job_data?.sweep_parent) &&
+                    {!consolidatedActions &&
+                      (job?.type === 'SWEEP' || job?.job_data?.sweep_parent) &&
                       job?.status === 'COMPLETE' && (
                         <Button
                           size="sm"
@@ -455,17 +471,19 @@ const JobsList: React.FC<JobsListProps> = ({
                           Sweep Results
                         </Button>
                       )}
-                    {job?.job_data?.sweep_output_file && (
-                      <Button
-                        size="sm"
-                        variant="plain"
-                        onClick={() => onViewSweepOutput?.(job?.id)}
-                        disabled={stopPending}
-                      >
-                        Sweep Output
-                      </Button>
-                    )}
-                    {job?.status === 'INTERACTIVE' &&
+                    {!consolidatedActions &&
+                      job?.job_data?.sweep_output_file && (
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          onClick={() => onViewSweepOutput?.(job?.id)}
+                          disabled={stopPending}
+                        >
+                          Sweep Output
+                        </Button>
+                      )}
+                    {!consolidatedActions &&
+                      job?.status === 'INTERACTIVE' &&
                       job?.job_data?.subtype === 'interactive' && (
                         <>
                           <Button
@@ -489,7 +507,7 @@ const JobsList: React.FC<JobsListProps> = ({
                           )}
                         </>
                       )}
-                    {job?.job_data?.checkpoints && (
+                    {!consolidatedActions && job?.job_data?.checkpoints && (
                       <Button
                         size="sm"
                         variant="plain"
@@ -500,17 +518,19 @@ const JobsList: React.FC<JobsListProps> = ({
                         Checkpoints
                       </Button>
                     )}
-                    {showFilesButton && !job?.placeholder && (
-                      <Button
-                        size="sm"
-                        variant="plain"
-                        onClick={() => onViewFileBrowser?.(job?.id)}
-                        disabled={stopPending}
-                        startDecorator={<FolderOpenIcon />}
-                      >
-                        Files
-                      </Button>
-                    )}
+                    {!consolidatedActions &&
+                      showFilesButton &&
+                      !job?.placeholder && (
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          onClick={() => onViewFileBrowser?.(job?.id)}
+                          disabled={stopPending}
+                          startDecorator={<FolderOpenIcon />}
+                        >
+                          Files
+                        </Button>
+                      )}
                     {!job?.placeholder && (
                       <Tooltip title="Copy permalink" variant="outlined">
                         <IconButton

--- a/src/renderer/components/Experiment/Tasks/JobsList.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Table from '@mui/joy/Table';
-import ButtonGroup from '@mui/joy/ButtonGroup';
+import Stack from '@mui/joy/Stack';
 import IconButton from '@mui/joy/IconButton';
 import Button from '@mui/joy/Button';
 import Skeleton from '@mui/joy/Skeleton';
@@ -181,7 +181,9 @@ const JobsList: React.FC<JobsListProps> = ({
             </Typography>
           )}
           {userDisplay && (
-            <Typography level="body-sm">{userDisplay}</Typography>
+            <Typography level="body-sm">
+              <b>Submitter:</b> {userDisplay}
+            </Typography>
           )}
           {providerDisplay && (
             <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
@@ -211,9 +213,21 @@ const JobsList: React.FC<JobsListProps> = ({
     return <b>{job.type || 'Unknown Job'}</b>;
   };
 
+  const tableHead = (
+    <thead>
+      <tr>
+        <th>Job ID</th>
+        <th>Job Details</th>
+        <th>Status</th>
+        <th style={{ textAlign: 'right' }}>Logs</th>
+      </tr>
+    </thead>
+  );
+
   if (loading) {
     return (
       <Table style={{ tableLayout: 'auto' }} stickyHeader>
+        {tableHead}
         <tbody>
           {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
             <tr key={i}>
@@ -243,6 +257,7 @@ const JobsList: React.FC<JobsListProps> = ({
 
   return (
     <Table style={{ tableLayout: 'auto' }} stickyHeader>
+      {tableHead}
       <tbody style={{ overflow: 'auto', height: '100%' }}>
         {jobs?.length > 0 ? (
           jobs?.map((job) => {
@@ -298,8 +313,11 @@ const JobsList: React.FC<JobsListProps> = ({
                     border: 'none',
                   }}
                 >
-                  <ButtonGroup
-                    sx={{ justifyContent: 'flex-end', flexWrap: 'wrap' }}
+                  <Stack
+                    direction="row"
+                    gap={0.5}
+                    flexWrap="wrap"
+                    justifyContent="flex-end"
                   >
                     {job?.placeholder && (
                       <Skeleton variant="rectangular" width={100} height={28} />
@@ -314,20 +332,9 @@ const JobsList: React.FC<JobsListProps> = ({
                         disabled={stopPending}
                         startDecorator={<LineChartIcon />}
                       >
-                        <Box
-                          sx={{
-                            display: {
-                              xs: 'none',
-                              sm: 'none',
-                              md: 'inline-flex',
-                            },
-                          }}
-                        >
-                          W&B Tracking
-                        </Box>
+                        W&B Tracking
                       </Button>
                     )}
-
                     {(job?.job_data?.trackio_db_artifact_path ||
                       job?.job_data?.trackio_project_name) &&
                       showTrackioForStatus(job?.status) && (
@@ -338,20 +345,9 @@ const JobsList: React.FC<JobsListProps> = ({
                           disabled={stopPending}
                           startDecorator={<LineChartIcon />}
                         >
-                          <Box
-                            sx={{
-                              display: {
-                                xs: 'none',
-                                sm: 'none',
-                                md: 'inline-flex',
-                              },
-                            }}
-                          >
-                            Trackio
-                          </Box>
+                          Trackio
                         </Button>
                       )}
-
                     {!hideOutputButton && (
                       <Button
                         size="sm"
@@ -360,17 +356,7 @@ const JobsList: React.FC<JobsListProps> = ({
                         disabled={stopPending}
                         startDecorator={<LogsIcon />}
                       >
-                        <Box
-                          sx={{
-                            display: {
-                              xs: 'none',
-                              sm: 'none',
-                              md: 'inline-flex',
-                            },
-                          }}
-                        >
-                          Output
-                        </Box>
+                        Output
                       </Button>
                     )}
                     {job?.job_data?.eval_images_dir && (
@@ -393,17 +379,7 @@ const JobsList: React.FC<JobsListProps> = ({
                           disabled={stopPending}
                           startDecorator={<FileTextIcon />}
                         >
-                          <Box
-                            sx={{
-                              display: {
-                                xs: 'none',
-                                sm: 'none',
-                                md: 'inline-flex',
-                              },
-                            }}
-                          >
-                            Eval Results
-                          </Box>
+                          Eval Results
                         </Button>
                       )}
                     {(forceArtifactsButtonVisible ||
@@ -420,17 +396,7 @@ const JobsList: React.FC<JobsListProps> = ({
                           disabled={stopPending}
                           startDecorator={<ArchiveIcon />}
                         >
-                          <Box
-                            sx={{
-                              display: {
-                                xs: 'none',
-                                sm: 'none',
-                                md: 'inline-flex',
-                              },
-                            }}
-                          >
-                            Artifacts
-                          </Box>
+                          Artifacts
                         </Button>
                       )}
                     {(job?.type === 'SWEEP' || job?.job_data?.sweep_parent) &&
@@ -442,17 +408,7 @@ const JobsList: React.FC<JobsListProps> = ({
                           disabled={stopPending}
                           startDecorator={<LineChartIcon />}
                         >
-                          <Box
-                            sx={{
-                              display: {
-                                xs: 'none',
-                                sm: 'none',
-                                md: 'inline-flex',
-                              },
-                            }}
-                          >
-                            Sweep Results
-                          </Box>
+                          Sweep Results
                         </Button>
                       )}
                     {job?.job_data?.sweep_output_file && (
@@ -484,17 +440,7 @@ const JobsList: React.FC<JobsListProps> = ({
                               disabled={stopPending}
                               startDecorator={<LogsIcon />}
                             >
-                              <Box
-                                sx={{
-                                  display: {
-                                    xs: 'none',
-                                    sm: 'none',
-                                    md: 'inline-flex',
-                                  },
-                                }}
-                              >
-                                Output
-                              </Box>
+                              Output
                             </Button>
                           )}
                         </>
@@ -506,21 +452,8 @@ const JobsList: React.FC<JobsListProps> = ({
                         onClick={() => onViewCheckpoints?.(job?.id)}
                         disabled={stopPending}
                         startDecorator={<WaypointsIcon />}
-                        sx={{
-                          justifyContent: 'center',
-                        }}
                       >
-                        <Box
-                          sx={{
-                            display: {
-                              xs: 'none',
-                              sm: 'none',
-                              md: 'inline-flex',
-                            },
-                          }}
-                        >
-                          Checkpoints
-                        </Box>
+                        Checkpoints
                       </Button>
                     )}
                     {showFilesButton && !job?.placeholder && (
@@ -531,17 +464,7 @@ const JobsList: React.FC<JobsListProps> = ({
                         disabled={stopPending}
                         startDecorator={<FolderOpenIcon />}
                       >
-                        <Box
-                          sx={{
-                            display: {
-                              xs: 'none',
-                              sm: 'none',
-                              md: 'inline-flex',
-                            },
-                          }}
-                        >
-                          Files
-                        </Box>
+                        Files
                       </Button>
                     )}
                     {!job?.placeholder && (
@@ -570,6 +493,7 @@ const JobsList: React.FC<JobsListProps> = ({
                     )}
                     {!job?.placeholder && (
                       <IconButton
+                        size="sm"
                         variant="plain"
                         disabled={
                           stopPending ||
@@ -590,7 +514,11 @@ const JobsList: React.FC<JobsListProps> = ({
                         <MenuButton
                           slots={{ root: IconButton }}
                           slotProps={{
-                            root: { variant: 'plain', color: 'neutral' },
+                            root: {
+                              variant: 'plain',
+                              color: 'neutral',
+                              size: 'sm',
+                            },
                           }}
                           sx={{ minWidth: 0 }}
                           disabled={stopPending}
@@ -638,7 +566,7 @@ const JobsList: React.FC<JobsListProps> = ({
                         </Menu>
                       </Dropdown>
                     )}
-                  </ButtonGroup>
+                  </Stack>
                 </td>
               </tr>
             );

--- a/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
@@ -351,6 +351,7 @@ export default function TaskRunsPage() {
               hideJobId={false}
               showFilesButton={false}
               forceArtifactsButtonVisible
+              consolidatedActions
             />
           )}
         </Box>

--- a/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
@@ -126,11 +126,15 @@ export default function TaskRunsPage() {
     return out;
   }, [taskJobs]);
 
-  const goToJob = (jobId: string | undefined) => {
+  const goToJob = (jobId: string | undefined, section?: string) => {
     const id = jobId == null ? '' : String(jobId);
     if (!id || id === '-1' || id === 'NaN') return;
-    navigate(`/experiment/${experimentName}/jobs/${id}`);
+    const suffix = section ? `?section=${section}` : '';
+    navigate(`/experiment/${experimentName}/jobs/${id}${suffix}`);
   };
+
+  const goToJobSection = (section: string) => (jobId: string | undefined) =>
+    goToJob(jobId, section);
 
   const copyPermalink = () => {
     navigator.clipboard
@@ -337,14 +341,14 @@ export default function TaskRunsPage() {
               jobs={taskJobs}
               launchProgressByJobId={launchProgressByJobId}
               onDeleteJob={handleDeleteJob}
-              onViewOutput={goToJob}
-              onViewCheckpoints={goToJob}
-              onViewAllArtifacts={goToJob}
-              onViewEvalImages={goToJob}
-              onViewEvalResults={goToJob}
-              onViewSweepOutput={goToJob}
-              onViewSweepResults={goToJob}
-              onViewInteractive={goToJob}
+              onViewOutput={goToJobSection('logs')}
+              onViewCheckpoints={goToJobSection('checkpoints')}
+              onViewAllArtifacts={goToJobSection('artifacts')}
+              onViewEvalImages={goToJobSection('artifacts')}
+              onViewEvalResults={goToJobSection('evalResults')}
+              onViewSweepOutput={goToJobSection('logs')}
+              onViewSweepResults={goToJobSection('sweepResults')}
+              onViewInteractive={goToJobSection('logs')}
               onViewTrackio={goToJob}
               loading={jobsLoading && taskJobs.length === 0}
               hideJobId={false}

--- a/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
@@ -313,7 +313,6 @@ export default function TaskRunsPage() {
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
                         flex: 1,
-                        fontWeight: isActive ? 'lg' : undefined,
                       }}
                     >
                       {label}

--- a/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
@@ -1,0 +1,360 @@
+import React, { useEffect, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import Box from '@mui/joy/Box';
+import CircularProgress from '@mui/joy/CircularProgress';
+import Typography from '@mui/joy/Typography';
+import Chip from '@mui/joy/Chip';
+import IconButton from '@mui/joy/IconButton';
+import Tooltip from '@mui/joy/Tooltip';
+import List from '@mui/joy/List';
+import ListItem from '@mui/joy/ListItem';
+import ListItemButton from '@mui/joy/ListItemButton';
+import { ArrowLeftIcon, LinkIcon } from 'lucide-react';
+import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
+import { useSWRWithAuth as useSWR, useAuth } from 'renderer/lib/authContext';
+import { fetcher } from 'renderer/lib/transformerlab-api-sdk';
+import * as chatAPI from 'renderer/lib/transformerlab-api-sdk';
+import { isDeletableJobRecordStatus } from 'renderer/lib/utils';
+import { useNotification } from 'renderer/components/Shared/NotificationSystem';
+import SafeJSONParse from 'renderer/components/Shared/SafeJSONParse';
+import { generateTaskRunsPermalink } from '../Jobs/jobDetailUtils';
+import JobsList from './JobsList';
+import { jobBelongsToTask } from './taskJobMatching';
+
+function isInteractiveTemplate(task: any): boolean {
+  const config =
+    typeof task?.config === 'string'
+      ? SafeJSONParse(task.config, {})
+      : (task?.config ?? {});
+  return (
+    task?.subtype === 'interactive' ||
+    config?.subtype === 'interactive' ||
+    Boolean(task?.interactive_type) ||
+    Boolean(config?.interactive_type)
+  );
+}
+
+export default function TaskRunsPage() {
+  const { experimentName = '', taskId = '' } = useParams<{
+    experimentName: string;
+    taskId: string;
+  }>();
+  const navigate = useNavigate();
+  const { experimentInfo, setExperimentId } = useExperimentInfo();
+  const { fetchWithAuth } = useAuth();
+  const { addNotification } = useNotification();
+
+  useEffect(() => {
+    if (experimentName) setExperimentId(experimentName);
+  }, [experimentName, setExperimentId]);
+
+  const {
+    data: task,
+    isError: taskError,
+    isLoading: taskLoading,
+  } = useSWR(
+    experimentInfo?.id && taskId
+      ? chatAPI.Endpoints.Task.GetByID(experimentInfo.id, taskId)
+      : null,
+    fetcher,
+  );
+
+  const { data: allTemplates } = useSWR(
+    experimentInfo?.id ? chatAPI.Endpoints.Task.List(experimentInfo.id) : null,
+    fetcher,
+    { refreshInterval: 10000, revalidateOnFocus: false },
+  );
+
+  const {
+    data: jobsRaw,
+    isLoading: jobsLoading,
+    mutate: jobsMutate,
+  } = useSWR(
+    experimentInfo?.id
+      ? chatAPI.Endpoints.Jobs.GetJobsOfType(experimentInfo.id, 'REMOTE', '')
+      : null,
+    fetcher,
+    {
+      refreshInterval: 3000,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: true,
+      refreshWhenHidden: true,
+      refreshWhenOffline: false,
+    },
+  );
+
+  const tasksForExperiment = useMemo(() => {
+    const list = Array.isArray(allTemplates)
+      ? allTemplates
+      : (allTemplates?.data ?? []);
+    return (list as any[]).filter(
+      (t) => t.experiment_id === experimentInfo?.id,
+    );
+  }, [allTemplates, experimentInfo?.id]);
+
+  const sidebarTasks = useMemo(() => {
+    const currentIsInteractive = task ? isInteractiveTemplate(task) : false;
+    return tasksForExperiment.filter(
+      (t) => isInteractiveTemplate(t) === currentIsInteractive,
+    );
+  }, [tasksForExperiment, task]);
+
+  const runCountByTaskId = useMemo(() => {
+    const all = Array.isArray(jobsRaw) ? jobsRaw : [];
+    const out: Record<string, number> = {};
+    for (const t of sidebarTasks) {
+      out[t.id] = all.filter((j: any) => jobBelongsToTask(j, t)).length;
+    }
+    return out;
+  }, [sidebarTasks, jobsRaw]);
+
+  const taskJobs = useMemo(() => {
+    if (!task) return [];
+    const all = Array.isArray(jobsRaw) ? jobsRaw : [];
+    return all.filter((j: any) => jobBelongsToTask(j, task as any));
+  }, [task, jobsRaw]);
+
+  const launchProgressByJobId = useMemo(() => {
+    const out: Record<
+      string,
+      { phase?: string; percent?: number; message?: string }
+    > = {};
+    for (const job of taskJobs as any[]) {
+      const lp = job?.job_data?.launch_progress;
+      if (lp) out[String(job.id)] = lp;
+    }
+    return out;
+  }, [taskJobs]);
+
+  const goToJob = (jobId: string | undefined) => {
+    const id = jobId == null ? '' : String(jobId);
+    if (!id || id === '-1' || id === 'NaN') return;
+    navigate(`/experiment/${experimentName}/jobs/${id}`);
+  };
+
+  const copyPermalink = () => {
+    navigator.clipboard
+      .writeText(
+        window.location.href.split('#')[0] +
+          generateTaskRunsPermalink(experimentName, taskId),
+      )
+      // eslint-disable-next-line no-console
+      .catch((err) => console.error('Failed to copy permalink:', err));
+  };
+
+  const handleDeleteJob = async (jobId: string) => {
+    if (!experimentInfo?.id) return;
+    const target = (taskJobs as any[]).find(
+      (j) => String(j.id) === String(jobId),
+    );
+    if (!target || !isDeletableJobRecordStatus(target.status)) {
+      addNotification({
+        type: 'warning',
+        message:
+          'You can only delete jobs that have not started yet or have finished. Stop the job first if it is still running.',
+      });
+      return;
+    }
+    // eslint-disable-next-line no-alert
+    if (!confirm('Are you sure you want to delete this job?')) return;
+    try {
+      const response = await fetchWithAuth(
+        chatAPI.Endpoints.Jobs.Delete(experimentInfo.id, jobId),
+        { method: 'GET' },
+      );
+      if (response.ok) {
+        addNotification({ type: 'success', message: 'Job deleted.' });
+        await jobsMutate();
+      } else {
+        addNotification({
+          type: 'danger',
+          message: 'Failed to delete job.',
+        });
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to delete job', err);
+      addNotification({ type: 'danger', message: 'Failed to delete job.' });
+    }
+  };
+
+  if (!experimentInfo) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100%',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (taskError || (!taskLoading && !task)) {
+    return (
+      <Box sx={{ p: 4 }}>
+        <Typography level="h4" color="danger">
+          Task not found
+        </Typography>
+        <Typography
+          sx={{ mt: 1, cursor: 'pointer', textDecoration: 'underline' }}
+          onClick={() => navigate(`/experiment/${experimentName}/tasks`)}
+        >
+          Back to Tasks
+        </Typography>
+      </Box>
+    );
+  }
+
+  const taskName = (task as any)?.title || (task as any)?.name || taskId;
+  const taskType = (task as any)?.type;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Top bar */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          px: 2,
+          py: 1,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0,
+          gap: 1,
+        }}
+      >
+        <Tooltip title={`Back to ${experimentName} tasks`}>
+          <IconButton
+            size="sm"
+            variant="plain"
+            onClick={() => navigate(`/experiment/${experimentName}/tasks`)}
+          >
+            <ArrowLeftIcon size={16} />
+          </IconButton>
+        </Tooltip>
+        <Typography level="title-sm" sx={{ color: 'text.secondary' }}>
+          {experimentName}
+        </Typography>
+        <Typography level="title-sm" sx={{ color: 'text.tertiary' }}>
+          /
+        </Typography>
+        <Typography level="title-sm">{taskName}</Typography>
+        {taskType && (
+          <Chip size="sm" color="primary" variant="soft">
+            {taskType}
+          </Chip>
+        )}
+        <Chip size="sm" variant="soft" color="neutral">
+          {jobsLoading && taskJobs.length === 0
+            ? '…'
+            : `${taskJobs.length} run${taskJobs.length === 1 ? '' : 's'}`}
+        </Chip>
+        <Tooltip title="Copy permalink">
+          <IconButton
+            size="sm"
+            variant="plain"
+            color="neutral"
+            onClick={copyPermalink}
+          >
+            <LinkIcon size={14} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      {/* Body: sidebar (tasks) + content (jobs) */}
+      <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        <Box
+          sx={{
+            width: 240,
+            flexShrink: 0,
+            borderRight: '1px solid',
+            borderColor: 'divider',
+            overflowY: 'auto',
+            bgcolor: 'background.level1',
+          }}
+        >
+          <Typography
+            level="body-xs"
+            sx={{
+              textTransform: 'uppercase',
+              letterSpacing: 0.5,
+              color: 'text.tertiary',
+              px: 2,
+              pt: 2,
+              pb: 1,
+            }}
+          >
+            Tasks
+          </Typography>
+          <List size="sm" sx={{ py: 0 }}>
+            {sidebarTasks.map((t) => {
+              const label = t.title?.trim() || t.name;
+              const count = runCountByTaskId[t.id] ?? 0;
+              const isActive = String(t.id) === String(taskId);
+              return (
+                <ListItem key={t.id}>
+                  <ListItemButton
+                    selected={isActive}
+                    onClick={() =>
+                      navigate(
+                        `/experiment/${experimentName}/tasks/${t.id}/runs`,
+                      )
+                    }
+                    sx={{ display: 'flex', justifyContent: 'space-between' }}
+                  >
+                    <Typography
+                      level="body-sm"
+                      sx={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        flex: 1,
+                        fontWeight: isActive ? 'lg' : undefined,
+                      }}
+                    >
+                      {label}
+                    </Typography>
+                    <Chip size="sm" variant="soft" color="neutral">
+                      {count}
+                    </Chip>
+                  </ListItemButton>
+                </ListItem>
+              );
+            })}
+          </List>
+        </Box>
+
+        <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
+          {taskJobs.length === 0 && !jobsLoading ? (
+            <Typography level="body-sm" sx={{ color: 'text.tertiary' }}>
+              No runs yet for this task.
+            </Typography>
+          ) : (
+            <JobsList
+              jobs={taskJobs}
+              launchProgressByJobId={launchProgressByJobId}
+              onDeleteJob={handleDeleteJob}
+              onViewOutput={goToJob}
+              onViewCheckpoints={goToJob}
+              onViewAllArtifacts={goToJob}
+              onViewEvalImages={goToJob}
+              onViewEvalResults={goToJob}
+              onViewSweepOutput={goToJob}
+              onViewSweepResults={goToJob}
+              onViewInteractive={goToJob}
+              onViewTrackio={goToJob}
+              loading={jobsLoading && taskJobs.length === 0}
+              hideJobId={false}
+              showFilesButton={false}
+              forceArtifactsButtonVisible
+            />
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
@@ -350,7 +350,6 @@ export default function TaskRunsPage() {
               hideJobId={false}
               showFilesButton={false}
               forceArtifactsButtonVisible
-              consolidatedActions
             />
           )}
         </Box>

--- a/src/renderer/components/Experiment/Tasks/TaskTemplateList.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskTemplateList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   Table,
   ButtonGroup,
@@ -19,6 +19,8 @@ import {
   MoreVerticalIcon,
   ChevronRightIcon,
   ChevronDownIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
 } from 'lucide-react';
 import SafeJSONParse from 'renderer/components/Shared/SafeJSONParse';
 
@@ -37,10 +39,9 @@ type TaskRow = {
 
 function jobBelongsToTask(job: any, task: TaskRow): boolean {
   const jd = job?.job_data ?? {};
-  if (jd.task_id && String(jd.task_id) === String(task.id)) return true;
-  const taskName = (task.title?.trim() || task.name?.trim()) ?? '';
-  if (taskName && jd.template_name && jd.template_name === taskName)
-    return true;
+  const name = task.name?.trim() ?? '';
+  if (name && jd.task_name && jd.task_name === name) return true;
+  if (name && jd.template_name && jd.template_name === name) return true;
   return false;
 }
 
@@ -54,10 +55,29 @@ type TaskTemplateListProps = {
   loading: boolean;
   interactTasks?: boolean;
   allJobs?: any[];
+  allJobsLoading?: boolean;
   expandedTaskIds?: Set<string>;
   onToggleTaskExpanded?: (taskId: string) => void;
   renderJobsForTask?: (taskId: string, jobs: any[]) => React.ReactNode;
 };
+
+function relativeTime(ts: string | undefined): string {
+  if (!ts) return '—';
+  const ms = Date.now() - new Date(ts).getTime();
+  if (ms < 0) return 'just now';
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return 'just now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ts).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
 
 function getTitle(task: TaskRow) {
   if (task.title && task.title.trim() !== '') {
@@ -76,10 +96,42 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
   loading,
   interactTasks = false,
   allJobs = [],
+  allJobsLoading = false,
   expandedTaskIds = new Set(),
   onToggleTaskExpanded,
   renderJobsForTask,
 }) => {
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const lastRunByTaskName = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const job of allJobs) {
+      if (job?.placeholder) continue;
+      const jd = job?.job_data ?? {};
+      const taskName = (jd.task_name || jd.template_name || '').trim();
+      if (!taskName) continue;
+      const ts: string = job.created_at || job.created || '';
+      if (!ts) continue;
+      if (!map[taskName] || ts > map[taskName]) {
+        map[taskName] = ts;
+      }
+    }
+    return map;
+  }, [allJobs]);
+
+  const sortedTasks = useMemo(() => {
+    return [...tasksList].sort((a, b) => {
+      const tsA = lastRunByTaskName[a.name?.trim() ?? ''] ?? '';
+      const tsB = lastRunByTaskName[b.name?.trim() ?? ''] ?? '';
+      if (!tsA && !tsB) return 0;
+      if (!tsA) return 1;
+      if (!tsB) return -1;
+      return sortDir === 'desc'
+        ? tsB.localeCompare(tsA)
+        : tsA.localeCompare(tsB);
+    });
+  }, [tasksList, sortDir, lastRunByTaskName]);
+
   const getResourcesInfo = (task: TaskRow) => {
     if (task.type !== 'REMOTE') {
       return 'N/A';
@@ -174,14 +226,16 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
 
   if (loading) {
     return (
-      <Table stickyHeader>
+      <Table stickyHeader sx={{ tableLayout: 'fixed', width: '100%' }}>
         <thead>
           <tr>
-            <th style={{ width: '150px' }}>Name</th>
-            {interactTasks && <th>Provider</th>}
-            <th>Command</th>
-            <th>Resources</th>
-            <th style={{ textAlign: 'right', width: '320px' }}>Actions</th>
+            <th style={{ width: '20%' }}>Name</th>
+            {interactTasks && <th style={{ width: '10%' }}>Provider</th>}
+            <th style={{ width: '6%', textAlign: 'center' }}>Runs</th>
+            <th style={{ width: '14%' }}>Last Run</th>
+            <th style={{ width: '22%' }}>Command</th>
+            <th style={{ width: '14%' }}>Resources</th>
+            <th style={{ width: '24%', textAlign: 'right' }}>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -195,6 +249,12 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
                   <Skeleton variant="text" level="title-sm" />
                 </td>
               )}
+              <td>
+                <Skeleton variant="text" level="body-sm" />
+              </td>
+              <td>
+                <Skeleton variant="text" level="body-sm" />
+              </td>
               <td>
                 <Skeleton variant="text" level="body-sm" />
               </td>
@@ -217,23 +277,48 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
   }
 
   return (
-    <Table stickyHeader>
+    <Table
+      stickyHeader
+      hoverRow
+      sx={{
+        tableLayout: 'fixed',
+        width: '100%',
+        // Thicker top border when one collapsed task immediately follows another
+        '& tbody tr[data-task-row] + tr[data-task-row] > td': {
+          borderTopWidth: '2px',
+        },
+      }}
+    >
       <thead>
         <tr>
-          <th style={{ width: '150px' }}>Name</th>
-          {interactTasks && <th>Provider</th>}
-          <th>Command</th>
-          <th>Resources</th>
-          <th style={{ textAlign: 'right', width: '320px' }}>Actions</th>
+          <th style={{ width: '20%' }}>Name</th>
+          {interactTasks && <th style={{ width: '10%' }}>Provider</th>}
+          <th style={{ width: '6%', textAlign: 'center' }}>Runs</th>
+          <th
+            style={{ width: '14%', cursor: 'pointer', userSelect: 'none' }}
+            onClick={() => setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              Last Run
+              {sortDir === 'desc' ? (
+                <ArrowDownIcon size={12} />
+              ) : (
+                <ArrowUpIcon size={12} />
+              )}
+            </Box>
+          </th>
+          <th style={{ width: '22%' }}>Command</th>
+          <th style={{ width: '14%' }}>Resources</th>
+          <th style={{ width: '24%', textAlign: 'right' }}>Actions</th>
         </tr>
       </thead>
       <tbody>
-        {tasksList.map((row) => {
+        {sortedTasks.map((row) => {
           const isExpanded = expandedTaskIds.has(row.id);
           const taskJobs = allJobs.filter((job) => jobBelongsToTask(job, row));
           return (
             <React.Fragment key={row.id}>
-              <tr>
+              <tr data-task-row="">
                 <td>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     {onToggleTaskExpanded && (
@@ -254,17 +339,37 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
                     <Typography level="title-sm" sx={{ overflow: 'clip' }}>
                       {getTitle(row)}
                     </Typography>
-                    {onToggleTaskExpanded && taskJobs.length > 0 && (
-                      <Chip
-                        size="sm"
-                        variant="soft"
-                        color="neutral"
-                        sx={{ ml: 0.5 }}
-                      >
-                        {taskJobs.length}
-                      </Chip>
-                    )}
                   </Box>
+                </td>
+                <td style={{ textAlign: 'center' }}>
+                  <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+                    {allJobsLoading ? (
+                      <Skeleton
+                        variant="text"
+                        level="body-sm"
+                        width={16}
+                        sx={{ display: 'inline-block' }}
+                      />
+                    ) : taskJobs.length > 0 ? (
+                      taskJobs.length
+                    ) : (
+                      '—'
+                    )}
+                  </Typography>
+                </td>
+                <td>
+                  <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+                    {allJobsLoading ? (
+                      <Skeleton
+                        variant="text"
+                        level="body-sm"
+                        width={40}
+                        sx={{ display: 'inline-block' }}
+                      />
+                    ) : (
+                      relativeTime(lastRunByTaskName[row.name?.trim() ?? ''])
+                    )}
+                  </Typography>
                 </td>
                 {interactTasks && (
                   <td style={{ overflow: 'clip' }}>
@@ -337,15 +442,24 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
               </tr>
               {isExpanded && renderJobsForTask && (
                 <tr>
-                  <td colSpan={99} style={{ padding: 0, border: 'none' }}>
+                  <td
+                    colSpan={99}
+                    style={{ padding: 0, border: 'none', width: '100%' }}
+                  >
                     <Box
                       sx={{
+                        display: 'block',
+                        width: '100%',
                         pl: 4,
                         pr: 1,
                         py: 1,
                         bgcolor: 'background.level1',
-                        borderBottom: '1px solid',
-                        borderColor: 'divider',
+                        borderBottom: '2px solid',
+                        borderColor: 'neutral.300',
+                        '& table': {
+                          tableLayout: 'auto',
+                          width: '100%',
+                        },
                       }}
                     >
                       {taskJobs.length === 0 ? (

--- a/src/renderer/components/Experiment/Tasks/TaskTemplateList.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskTemplateList.tsx
@@ -10,8 +10,16 @@ import {
   Menu,
   MenuItem,
   Skeleton,
+  Chip,
+  Box,
 } from '@mui/joy';
-import { PlayIcon, Trash2Icon, MoreVerticalIcon } from 'lucide-react';
+import {
+  PlayIcon,
+  Trash2Icon,
+  MoreVerticalIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
+} from 'lucide-react';
 import SafeJSONParse from 'renderer/components/Shared/SafeJSONParse';
 
 type TaskRow = {
@@ -27,6 +35,15 @@ type TaskRow = {
   remote_task?: boolean;
 };
 
+function jobBelongsToTask(job: any, task: TaskRow): boolean {
+  const jd = job?.job_data ?? {};
+  if (jd.task_id && String(jd.task_id) === String(task.id)) return true;
+  const taskName = (task.title?.trim() || task.name?.trim()) ?? '';
+  if (taskName && jd.template_name && jd.template_name === taskName)
+    return true;
+  return false;
+}
+
 type TaskTemplateListProps = {
   tasksList: TaskRow[];
   onDeleteTask?: (taskId: string, taskName?: string) => void;
@@ -36,6 +53,10 @@ type TaskTemplateListProps = {
   onViewFilesTask?: (task: TaskRow) => void;
   loading: boolean;
   interactTasks?: boolean;
+  allJobs?: any[];
+  expandedTaskIds?: Set<string>;
+  onToggleTaskExpanded?: (taskId: string) => void;
+  renderJobsForTask?: (taskId: string, jobs: any[]) => React.ReactNode;
 };
 
 function getTitle(task: TaskRow) {
@@ -54,6 +75,10 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
   onViewFilesTask,
   loading,
   interactTasks = false,
+  allJobs = [],
+  expandedTaskIds = new Set(),
+  onToggleTaskExpanded,
+  renderJobsForTask,
 }) => {
   const getResourcesInfo = (task: TaskRow) => {
     if (task.type !== 'REMOTE') {
@@ -203,78 +228,143 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
         </tr>
       </thead>
       <tbody>
-        {tasksList.map((row) => (
-          <tr key={row.id}>
-            <td>
-              <Typography level="title-sm" sx={{ overflow: 'clip' }}>
-                {getTitle(row)}
-              </Typography>
-            </td>
-            {interactTasks && (
-              <td style={{ overflow: 'clip' }}>
-                <Typography level="body-sm">{row.provider_name}</Typography>
-              </td>
-            )}
-            <td style={{ overflow: 'clip' }}>
-              <Typography level="body-sm">{getCommandInfo(row)}</Typography>
-            </td>
-            <td style={{ overflow: 'hidden' }}>
-              <Typography level="body-sm">{getResourcesInfo(row)}</Typography>
-            </td>
-            <td
-              style={{
-                overflow: 'visible',
-              }}
-            >
-              <ButtonGroup sx={{ justifyContent: 'flex-end' }}>
-                <Button
-                  startDecorator={<PlayIcon />}
-                  variant="soft"
-                  color="success"
-                  onClick={() => onQueueTask?.(row)}
-                >
-                  Queue
-                </Button>
-                <Button variant="outlined" onClick={() => onEditTask?.(row)}>
-                  Edit
-                </Button>
-                <IconButton
-                  variant="plain"
-                  color="danger"
-                  onClick={() => onDeleteTask?.(row.id, getTitle(row))}
-                  title="Delete task"
-                >
-                  <Trash2Icon style={{ cursor: 'pointer' }} />
-                </IconButton>
-                {(onExportTask || onViewFilesTask) && (
-                  <Dropdown>
-                    <MenuButton
-                      slots={{ root: IconButton }}
-                      slotProps={{
-                        root: { variant: 'plain', color: 'neutral' },
-                      }}
-                      sx={{ minWidth: 0 }}
-                    >
-                      <MoreVerticalIcon size={16} />
-                    </MenuButton>
-                    <Menu>
-                      {onViewFilesTask && (
-                        <MenuItem onClick={() => onViewFilesTask?.(row)}>
-                          View Files
-                        </MenuItem>
-                      )}
-                      {onExportTask && (
-                        <MenuItem onClick={() => onExportTask?.(row.id)}>
-                          Export to Team Gallery
-                        </MenuItem>
-                      )}
-                    </Menu>
-                  </Dropdown>
+        {tasksList.map((row) => {
+          const isExpanded = expandedTaskIds.has(row.id);
+          const taskJobs = allJobs.filter((job) => jobBelongsToTask(job, row));
+          return (
+            <React.Fragment key={row.id}>
+              <tr>
+                <td>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    {onToggleTaskExpanded && (
+                      <IconButton
+                        size="sm"
+                        variant="plain"
+                        color="neutral"
+                        onClick={() => onToggleTaskExpanded(row.id)}
+                        sx={{ minWidth: 0, p: 0.25 }}
+                      >
+                        {isExpanded ? (
+                          <ChevronDownIcon size={14} />
+                        ) : (
+                          <ChevronRightIcon size={14} />
+                        )}
+                      </IconButton>
+                    )}
+                    <Typography level="title-sm" sx={{ overflow: 'clip' }}>
+                      {getTitle(row)}
+                    </Typography>
+                    {onToggleTaskExpanded && taskJobs.length > 0 && (
+                      <Chip
+                        size="sm"
+                        variant="soft"
+                        color="neutral"
+                        sx={{ ml: 0.5 }}
+                      >
+                        {taskJobs.length}
+                      </Chip>
+                    )}
+                  </Box>
+                </td>
+                {interactTasks && (
+                  <td style={{ overflow: 'clip' }}>
+                    <Typography level="body-sm">{row.provider_name}</Typography>
+                  </td>
                 )}
-              </ButtonGroup>
-            </td>
-          </tr>
-        ))}
+                <td style={{ overflow: 'clip' }}>
+                  <Typography level="body-sm">{getCommandInfo(row)}</Typography>
+                </td>
+                <td style={{ overflow: 'hidden' }}>
+                  <Typography level="body-sm">
+                    {getResourcesInfo(row)}
+                  </Typography>
+                </td>
+                <td
+                  style={{
+                    overflow: 'visible',
+                  }}
+                >
+                  <ButtonGroup sx={{ justifyContent: 'flex-end' }}>
+                    <Button
+                      startDecorator={<PlayIcon />}
+                      variant="soft"
+                      color="success"
+                      onClick={() => onQueueTask?.(row)}
+                    >
+                      Queue
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      onClick={() => onEditTask?.(row)}
+                    >
+                      Edit
+                    </Button>
+                    <IconButton
+                      variant="plain"
+                      color="danger"
+                      onClick={() => onDeleteTask?.(row.id, getTitle(row))}
+                      title="Delete task"
+                    >
+                      <Trash2Icon style={{ cursor: 'pointer' }} />
+                    </IconButton>
+                    {(onExportTask || onViewFilesTask) && (
+                      <Dropdown>
+                        <MenuButton
+                          slots={{ root: IconButton }}
+                          slotProps={{
+                            root: { variant: 'plain', color: 'neutral' },
+                          }}
+                          sx={{ minWidth: 0 }}
+                        >
+                          <MoreVerticalIcon size={16} />
+                        </MenuButton>
+                        <Menu>
+                          {onViewFilesTask && (
+                            <MenuItem onClick={() => onViewFilesTask?.(row)}>
+                              View Files
+                            </MenuItem>
+                          )}
+                          {onExportTask && (
+                            <MenuItem onClick={() => onExportTask?.(row.id)}>
+                              Export to Team Gallery
+                            </MenuItem>
+                          )}
+                        </Menu>
+                      </Dropdown>
+                    )}
+                  </ButtonGroup>
+                </td>
+              </tr>
+              {isExpanded && renderJobsForTask && (
+                <tr>
+                  <td colSpan={99} style={{ padding: 0, border: 'none' }}>
+                    <Box
+                      sx={{
+                        pl: 4,
+                        pr: 1,
+                        py: 1,
+                        bgcolor: 'background.level1',
+                        borderBottom: '1px solid',
+                        borderColor: 'divider',
+                      }}
+                    >
+                      {taskJobs.length === 0 ? (
+                        <Typography
+                          level="body-sm"
+                          sx={{ color: 'text.tertiary', py: 1 }}
+                        >
+                          No runs yet
+                        </Typography>
+                      ) : (
+                        renderJobsForTask(row.id, taskJobs)
+                      )}
+                    </Box>
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
+          );
+        })}
       </tbody>
     </Table>
   );

--- a/src/renderer/components/Experiment/Tasks/TaskTemplateList.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskTemplateList.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import {
   Table,
   ButtonGroup,
@@ -10,19 +11,21 @@ import {
   Menu,
   MenuItem,
   Skeleton,
-  Chip,
   Box,
 } from '@mui/joy';
 import {
   PlayIcon,
   Trash2Icon,
   MoreVerticalIcon,
-  ChevronRightIcon,
-  ChevronDownIcon,
   ArrowUpIcon,
   ArrowDownIcon,
+  LinkIcon,
 } from 'lucide-react';
+import Tooltip from '@mui/joy/Tooltip';
+import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
 import SafeJSONParse from 'renderer/components/Shared/SafeJSONParse';
+import { jobBelongsToTask } from './taskJobMatching';
+import { generateTaskRunsPermalink } from '../Jobs/jobDetailUtils';
 
 type TaskRow = {
   id: string;
@@ -37,14 +40,6 @@ type TaskRow = {
   remote_task?: boolean;
 };
 
-function jobBelongsToTask(job: any, task: TaskRow): boolean {
-  const jd = job?.job_data ?? {};
-  const name = task.name?.trim() ?? '';
-  if (name && jd.task_name && jd.task_name === name) return true;
-  if (name && jd.template_name && jd.template_name === name) return true;
-  return false;
-}
-
 type TaskTemplateListProps = {
   tasksList: TaskRow[];
   onDeleteTask?: (taskId: string, taskName?: string) => void;
@@ -56,9 +51,6 @@ type TaskTemplateListProps = {
   interactTasks?: boolean;
   allJobs?: any[];
   allJobsLoading?: boolean;
-  expandedTaskIds?: Set<string>;
-  onToggleTaskExpanded?: (taskId: string) => void;
-  renderJobsForTask?: (taskId: string, jobs: any[]) => React.ReactNode;
 };
 
 function relativeTime(ts: string | undefined): string {
@@ -97,11 +89,10 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
   interactTasks = false,
   allJobs = [],
   allJobsLoading = false,
-  expandedTaskIds = new Set(),
-  onToggleTaskExpanded,
-  renderJobsForTask,
 }) => {
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+  const { experimentInfo } = useExperimentInfo();
+  const experimentName = experimentInfo?.name || experimentInfo?.id || '';
 
   const lastRunByTaskName = useMemo(() => {
     const map: Record<string, string> = {};
@@ -199,31 +190,6 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
     return run.length > 50 ? `${run.substring(0, 50)}...` : run;
   };
 
-  const getProviderInfo = (task: TaskRow) => {
-    if (task.type !== 'REMOTE') {
-      return 'N/A';
-    }
-
-    // For templates, fields are stored directly (not nested in config)
-    const config =
-      (typeof task.config === 'string'
-        ? SafeJSONParse(task.config as string, {})
-        : (task.config as any)) || {};
-
-    // Check if config has nested structure (old task format) or is empty
-    const isTemplate =
-      !task.config ||
-      (typeof config === 'object' && Object.keys(config).length === 0) ||
-      (!config.run && !config.cluster_name);
-
-    // Use template field directly if it's a template, otherwise use config
-    const providerName = isTemplate
-      ? (task as any).provider_name
-      : config.provider_name;
-
-    return providerName || 'Not specified';
-  };
-
   if (loading) {
     return (
       <Table stickyHeader sx={{ tableLayout: 'fixed', width: '100%' }}>
@@ -283,10 +249,6 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
       sx={{
         tableLayout: 'fixed',
         width: '100%',
-        // Thicker top border when one collapsed task immediately follows another
-        '& tbody tr[data-task-row] + tr[data-task-row] > td': {
-          borderTopWidth: '2px',
-        },
       }}
     >
       <thead>
@@ -314,169 +276,153 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
       </thead>
       <tbody>
         {sortedTasks.map((row) => {
-          const isExpanded = expandedTaskIds.has(row.id);
           const taskJobs = allJobs.filter((job) => jobBelongsToTask(job, row));
+          const runsHref = experimentName
+            ? `/experiment/${experimentName}/tasks/${row.id}/runs`
+            : '';
           return (
-            <React.Fragment key={row.id}>
-              <tr data-task-row="">
-                <td>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    {onToggleTaskExpanded && (
-                      <IconButton
-                        size="sm"
-                        variant="plain"
-                        color="neutral"
-                        onClick={() => onToggleTaskExpanded(row.id)}
-                        sx={{ minWidth: 0, p: 0.25 }}
-                      >
-                        {isExpanded ? (
-                          <ChevronDownIcon size={14} />
-                        ) : (
-                          <ChevronRightIcon size={14} />
-                        )}
-                      </IconButton>
-                    )}
-                    <Typography level="title-sm" sx={{ overflow: 'clip' }}>
-                      {getTitle(row)}
-                    </Typography>
-                  </Box>
-                </td>
-                <td style={{ textAlign: 'center' }}>
-                  <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
-                    {allJobsLoading ? (
-                      <Skeleton
-                        variant="text"
-                        level="body-sm"
-                        width={16}
-                        sx={{ display: 'inline-block' }}
-                      />
-                    ) : taskJobs.length > 0 ? (
-                      taskJobs.length
-                    ) : (
-                      '—'
-                    )}
-                  </Typography>
-                </td>
-                <td>
-                  <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
-                    {allJobsLoading ? (
-                      <Skeleton
-                        variant="text"
-                        level="body-sm"
-                        width={40}
-                        sx={{ display: 'inline-block' }}
-                      />
-                    ) : (
-                      relativeTime(lastRunByTaskName[row.name?.trim() ?? ''])
-                    )}
-                  </Typography>
-                </td>
-                {interactTasks && (
-                  <td style={{ overflow: 'clip' }}>
-                    <Typography level="body-sm">{row.provider_name}</Typography>
-                  </td>
-                )}
-                <td style={{ overflow: 'clip' }}>
-                  <Typography level="body-sm">{getCommandInfo(row)}</Typography>
-                </td>
-                <td style={{ overflow: 'hidden' }}>
-                  <Typography level="body-sm">
-                    {getResourcesInfo(row)}
-                  </Typography>
-                </td>
-                <td
-                  style={{
-                    overflow: 'visible',
-                  }}
-                >
-                  <ButtonGroup sx={{ justifyContent: 'flex-end' }}>
-                    <Button
-                      startDecorator={<PlayIcon />}
-                      variant="soft"
-                      color="success"
-                      onClick={() => onQueueTask?.(row)}
-                    >
-                      Queue
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      onClick={() => onEditTask?.(row)}
-                    >
-                      Edit
-                    </Button>
-                    <IconButton
-                      variant="plain"
-                      color="danger"
-                      onClick={() => onDeleteTask?.(row.id, getTitle(row))}
-                      title="Delete task"
-                    >
-                      <Trash2Icon style={{ cursor: 'pointer' }} />
-                    </IconButton>
-                    {(onExportTask || onViewFilesTask) && (
-                      <Dropdown>
-                        <MenuButton
-                          slots={{ root: IconButton }}
-                          slotProps={{
-                            root: { variant: 'plain', color: 'neutral' },
-                          }}
-                          sx={{ minWidth: 0 }}
-                        >
-                          <MoreVerticalIcon size={16} />
-                        </MenuButton>
-                        <Menu>
-                          {onViewFilesTask && (
-                            <MenuItem onClick={() => onViewFilesTask?.(row)}>
-                              View Files
-                            </MenuItem>
-                          )}
-                          {onExportTask && (
-                            <MenuItem onClick={() => onExportTask?.(row.id)}>
-                              Export to Team Gallery
-                            </MenuItem>
-                          )}
-                        </Menu>
-                      </Dropdown>
-                    )}
-                  </ButtonGroup>
-                </td>
-              </tr>
-              {isExpanded && renderJobsForTask && (
-                <tr>
-                  <td
-                    colSpan={99}
-                    style={{ padding: 0, border: 'none', width: '100%' }}
+            <tr key={row.id}>
+              <td>
+                {runsHref ? (
+                  <RouterLink
+                    to={runsHref}
+                    style={{ textDecoration: 'none', color: 'inherit' }}
                   >
-                    <Box
+                    <Typography
+                      level="title-sm"
                       sx={{
-                        display: 'block',
-                        width: '100%',
-                        pl: 4,
-                        pr: 1,
-                        py: 1,
-                        bgcolor: 'background.level1',
-                        borderBottom: '2px solid',
-                        borderColor: 'neutral.300',
-                        '& table': {
-                          tableLayout: 'auto',
-                          width: '100%',
-                        },
+                        overflow: 'clip',
+                        cursor: 'pointer',
+                        '&:hover': { textDecoration: 'underline' },
                       }}
                     >
-                      {taskJobs.length === 0 ? (
-                        <Typography
-                          level="body-sm"
-                          sx={{ color: 'text.tertiary', py: 1 }}
-                        >
-                          No runs yet
-                        </Typography>
-                      ) : (
-                        renderJobsForTask(row.id, taskJobs)
-                      )}
-                    </Box>
-                  </td>
-                </tr>
+                      {getTitle(row)}
+                    </Typography>
+                  </RouterLink>
+                ) : (
+                  <Typography level="title-sm" sx={{ overflow: 'clip' }}>
+                    {getTitle(row)}
+                  </Typography>
+                )}
+              </td>
+              <td style={{ textAlign: 'center' }}>
+                <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+                  {allJobsLoading ? (
+                    <Skeleton
+                      variant="text"
+                      level="body-sm"
+                      width={16}
+                      sx={{ display: 'inline-block' }}
+                    />
+                  ) : taskJobs.length > 0 ? (
+                    taskJobs.length
+                  ) : (
+                    '—'
+                  )}
+                </Typography>
+              </td>
+              <td>
+                <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+                  {allJobsLoading ? (
+                    <Skeleton
+                      variant="text"
+                      level="body-sm"
+                      width={40}
+                      sx={{ display: 'inline-block' }}
+                    />
+                  ) : (
+                    relativeTime(lastRunByTaskName[row.name?.trim() ?? ''])
+                  )}
+                </Typography>
+              </td>
+              {interactTasks && (
+                <td style={{ overflow: 'clip' }}>
+                  <Typography level="body-sm">{row.provider_name}</Typography>
+                </td>
               )}
-            </React.Fragment>
+              <td style={{ overflow: 'clip' }}>
+                <Typography level="body-sm">{getCommandInfo(row)}</Typography>
+              </td>
+              <td style={{ overflow: 'hidden' }}>
+                <Typography level="body-sm">{getResourcesInfo(row)}</Typography>
+              </td>
+              <td
+                style={{
+                  overflow: 'visible',
+                }}
+              >
+                <ButtonGroup sx={{ justifyContent: 'flex-end' }}>
+                  <Button
+                    startDecorator={<PlayIcon />}
+                    variant="soft"
+                    color="success"
+                    onClick={() => onQueueTask?.(row)}
+                  >
+                    Queue
+                  </Button>
+                  <Button variant="outlined" onClick={() => onEditTask?.(row)}>
+                    Edit
+                  </Button>
+                  {runsHref && (
+                    <Tooltip title="Copy permalink to runs">
+                      <IconButton
+                        variant="plain"
+                        color="neutral"
+                        onClick={() => {
+                          navigator.clipboard
+                            .writeText(
+                              window.location.href.split('#')[0] +
+                                generateTaskRunsPermalink(
+                                  experimentName,
+                                  row.id,
+                                ),
+                            )
+                            // eslint-disable-next-line no-console
+                            .catch((err) =>
+                              console.error('Failed to copy permalink:', err),
+                            );
+                        }}
+                      >
+                        <LinkIcon size={16} />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                  <IconButton
+                    variant="plain"
+                    color="danger"
+                    onClick={() => onDeleteTask?.(row.id, getTitle(row))}
+                    title="Delete task"
+                  >
+                    <Trash2Icon style={{ cursor: 'pointer' }} />
+                  </IconButton>
+                  {(onExportTask || onViewFilesTask) && (
+                    <Dropdown>
+                      <MenuButton
+                        slots={{ root: IconButton }}
+                        slotProps={{
+                          root: { variant: 'plain', color: 'neutral' },
+                        }}
+                        sx={{ minWidth: 0 }}
+                      >
+                        <MoreVerticalIcon size={16} />
+                      </MenuButton>
+                      <Menu>
+                        {onViewFilesTask && (
+                          <MenuItem onClick={() => onViewFilesTask?.(row)}>
+                            View Files
+                          </MenuItem>
+                        )}
+                        {onExportTask && (
+                          <MenuItem onClick={() => onExportTask?.(row.id)}>
+                            Export to Team Gallery
+                          </MenuItem>
+                        )}
+                      </Menu>
+                    </Dropdown>
+                  )}
+                </ButtonGroup>
+              </td>
+            </tr>
           );
         })}
       </tbody>

--- a/src/renderer/components/Experiment/Tasks/TaskTemplateList.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskTemplateList.tsx
@@ -94,17 +94,17 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
   const { experimentInfo } = useExperimentInfo();
   const experimentName = experimentInfo?.name || experimentInfo?.id || '';
 
-  const lastRunByTaskName = useMemo(() => {
+  const lastRunByTaskId = useMemo(() => {
     const map: Record<string, string> = {};
     for (const job of allJobs) {
       if (job?.placeholder) continue;
-      const jd = job?.job_data ?? {};
-      const taskName = (jd.task_name || jd.template_name || '').trim();
-      if (!taskName) continue;
+      const taskId = job?.job_data?.task_id;
+      if (taskId == null) continue;
+      const key = String(taskId);
       const ts: string = job.created_at || job.created || '';
       if (!ts) continue;
-      if (!map[taskName] || ts > map[taskName]) {
-        map[taskName] = ts;
+      if (!map[key] || ts > map[key]) {
+        map[key] = ts;
       }
     }
     return map;
@@ -112,8 +112,8 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
 
   const sortedTasks = useMemo(() => {
     return [...tasksList].sort((a, b) => {
-      const tsA = lastRunByTaskName[a.name?.trim() ?? ''] ?? '';
-      const tsB = lastRunByTaskName[b.name?.trim() ?? ''] ?? '';
+      const tsA = lastRunByTaskId[String(a.id)] ?? '';
+      const tsB = lastRunByTaskId[String(b.id)] ?? '';
       if (!tsA && !tsB) return 0;
       if (!tsA) return 1;
       if (!tsB) return -1;
@@ -121,7 +121,7 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
         ? tsB.localeCompare(tsA)
         : tsA.localeCompare(tsB);
     });
-  }, [tasksList, sortDir, lastRunByTaskName]);
+  }, [tasksList, sortDir, lastRunByTaskId]);
 
   const getResourcesInfo = (task: TaskRow) => {
     if (task.type !== 'REMOTE') {
@@ -331,7 +331,7 @@ const TaskTemplateList: React.FC<TaskTemplateListProps> = ({
                       sx={{ display: 'inline-block' }}
                     />
                   ) : (
-                    relativeTime(lastRunByTaskName[row.name?.trim() ?? ''])
+                    relativeTime(lastRunByTaskId[String(row.id)])
                   )}
                 </Typography>
               </td>

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -100,21 +100,6 @@ export default function Tasks({ subtype }: { subtype?: string }) {
     id: string;
     name?: string;
   } | null>(null);
-  const [expandedTaskIds, setExpandedTaskIds] = useState<Set<string>>(
-    new Set(),
-  );
-
-  const handleToggleTaskExpanded = useCallback((taskId: string) => {
-    setExpandedTaskIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(taskId)) {
-        next.delete(taskId);
-      } else {
-        next.add(taskId);
-      }
-      return next;
-    });
-  }, []);
   const [stopPendingByJobId, setStopPendingByJobId] = useState<
     Record<string, boolean>
   >({});
@@ -1382,71 +1367,6 @@ export default function Tasks({ subtype }: { subtype?: string }) {
           loading={templatesIsLoading}
           allJobs={filteredJobsForDisplay}
           allJobsLoading={jobsIsLoading}
-          expandedTaskIds={expandedTaskIds}
-          onToggleTaskExpanded={handleToggleTaskExpanded}
-          renderJobsForTask={(_, taskJobs) => (
-            <JobsList
-              jobs={taskJobs}
-              launchProgressByJobId={launchProgressByJobId}
-              onDeleteJob={handleDeleteJob}
-              onViewOutput={(jobId) => {
-                const jobIdStr =
-                  jobId === null || jobId === undefined ? '' : String(jobId);
-                if (!jobIdStr || jobIdStr === '-1' || jobIdStr === 'NaN')
-                  return;
-                setViewOutputFromJob(jobIdStr);
-              }}
-              onViewCheckpoints={(jobId) =>
-                setViewCheckpointsFromJob(
-                  jobId && jobId !== 'NaN' ? jobId : null,
-                )
-              }
-              onViewAllArtifacts={(jobId) =>
-                setViewAllArtifactsFromJob(
-                  jobId && jobId !== 'NaN' ? jobId : null,
-                )
-              }
-              onViewEvalImages={(jobId) =>
-                setViewEvalImagesFromJob(
-                  jobId && jobId !== 'NaN' ? jobId : null,
-                )
-              }
-              onViewEvalResults={(jobId) =>
-                setViewEvalResultsFromJob(
-                  jobId && jobId !== 'NaN' ? jobId : null,
-                )
-              }
-              onViewGeneratedDataset={(_jobId, datasetId) => {
-                setPreviewDatasetModal({ open: true, datasetId });
-              }}
-              onViewSweepOutput={(jobId) => {
-                setViewOutputFromSweepJob(true);
-                const jobIdStr =
-                  jobId === null || jobId === undefined ? '' : String(jobId);
-                if (!jobIdStr || jobIdStr === '-1' || jobIdStr === 'NaN')
-                  return;
-                setViewOutputFromJob(jobIdStr);
-              }}
-              onViewSweepResults={(jobId) => {
-                setViewSweepResultsFromJob(
-                  jobId && jobId !== 'NaN' ? jobId : null,
-                );
-              }}
-              onViewInteractive={(jobId) =>
-                setInteractiveJobForModal(
-                  jobId && jobId !== 'NaN' ? jobId : null,
-                )
-              }
-              onViewTrackio={(jobId) =>
-                setTrackioJobIdForModal(jobId && jobId !== 'NaN' ? jobId : null)
-              }
-              loading={false}
-              hideJobId={false}
-              showFilesButton={false}
-              forceArtifactsButtonVisible
-              onStopPendingChange={handleStopPendingChange}
-            />
-          )}
         />
       </Sheet>
       {/* <JobsPanel

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -1369,7 +1369,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
           allJobsLoading={jobsIsLoading}
         />
       </Sheet>
-      {/* <JobsPanel
+      <JobsPanel
         title="Jobs"
         jobs={filteredJobsForDisplay as any}
         loading={jobsIsLoading}
@@ -1500,7 +1500,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
             onStopPendingChange={handleStopPendingChange}
           />
         )}
-      /> */}
+      />
       <ViewSweepResultsModal
         jobId={viewSweepResultsFromJob}
         setJobId={(jobId: string | null) => setViewSweepResultsFromJob(jobId)}

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -1381,6 +1381,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
           // }
           loading={templatesIsLoading}
           allJobs={filteredJobsForDisplay}
+          allJobsLoading={jobsIsLoading}
           expandedTaskIds={expandedTaskIds}
           onToggleTaskExpanded={handleToggleTaskExpanded}
           renderJobsForTask={(_, taskJobs) => (
@@ -1448,7 +1449,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
           )}
         />
       </Sheet>
-      <JobsPanel
+      {/* <JobsPanel
         title="Jobs"
         jobs={filteredJobsForDisplay as any}
         loading={jobsIsLoading}
@@ -1579,7 +1580,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
             onStopPendingChange={handleStopPendingChange}
           />
         )}
-      />
+      /> */}
       <ViewSweepResultsModal
         jobId={viewSweepResultsFromJob}
         setJobId={(jobId: string | null) => setViewSweepResultsFromJob(jobId)}

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -100,6 +100,21 @@ export default function Tasks({ subtype }: { subtype?: string }) {
     id: string;
     name?: string;
   } | null>(null);
+  const [expandedTaskIds, setExpandedTaskIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const handleToggleTaskExpanded = useCallback((taskId: string) => {
+    setExpandedTaskIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(taskId)) {
+        next.delete(taskId);
+      } else {
+        next.add(taskId);
+      }
+      return next;
+    });
+  }, []);
   const [stopPendingByJobId, setStopPendingByJobId] = useState<
     Record<string, boolean>
   >({});
@@ -1365,6 +1380,72 @@ export default function Tasks({ subtype }: { subtype?: string }) {
           //   })
           // }
           loading={templatesIsLoading}
+          allJobs={filteredJobsForDisplay}
+          expandedTaskIds={expandedTaskIds}
+          onToggleTaskExpanded={handleToggleTaskExpanded}
+          renderJobsForTask={(_, taskJobs) => (
+            <JobsList
+              jobs={taskJobs}
+              launchProgressByJobId={launchProgressByJobId}
+              onDeleteJob={handleDeleteJob}
+              onViewOutput={(jobId) => {
+                const jobIdStr =
+                  jobId === null || jobId === undefined ? '' : String(jobId);
+                if (!jobIdStr || jobIdStr === '-1' || jobIdStr === 'NaN')
+                  return;
+                setViewOutputFromJob(jobIdStr);
+              }}
+              onViewCheckpoints={(jobId) =>
+                setViewCheckpointsFromJob(
+                  jobId && jobId !== 'NaN' ? jobId : null,
+                )
+              }
+              onViewAllArtifacts={(jobId) =>
+                setViewAllArtifactsFromJob(
+                  jobId && jobId !== 'NaN' ? jobId : null,
+                )
+              }
+              onViewEvalImages={(jobId) =>
+                setViewEvalImagesFromJob(
+                  jobId && jobId !== 'NaN' ? jobId : null,
+                )
+              }
+              onViewEvalResults={(jobId) =>
+                setViewEvalResultsFromJob(
+                  jobId && jobId !== 'NaN' ? jobId : null,
+                )
+              }
+              onViewGeneratedDataset={(_jobId, datasetId) => {
+                setPreviewDatasetModal({ open: true, datasetId });
+              }}
+              onViewSweepOutput={(jobId) => {
+                setViewOutputFromSweepJob(true);
+                const jobIdStr =
+                  jobId === null || jobId === undefined ? '' : String(jobId);
+                if (!jobIdStr || jobIdStr === '-1' || jobIdStr === 'NaN')
+                  return;
+                setViewOutputFromJob(jobIdStr);
+              }}
+              onViewSweepResults={(jobId) => {
+                setViewSweepResultsFromJob(
+                  jobId && jobId !== 'NaN' ? jobId : null,
+                );
+              }}
+              onViewInteractive={(jobId) =>
+                setInteractiveJobForModal(
+                  jobId && jobId !== 'NaN' ? jobId : null,
+                )
+              }
+              onViewTrackio={(jobId) =>
+                setTrackioJobIdForModal(jobId && jobId !== 'NaN' ? jobId : null)
+              }
+              loading={false}
+              hideJobId={false}
+              showFilesButton={false}
+              forceArtifactsButtonVisible
+              onStopPendingChange={handleStopPendingChange}
+            />
+          )}
         />
       </Sheet>
       <JobsPanel

--- a/src/renderer/components/Experiment/Tasks/taskJobMatching.ts
+++ b/src/renderer/components/Experiment/Tasks/taskJobMatching.ts
@@ -1,12 +1,9 @@
 export type TaskRowLike = {
-  name: string;
+  id: string | number;
 };
 
 export function jobBelongsToTask(job: any, task: TaskRowLike): boolean {
-  const jd = job?.job_data ?? {};
-  const name = task.name?.trim() ?? '';
-  if (!name) return false;
-  if (jd.task_name && jd.task_name === name) return true;
-  if (jd.template_name && jd.template_name === name) return true;
-  return false;
+  const jobTaskId = job?.job_data?.task_id;
+  if (jobTaskId == null || task?.id == null) return false;
+  return String(jobTaskId) === String(task.id);
 }

--- a/src/renderer/components/Experiment/Tasks/taskJobMatching.ts
+++ b/src/renderer/components/Experiment/Tasks/taskJobMatching.ts
@@ -1,0 +1,12 @@
+export type TaskRowLike = {
+  name: string;
+};
+
+export function jobBelongsToTask(job: any, task: TaskRowLike): boolean {
+  const jd = job?.job_data ?? {};
+  const name = task.name?.trim() ?? '';
+  if (!name) return false;
+  if (jd.task_name && jd.task_name === name) return true;
+  if (jd.template_name && jd.template_name === name) return true;
+  return false;
+}

--- a/src/renderer/components/MainAppPanel.tsx
+++ b/src/renderer/components/MainAppPanel.tsx
@@ -33,6 +33,7 @@ import Team from './Team/Team';
 import UsageReport from './Team/UsageReport';
 import TasksGallery from './TasksGallery/TasksGallery';
 import JobDetailPage from './Experiment/Jobs/JobDetailPage';
+import TaskRunsPage from './Experiment/Tasks/TaskRunsPage';
 
 // // Define the app version
 // const APP_VERSION = '1.0.0';
@@ -239,6 +240,10 @@ export default function MainAppPanel({ setLogsDrawerOpen = null }) {
         <Route
           path="/experiment/:experimentName/jobs/:jobId"
           element={<JobDetailPage />}
+        />
+        <Route
+          path="/experiment/:experimentName/tasks/:taskId/runs"
+          element={<TaskRunsPage />}
         />
         <Route path="/api" element={<Api />} />
         <Route path="/zoo" element={<ModelZoo tab="groups" />} />

--- a/src/renderer/components/Nav/Sidebar.tsx
+++ b/src/renderer/components/Nav/Sidebar.tsx
@@ -53,7 +53,10 @@ function ExperimentMenuItems({ experimentInfo }: ExperimentMenuItemsProps) {
         <SubNavItem
           title="Tasks"
           path={`${basePath}/tasks`}
-          matchPattern="/experiment/:experimentName/tasks"
+          matchPattern={[
+            '/experiment/:experimentName/tasks/*',
+            '/experiment/:experimentName/jobs/*',
+          ]}
           icon={<StretchHorizontalIcon />}
           disabled={!experimentReady}
         />

--- a/src/renderer/components/Nav/SubNavItem.tsx
+++ b/src/renderer/components/Nav/SubNavItem.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { useNavigate, useMatch } from 'react-router-dom';
+import { useNavigate, useLocation, matchPath } from 'react-router-dom';
 
 import ListItem from '@mui/joy/ListItem';
 import ListItemContent from '@mui/joy/ListItemContent';
@@ -17,13 +17,17 @@ const SubNavItem = ({
 }: {
   title: string;
   path: string;
-  matchPattern?: string;
+  matchPattern?: string | string[];
   icon: ReactElement;
   disabled?: boolean;
   counter?: number | null;
 }) => {
   const navigate = useNavigate();
-  const match = useMatch(matchPattern || path);
+  const location = useLocation();
+  const patterns = Array.isArray(matchPattern)
+    ? matchPattern
+    : [matchPattern || path];
+  const match = patterns.some((p) => Boolean(matchPath(p, location.pathname)));
 
   return (
     <ListItem className="FirstSidebar_Content">


### PR DESCRIPTION
  ## Summary of main changes
  - Adds a dedicated runs page at `/experiment/<name>/tasks/<taskId>/runs` for viewing all jobs of a single task. ~~Replaces the inline accordion (which didn't scale past a handful of runs).~~ just remembered; have never pushed this, only discussed verbally
  - Task names in the Tasks list are now clickable; leads to the list of jobs for that task; and a permalink sits in the row's Actions column between Edit and Delete to link to all jobs for that task
  - Persistent left sidebar on the runs page lists other tasks so the user easily knows which task they have selected
  - Job-row actions (Outputs, Artifacts, Checkpoints) are consolidated into a single **Logs** button that opens `JobDetailPage`; permalink and delete are preserved
