### PR TITLE
Document the Transformer Lab agent skill

### DIFF
--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.43"
+version = "0.0.44"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/transformerlab-docs/docs/agent-skill.md
+++ b/transformerlab-docs/docs/agent-skill.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 16
+---
+
+# Agent Skill (for AI Coding Agents)
+
+Transformer Lab ships an [agent skill](https://github.com/anthropics/skills) that teaches AI coding agents — Claude Code, and other compatible assistants — how to drive Transformer Lab through the [`lab` CLI](https://github.com/transformerlab/transformerlab-app/tree/main/cli).
+
+Once installed, your agent knows how to:
+
+- check job status and stream logs
+- queue, upload, and edit training tasks
+- list, add, and configure compute providers
+- create models and upload/download datasets
+- publish job outputs
+
+…all by running `lab` commands on your behalf, from inside your normal coding session.
+
+## Install
+
+The easiest way is the bundled CLI command:
+
+```bash
+lab install-agent-skill
+```
+
+Behind the scenes this runs the following on your behalf:
+
+```bash
+npx skills add transformerlab/transformerlab-app --skill transformerlab-cli
+```
+
+You'll need [Node.js](https://nodejs.org) installed (`npx` ships with it). If `npx` is missing, the command will tell you.
+
+If you prefer to run the underlying `npx` invocation directly — for example in an environment that doesn't have the `lab` CLI installed yet — that one-liner above works on its own.
+
+## What it teaches the agent
+
+The skill is the same definition that lives in this repo at [`.agents/skills/transformerlab-cli/`](https://github.com/transformerlab/transformerlab-app/tree/main/.agents/skills/transformerlab-cli). It's a small bundle of instructions and command references that tells the agent which `lab` subcommands to use for common workflows, so you can ask things like:
+
+- "What jobs are running on the lab cluster?"
+- "Queue a training task using the dataset I just uploaded."
+- "Stream logs for the last training job and tell me when it finishes."
+
+…and the agent will translate those into the right `lab` calls.
+
+## Updating
+
+Re-run `lab install-agent-skill` (or the `npx` command) any time you upgrade Transformer Lab to pick up the latest version of the skill.

--- a/transformerlab-docs/docs/agent-skill.md
+++ b/transformerlab-docs/docs/agent-skill.md
@@ -32,7 +32,7 @@ npx skills add transformerlab/transformerlab-app --skill transformerlab-cli
 
 You'll need [Node.js](https://nodejs.org) installed (`npx` ships with it). If `npx` is missing, the command will tell you.
 
-If you prefer to run the underlying `npx` invocation directly — for example in an environment that doesn't have the `lab` CLI installed yet — that one-liner above works on its own.
+If you prefer to run the underlying `npx` invocation directly, that one-liner above works on its own. (You'll still need the `lab` CLI installed for the skill itself to be useful — the skill drives Transformer Lab by calling `lab` commands.)
 
 ## What it teaches the agent
 

--- a/transformerlab-docs/for-teams/running-a-task/task-submission-agent-skill.md
+++ b/transformerlab-docs/for-teams/running-a-task/task-submission-agent-skill.md
@@ -24,8 +24,16 @@ The agent will walk you through logging in and picking a current experiment the 
 From your project directory, install the skill with:
 
 ```bash
+lab install-agent-skill
+```
+
+This is a thin wrapper that runs the following on your behalf:
+
+```bash
 npx skills add transformerlab/transformerlab-app --skill transformerlab-cli
 ```
+
+You can run that `npx` command directly if you'd rather. Either way, you'll need [Node.js](https://nodejs.org) installed — `npx` ships with it.
 
 This teaches your agent how to use `lab` to check job status, stream logs, download artifacts, queue tasks, manage providers, and more.
 


### PR DESCRIPTION
## Summary

Adds a docs page for the Transformer Lab agent skill (the bundle that teaches Claude Code and other AI coding agents how to drive Transformer Lab via the \`lab\` CLI). Documents the new \`lab install-agent-skill\` command (#1937) as the recommended install path, and shows the underlying \`npx skills add ...\` one-liner as the fallback for environments that don't have the CLI yet.

## What changed

- New page \`transformerlab-docs/docs/agent-skill.md\` (sidebar position 16, between the Plugin SDK and Resources sections).
- Covers: what the skill enables, how to install it (\`lab install-agent-skill\` and the equivalent \`npx\` command), what it teaches the agent, and how to update.

## Test plan

- [ ] Reviewer: render the docs site locally (\`cd transformerlab-docs && npm start\` or equivalent) and confirm the new \"Agent Skill (for AI Coding Agents)\" entry appears in the sidebar between Plugin SDK and Resources.
- [ ] Confirm internal links to GitHub paths (\`.agents/skills/transformerlab-cli/\` and \`cli/\`) resolve.