### PR TITLE
Fix invite link flow

### DIFF
--- a/api/test/api/test_teams.py
+++ b/api/test/api/test_teams.py
@@ -804,6 +804,22 @@ def test_get_pending_invitations(client, fresh_owner_user, invited_user, fresh_t
     assert invitation["invited_by_email"] == fresh_owner_user["email"]
 
 
+def test_get_invitation_by_token_without_auth(client, fresh_owner_user, fresh_test_team):
+    """Invite-link lookup should work without authentication."""
+    headers = {"Authorization": f"Bearer {fresh_owner_user['token']}", "X-Team-Id": fresh_test_team["id"]}
+    invitation_data = {"email": "lookup@test.com", "role": "member"}
+    resp = client.post(f"/teams/{fresh_test_team['id']}/members", json=invitation_data, headers=headers)
+    assert resp.status_code == 200
+
+    token = resp.json()["invitation_url"].split("token=")[1]
+    lookup = client.get(f"/invitations/by-token?token={token}")
+    assert lookup.status_code == 200
+    data = lookup.json()
+    assert data["email"] == "lookup@test.com"
+    assert data["team_id"] == fresh_test_team["id"]
+    assert data["status"] == "pending"
+
+
 def test_accept_invitation(client, fresh_owner_user, invited_user, fresh_test_team):
     """Test accepting a team invitation"""
     # Create invitation

--- a/api/transformerlab/routers/auth.py
+++ b/api/transformerlab/routers/auth.py
@@ -39,6 +39,7 @@ from transformerlab.schemas.auth import CurrentUserResponse
 from transformerlab.utils.api_key_utils import mask_key
 from lab.dirs import get_workspace_dir
 from lab import storage
+import transformerlab.services.team_service as team_service
 from transformerlab.schemas.secrets import (
     UserSecretsRequest,
     SpecialSecretRequest,
@@ -52,6 +53,18 @@ router = APIRouter(tags=["users"])
 # Simple Pydantic model for the refresh request body
 class RefreshTokenRequest(BaseModel):
     refresh_token: str
+
+
+class InvitationLookupResponse(BaseModel):
+    id: str
+    email: str
+    team_id: str
+    team_name: str
+    role: str
+    status: str
+    invited_by_email: str
+    expires_at: str
+    created_at: str
 
 
 # Include Auth and Registration Routers only if EMAIL_AUTH_ENABLED is True
@@ -190,6 +203,14 @@ async def oidc_providers_list():
         "enabled": len(OIDC_PROVIDERS) > 0,
         "providers": [{"id": p["id"], "name": p["name"]} for p in OIDC_PROVIDERS],
     }
+
+
+@router.get("/invitations/by-token", response_model=InvitationLookupResponse)
+async def get_invitation_by_token(
+    token: str,
+    session: AsyncSession = Depends(get_async_session),
+):
+    return await team_service.get_invitation_by_token(session, token)
 
 
 for _oidc in OIDC_PROVIDERS:

--- a/api/transformerlab/routers/teams.py
+++ b/api/transformerlab/routers/teams.py
@@ -6,60 +6,18 @@ from transformerlab.shared.models.models import User, Team, TeamRole
 from transformerlab.models.users import current_active_user
 from transformerlab.routers.auth import require_team_owner, get_user_and_team
 from transformerlab.schemas.secrets import TeamSecretsRequest, SpecialSecretRequest
+from transformerlab.schemas.teams import (
+    AcceptInvitationRequest,
+    GitHubPATRequest,
+    InviteMemberRequest,
+    TeamResponse,
+    TeamUpdate,
+    UpdateMemberRoleRequest,
+)
 from lab.dirs import get_workspace_dir
 
-from pydantic import BaseModel, EmailStr
 from typing import Optional
 import transformerlab.services.team_service as team_service
-
-
-class TeamCreate(BaseModel):
-    name: str
-
-
-class TeamUpdate(BaseModel):
-    name: str
-
-
-class TeamResponse(BaseModel):
-    id: str
-    name: str
-
-
-class InviteMemberRequest(BaseModel):
-    email: EmailStr
-    role: str = TeamRole.MEMBER.value
-
-
-class UpdateMemberRoleRequest(BaseModel):
-    role: str
-
-
-class MemberResponse(BaseModel):
-    user_id: str
-    email: str
-    role: str
-
-
-class InvitationResponse(BaseModel):
-    id: str
-    email: str
-    team_id: str
-    team_name: str
-    role: str
-    status: str
-    invited_by_email: str
-    expires_at: str
-    created_at: str
-
-
-class AcceptInvitationRequest(BaseModel):
-    token: str
-
-
-class GitHubPATRequest(BaseModel):
-    pat: Optional[str] = None
-
 
 router = APIRouter(tags=["teams"])
 

--- a/api/transformerlab/schemas/teams.py
+++ b/api/transformerlab/schemas/teams.py
@@ -1,0 +1,53 @@
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr
+
+from transformerlab.shared.models.models import TeamRole
+
+
+class TeamCreate(BaseModel):
+    name: str
+
+
+class TeamUpdate(BaseModel):
+    name: str
+
+
+class TeamResponse(BaseModel):
+    id: str
+    name: str
+
+
+class InviteMemberRequest(BaseModel):
+    email: EmailStr
+    role: str = TeamRole.MEMBER.value
+
+
+class UpdateMemberRoleRequest(BaseModel):
+    role: str
+
+
+class MemberResponse(BaseModel):
+    user_id: str
+    email: str
+    role: str
+
+
+class InvitationResponse(BaseModel):
+    id: str
+    email: str
+    team_id: str
+    team_name: str
+    role: str
+    status: str
+    invited_by_email: str
+    expires_at: str
+    created_at: str
+
+
+class AcceptInvitationRequest(BaseModel):
+    token: str
+
+
+class GitHubPATRequest(BaseModel):
+    pat: Optional[str] = None

--- a/api/transformerlab/services/team_service.py
+++ b/api/transformerlab/services/team_service.py
@@ -364,7 +364,7 @@ async def invite_member(
         else:
             message = "Invitation already exists and was resent"
 
-        invitation_url = f"{app_url}/#/?invitation_token={existing.token}"
+        invitation_url = f"{app_url}/#/invite?token={existing.token}"
         email_sent, email_error = _send_invite_email(email, team.name, inviter_user.email, invitation_url)
         return {
             "message": message,
@@ -389,7 +389,7 @@ async def invite_member(
     await session.commit()
     await session.refresh(invitation)
 
-    invitation_url = f"{app_url}/#/?invitation_token={invitation.token}"
+    invitation_url = f"{app_url}/#/invite?token={invitation.token}"
     try:
         email_sent, email_error = _send_invite_email(email, team.name, inviter_user.email, invitation_url)
     except HTTPException:
@@ -458,6 +458,38 @@ async def get_my_invitations(session: AsyncSession, user_email: str) -> dict:
         for inv in valid
     ]
     return {"invitations": responses}
+
+
+async def get_invitation_by_token(session: AsyncSession, token: str) -> dict:
+    """Lookup invitation details by token for invite-link UX."""
+    stmt = select(TeamInvitation).where(TeamInvitation.token == token)
+    result = await session.execute(stmt)
+    invitation = result.scalar_one_or_none()
+
+    if not invitation:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+
+    if invitation.status == InvitationStatus.PENDING.value and invitation.expires_at < datetime.utcnow():
+        invitation.status = InvitationStatus.EXPIRED.value
+        await session.commit()
+
+    result = await session.execute(select(Team).where(Team.id == invitation.team_id))
+    team = result.scalar_one_or_none()
+
+    result = await session.execute(select(User).where(User.id == invitation.invited_by_user_id))
+    inviter = result.scalar_one_or_none()
+
+    return {
+        "id": invitation.id,
+        "email": invitation.email,
+        "team_id": invitation.team_id,
+        "team_name": team.name if team else "Unknown Team",
+        "role": invitation.role,
+        "status": invitation.status,
+        "invited_by_email": inviter.email if inviter else "Unknown",
+        "expires_at": invitation.expires_at.isoformat(),
+        "created_at": invitation.created_at.isoformat(),
+    }
 
 
 async def get_team_invitations(session: AsyncSession, team_id: str) -> dict:

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { CssVarsProvider } from '@mui/joy/styles';
 import CssBaseline from '@mui/joy/CssBaseline';
 import Box from '@mui/joy/Box';
+import { useLocation } from 'react-router-dom';
 
 import Sidebar from './components/Nav/Sidebar';
 import MainAppPanel from './components/MainAppPanel';
@@ -23,6 +24,7 @@ import LoginPage from './components/Login/LoginPage';
 import { AnalyticsProvider } from './components/Shared/analytics/AnalyticsContext';
 import FullPageLoader from './components/Shared/FullPageLoader';
 import ConnectionLostModal from './components/Shared/ConnectionLostModal';
+import InvitationLanding from './components/Team/InvitationLanding';
 
 type AppContentProps = {
   connection: string;
@@ -37,9 +39,11 @@ function AppContent({
   setLogsDrawerOpen,
   themeSetter,
 }: AppContentProps) {
+  const location = useLocation();
   const authContext = useAuth();
   const { isError: connectionHealthError, isLoading: connectionHealthLoading } =
     chatAPI.useConnectionHealth(connection);
+  const isInvitePage = location.pathname === '/invite';
 
   const showConnectionLostModal =
     connection !== '' && !connectionHealthLoading && !!connectionHealthError;
@@ -59,6 +63,24 @@ function AppContent({
       }
     }
   }, [authContext.isAuthenticated]);
+
+  if (isInvitePage) {
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          width: '100vw',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          p: 2,
+          backgroundColor: 'background.body',
+        }}
+      >
+        <InvitationLanding />
+      </Box>
+    );
+  }
 
   if (authContext.initializing || isInitialUserLoad) {
     return <FullPageLoader />;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -64,6 +64,15 @@ function AppContent({
     }
   }, [authContext.isAuthenticated]);
 
+  useEffect(() => {
+    if (isInvitePage && !authContext.isAuthenticated) {
+      const currentHash = window.location.hash;
+      if (currentHash) {
+        localStorage.setItem('redirectAfterLogin', currentHash);
+      }
+    }
+  }, [isInvitePage, authContext.isAuthenticated]);
+
   if (isInvitePage) {
     return (
       <Box

--- a/src/renderer/components/Login/LoginPage.tsx
+++ b/src/renderer/components/Login/LoginPage.tsx
@@ -101,7 +101,8 @@ export default function LoginPage() {
     const invitationToken = params.get('invitation_token');
 
     if (invitationToken) {
-      localStorage.setItem('pending_invitation_token', invitationToken);
+      window.location.hash = `#/invite?token=${encodeURIComponent(invitationToken)}`;
+      return;
     }
 
     if (token) {

--- a/src/renderer/components/Team/InvitationLanding.tsx
+++ b/src/renderer/components/Team/InvitationLanding.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Alert, Box, Button, Card, Stack, Typography } from '@mui/joy';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from 'renderer/lib/authContext';
+import { getPath } from 'renderer/lib/api-client/urls';
+
+type InvitationData = {
+  id: string;
+  email: string;
+  team_id: string;
+  team_name: string;
+  role: string;
+  status: string;
+  invited_by_email: string;
+  expires_at: string;
+  created_at: string;
+};
+
+export default function InvitationLanding() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { isAuthenticated, user, fetchWithAuth } = useAuth();
+
+  const token = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('token') ?? '';
+  }, [location.search]);
+
+  const [invitation, setInvitation] = useState<InvitationData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [resultMessage, setResultMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setLoading(false);
+      setError('Missing invitation token.');
+      return;
+    }
+
+    const loadInvitation = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetchWithAuth(
+          getPath('invitations', ['byToken'], { token }),
+          { method: 'GET' },
+        );
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          setError(data.detail ?? 'Failed to load invitation.');
+          return;
+        }
+
+        const data = (await response.json()) as InvitationData;
+        setInvitation(data);
+      } catch {
+        setError('Failed to load invitation.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadInvitation();
+  }, [fetchWithAuth, token]);
+
+  const handleAccept = async () => {
+    if (!token) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetchWithAuth(
+        getPath('invitations', ['accept'], {}),
+        {
+          method: 'POST',
+          body: JSON.stringify({ token }),
+        },
+      );
+
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setError(data.detail ?? 'Failed to accept invitation.');
+        return;
+      }
+
+      setResultMessage(
+        `Invitation accepted. You joined ${data.team_name ?? 'the team'}.`,
+      );
+      setInvitation((prev) =>
+        prev
+          ? {
+              ...prev,
+              status: 'accepted',
+            }
+          : prev,
+      );
+    } catch {
+      setError('Failed to accept invitation.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!invitation?.id) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetchWithAuth(
+        getPath('invitations', ['reject'], { invitationId: invitation.id }),
+        { method: 'POST' },
+      );
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setError(data.detail ?? 'Failed to decline invitation.');
+        return;
+      }
+
+      setResultMessage('Invitation declined.');
+      setInvitation((prev) =>
+        prev
+          ? {
+              ...prev,
+              status: 'rejected',
+            }
+          : prev,
+      );
+    } catch {
+      setError('Failed to decline invitation.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const userEmail = user?.email ?? '';
+  const isMismatch =
+    isAuthenticated &&
+    invitation &&
+    userEmail &&
+    invitation.email !== userEmail;
+  const canAct =
+    isAuthenticated &&
+    invitation &&
+    !isMismatch &&
+    invitation.status === 'pending' &&
+    !resultMessage;
+
+  return (
+    <Box sx={{ width: '100%', maxWidth: 680 }}>
+      <Card variant="outlined" sx={{ p: 3 }}>
+        <Typography level="h3" sx={{ mb: 1 }}>
+          Team Invitation
+        </Typography>
+
+        {loading && <Typography>Loading invitation...</Typography>}
+        {!loading && error && <Alert color="danger">{error}</Alert>}
+
+        {!loading && invitation && (
+          <Stack spacing={1.2}>
+            <Typography>
+              You were invited to join <strong>{invitation.team_name}</strong>{' '}
+              as <strong>{invitation.role}</strong>.
+            </Typography>
+            <Typography level="body-sm" color="neutral">
+              Invited email: {invitation.email}
+            </Typography>
+            <Typography level="body-sm" color="neutral">
+              Invited by: {invitation.invited_by_email}
+            </Typography>
+            <Typography level="body-sm" color="neutral">
+              Status: {invitation.status}
+            </Typography>
+
+            {!isAuthenticated && (
+              <Alert color="warning">
+                Sign in with <strong>{invitation.email}</strong> to accept or
+                decline this invitation.
+              </Alert>
+            )}
+
+            {isMismatch && (
+              <Alert color="danger">
+                You are signed in as <strong>{userEmail}</strong>, but this
+                invitation is for <strong>{invitation.email}</strong>. Please
+                sign out, then sign in with the invited account.
+              </Alert>
+            )}
+
+            {resultMessage && <Alert color="success">{resultMessage}</Alert>}
+
+            {canAct && (
+              <Stack direction="row" spacing={1}>
+                <Button loading={submitting} onClick={handleAccept}>
+                  Accept
+                </Button>
+                <Button
+                  loading={submitting}
+                  variant="outlined"
+                  color="neutral"
+                  onClick={handleDecline}
+                >
+                  Decline
+                </Button>
+              </Stack>
+            )}
+
+            {!isAuthenticated && (
+              <Button onClick={() => navigate('/')}>Go to Login</Button>
+            )}
+          </Stack>
+        )}
+      </Card>
+    </Box>
+  );
+}

--- a/src/renderer/components/Team/InvitationLanding.tsx
+++ b/src/renderer/components/Team/InvitationLanding.tsx
@@ -33,6 +33,26 @@ export default function InvitationLanding() {
   const [resultMessage, setResultMessage] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!resultMessage) return;
+
+    const nextPath =
+      invitation?.status === 'accepted'
+        ? '/user'
+        : invitation?.status === 'rejected'
+          ? '/'
+          : null;
+    if (!nextPath) return;
+
+    const redirectTimer = window.setTimeout(() => {
+      navigate(nextPath);
+    }, 1500);
+
+    return () => {
+      window.clearTimeout(redirectTimer);
+    };
+  }, [resultMessage, invitation?.status, navigate]);
+
+  useEffect(() => {
     if (!token) {
       setLoading(false);
       setError('Missing invitation token.');
@@ -182,13 +202,22 @@ export default function InvitationLanding() {
 
             {isMismatch && (
               <Alert color="danger">
-                You are signed in as <strong>{userEmail}</strong>, but this
-                invitation is for <strong>{invitation.email}</strong>. Please
-                sign out, then sign in with the invited account.
+                You are signed in as {userEmail}, but this invitation is for{' '}
+                {invitation.email}. Please sign out, then sign in with the
+                invited account.
               </Alert>
             )}
 
-            {resultMessage && <Alert color="success">{resultMessage}</Alert>}
+            {resultMessage && (
+              <Alert color="success">
+                {resultMessage}{' '}
+                {invitation?.status === 'accepted'
+                  ? 'Redirecting to User Settings...'
+                  : invitation?.status === 'rejected'
+                    ? 'Redirecting to home...'
+                    : null}
+              </Alert>
+            )}
 
             {canAct && (
               <Stack direction="row" spacing={1}>
@@ -207,7 +236,17 @@ export default function InvitationLanding() {
             )}
 
             {!isAuthenticated && (
-              <Button onClick={() => navigate('/')}>Go to Login</Button>
+              <Button
+                onClick={() => {
+                  localStorage.setItem(
+                    'redirectAfterLogin',
+                    window.location.hash,
+                  );
+                  navigate('/');
+                }}
+              >
+                Go to Login
+              </Button>
             )}
           </Stack>
         )}

--- a/src/renderer/lib/api-client/allEndpoints.json
+++ b/src/renderer/lib/api-client/allEndpoints.json
@@ -396,6 +396,10 @@
       "method": "GET",
       "path": "invitations/me"
     },
+    "byToken": {
+      "method": "GET",
+      "path": "invitations/by-token?token={token}"
+    },
     "accept": {
       "method": "POST",
       "path": "invitations/accept"


### PR DESCRIPTION
Currently invitation flow is broken for the 2nd part where a user who received an invite has to accept it
We fix the following things: 


- User account mismatch (if I'm logged into another account and go to the url having invite token for another account):

<img width="1234" height="647" alt="Screenshot 2026-04-30 at 9 52 07 AM" src="https://github.com/user-attachments/assets/fdf80f5d-0d1d-48b6-aca6-f1d4c27b9699" />


- There was no way where I could open an invite link, log in and know where to go to accept an invite which I received. The invite link in the frontend url was never used and the user settings page just checked pending invitations for a user. We show prompts now:

Before Login:
<img width="1207" height="524" alt="Screenshot 2026-04-30 at 9 52 37 AM" src="https://github.com/user-attachments/assets/dc6d1041-e149-4a9d-a606-79ad634d0da6" />

After Login:
<img width="1209" height="614" alt="Screenshot 2026-04-30 at 9 53 46 AM" src="https://github.com/user-attachments/assets/f58f92c0-27cc-45e5-8cd7-b9e137084270" />

