### PR TITLE
Fix dependencies

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -197,26 +197,31 @@ tags_metadata = [
 ]
 
 if os.getenv("SENTRY_DSN"):
-    # Import only if SENTRY_DSN is set.
-    # This way we can avoid making sentry_sdk a mandatory dependency.
-    import sentry_sdk
-    from sentry_sdk.integrations.fastapi import FastApiIntegration
+    try:
+        # Import only if SENTRY_DSN is set.
+        # This way we can avoid making sentry_sdk a mandatory dependency.
+        import sentry_sdk
+        from sentry_sdk.integrations.fastapi import FastApiIntegration
 
-    sentry_sdk.init(
-        dsn=os.environ["SENTRY_DSN"],
-        integrations=[FastApiIntegration()],
-        # Enable sending logs to Sentry
-        enable_logs=True,
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for tracing.
-        traces_sample_rate=1.0,
-        # Set profile_session_sample_rate to 1.0 to profile 100%
-        # of profile sessions.
-        profile_session_sample_rate=1.0,
-        # Set profile_lifecycle to "trace" to automatically
-        # run the profiler on when there is an active transaction
-        profile_lifecycle="trace",
-    )
+        sentry_sdk.init(
+            dsn=os.environ["SENTRY_DSN"],
+            integrations=[FastApiIntegration()],
+            # Enable sending logs to Sentry
+            enable_logs=True,
+            # Set traces_sample_rate to 1.0 to capture 100%
+            # of transactions for tracing.
+            traces_sample_rate=1.0,
+            # Set profile_session_sample_rate to 1.0 to profile 100%
+            # of profile sessions.
+            profile_session_sample_rate=1.0,
+            # Set profile_lifecycle to "trace" to automatically
+            # run the profiler on when there is an active transaction
+            profile_lifecycle="trace",
+        )
+    except ImportError:
+        print(
+            "Sentry SDK is not installed. Skipping Sentry integration. Please install it with the following command: source ~/.transformerlab/envs/general-uv/bin/activate && pip install sentry-sdk"
+        )
 
 app = fastapi.FastAPI(
     title="Transformerlab API",

--- a/api/install.sh
+++ b/api/install.sh
@@ -591,7 +591,7 @@ multiuser_setup() {
   fi
 
   echo "Installing SkyPilot with Kubernetes support..."
-  uv pip install --python "${GENERAL_UV_ENV_DIR}/bin/python" "skypilot[kubernetes]==0.10.5"
+  uv pip install --python "${GENERAL_UV_ENV_DIR}/bin/python" "skypilot[kubernetes]==0.12.1"
 
   echo "Multiuser setup complete."
 

--- a/api/install.sh
+++ b/api/install.sh
@@ -593,12 +593,6 @@ multiuser_setup() {
   echo "Installing SkyPilot with Kubernetes support..."
   uv pip install --python "${GENERAL_UV_ENV_DIR}/bin/python" "skypilot[kubernetes]==0.10.5"
 
-  echo "Installing paramiko for SLURM provider support..."
-  uv pip install --python "${GENERAL_UV_ENV_DIR}/bin/python" paramiko
-
-  echo "Installing Sentry SDK..."
-  uv pip install --python "${GENERAL_UV_ENV_DIR}/bin/python" sentry-sdk
-
   echo "Multiuser setup complete."
 
 }

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
   "google-cloud-storage==2.18.2",
   "azure-storage-blob==12.28.0",
   "cashews==7.5.0",
+  "paramiko==4.0.0",
+  "sentry-sdk==2.58.0",
 ]
 name = "transformerlab-api"
 version = "0.27.0"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
   "azure-storage-blob==12.28.0",
   "cashews==7.5.0",
   "paramiko==4.0.0",
-  "sentry-sdk==2.58.0",
 ]
 name = "transformerlab-api"
 version = "0.27.0"

--- a/api/transformerlab/compute_providers/skypilot.py
+++ b/api/transformerlab/compute_providers/skypilot.py
@@ -152,6 +152,14 @@ class SkyPilotProvider(ComputeProvider):
         )
         return f"{distributed_env_setup};{run_command}"
 
+    def _normalize_dag(self, dag_result: Any) -> Any:
+        """Handle SkyPilot API variants where helpers return (dag, metadata)."""
+        if isinstance(dag_result, tuple):
+            if not dag_result:
+                raise ValueError("SkyPilot DAG conversion returned an empty tuple")
+            return dag_result[0]
+        return dag_result
+
     def _make_authenticated_request(
         self,
         method: str,
@@ -372,7 +380,7 @@ class SkyPilotProvider(ComputeProvider):
 
         # Convert Task to DAG and then to YAML string using SkyPilot's built-in method
         # This matches how the SDK does it internally
-        dag = dag_utils.convert_entrypoint_to_dag(task)
+        dag = self._normalize_dag(dag_utils.convert_entrypoint_to_dag(task))
 
         # Upload mounts if needed (for file mounts, etc.)
         try:
@@ -388,12 +396,12 @@ class SkyPilotProvider(ComputeProvider):
                         pass
 
             if client_common and hasattr(client_common, "upload_mounts_to_api_server"):
-                dag = client_common.upload_mounts_to_api_server(dag)
+                dag = self._normalize_dag(client_common.upload_mounts_to_api_server(dag))
         except Exception:
             # If upload_mounts fails, continue without it
             pass
 
-        dag_str = dag_utils.dump_chain_dag_to_yaml_str(dag)
+        dag_str = dag_utils.dump_dag_to_yaml_str(dag)
 
         # Get backend if specified in provider_config
         backend = None
@@ -995,7 +1003,7 @@ class SkyPilotProvider(ComputeProvider):
             task.num_nodes = job_config.num_nodes
 
         # Convert Task to DAG (matches SDK exactly)
-        dag = dag_utils.convert_entrypoint_to_dag(task)
+        dag = self._normalize_dag(dag_utils.convert_entrypoint_to_dag(task))
 
         # Validate DAG (matches SDK exactly)
         try:
@@ -1025,13 +1033,13 @@ class SkyPilotProvider(ComputeProvider):
                         pass
 
             if client_common and hasattr(client_common, "upload_mounts_to_api_server"):
-                dag = client_common.upload_mounts_to_api_server(dag, workdir_only=True)
+                dag = self._normalize_dag(client_common.upload_mounts_to_api_server(dag, workdir_only=True))
         except Exception:
             # If upload_mounts fails, continue without it
             pass
 
         # Dump DAG to YAML string (matches SDK exactly)
-        dag_str = dag_utils.dump_chain_dag_to_yaml_str(dag)
+        dag_str = dag_utils.dump_dag_to_yaml_str(dag)
 
         # Get backend if specified in provider_config
         backend = None


### PR DESCRIPTION
- Moves paramiko inside pyproject
- Upgrade skypilot sdk being used to 0.12.1
- Fix logic for dag entrypoint to handle the new tuple structure introduced in v0.12.1 of skypilot (internal source code changes within skypilot)
- This will fix the case where the api server and skypilot running on the same machines gave api server mismatch since we are on the latest skypilot version now
- Remove sentry and make it a manually installed dependency

Fixes https://github.com/transformerlab/transformerlab-app/issues/1905 