### PR TITLE
fix(lab-sdk): normalize scheme on storage.ls(detail=True) for remote backends

### DIFF
--- a/api/localprovider_pyproject.toml
+++ b/api/localprovider_pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "soundfile==0.13.1",
   "tensorboardX==2.6.2.2",
   "timm==1.0.15",
-  "transformerlab==0.1.27",
+  "transformerlab==0.1.28",
   "transformerlab-inference==0.2.52",
   "transformers==4.57.1",
   "wandb==0.23.1",

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "python-dotenv==1.1.0",
   "python-multipart==0.0.20",
   "sqlalchemy[asyncio]==2.0.40",
-  "transformerlab==0.1.27",
+  "transformerlab==0.1.28",
   "transformerlab-inference==0.2.52",
   "uvicorn==0.35.0",
   "watchfiles==1.0.5",

--- a/lab-sdk/pyproject.toml
+++ b/lab-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab"
-version = "0.1.27"
+version = "0.1.28"
 description = "Python SDK for Transformer Lab"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/lab-sdk/src/lab/storage.py
+++ b/lab-sdk/src/lab/storage.py
@@ -408,19 +408,36 @@ async def ls(path: str, detail: bool = False, fs=None):
     filesys = fs if fs is not None else await filesystem()
     try:
         paths = await asyncio.to_thread(filesys.ls, path, detail=detail)
-        # When we enable detail, we return the raw list of paths from the filesystem as they don't contain the current path
-        # and using filesys.ls on any of those would add the prefix correctly
+        is_remote = path.startswith(_REMOTE_PATH_PREFIXES)
+        protocol = (path.split("://", 1)[0] + "://") if is_remote else ""
+
         if detail:
-            return paths
+            # fsspec's detail=True returns dicts whose 'name'/'Key' field is
+            # scheme-less for remote backends (e.g. "bucket/key" for S3).
+            # Callers like asset_download_service.list_files compare these
+            # against the scheme-prefixed `path`, so normalize here.
+            if not is_remote:
+                return paths
+            normalized: list = []
+            for entry in paths:
+                if not isinstance(entry, dict):
+                    normalized.append(entry)
+                    continue
+                # fsspec uses 'name'; some backends also surface 'Key'.
+                for key in ("name", "Key"):
+                    val = entry.get(key)
+                    if isinstance(val, str) and not val.startswith(_REMOTE_PATH_PREFIXES):
+                        entry[key] = protocol + val.lstrip("/")
+                normalized.append(entry)
+            return normalized
+
         # Ensure paths are full URIs for remote filesystems
-        if path.startswith(("s3://", "gs://", "abfs://", "gcs://")):
+        if is_remote:
             full_paths = []
             for p in paths:
-                if not p.startswith(("s3://", "gs://", "abfs://", "gcs://")):
+                if not p.startswith(_REMOTE_PATH_PREFIXES):
                     # Convert relative path to full URI
-                    protocol = path.split("://")[0] + "://"
-                    full_path = protocol + p
-                    full_paths.append(full_path)
+                    full_paths.append(protocol + p)
                 else:
                     full_paths.append(p)
             full_paths = [p for p in full_paths if p != path]


### PR DESCRIPTION
## Summary

when `TFL_STORAGE_PROVIDER=aws` (or `gcp`/`azure`) and `TFL_REMOTE_STORAGE_ENABLED=true`, fsspec's `ls(path, detail=True)` returns dicts whose `name`/`Key` field is **scheme-less** (e.g. `bucket/orgs/<org>/workspace/models/<id>/config.json`, not `s3://bucket/...`). `lab.storage.ls(detail=True)` was returning those entries unchanged, but downstream callers compare them against the **scheme-prefixed** input path. The result is a silent prefix-mismatch that drops every entry.

The most visible symptom is `asset_download_service.list_files()`:

```python
normalized_dir = asset_dir.rstrip("/")        # "s3://bucket/.../models/<id>"
prefix = normalized_dir + "/"                  # starts with "s3://"
if not full_norm.startswith(prefix):           # entry name has no scheme
    continue                                    # → every file dropped
```

This PR normalizes `detail=True` results so they return the same scheme-prefixed form that `detail=False` already returns.

## Why this is safe

I audited every `storage.ls(..., detail=True)` caller in the codebase. None relies on the scheme-less form:

| Caller | What it does with `entry["name"]` | Effect of fix |
|---|---|---|
| `asset_download_service._walk_with_sizes` | prefix-match against scheme-prefixed `asset_dir` | **fixes the reported bug** |
| `asset_download_service._file_size` | basename comparison (`name.split("/")[-1] == leaf`) | works either way; tangentially correct |
| `experiment/jobs.py:1109,1136` (image listing) | `os.path.basename(...)` | no behavioral change |
| `experiment/jobs.py:1953` (browse_dir) | `os.path.basename(...)` | no behavioral change |
| `experiment/documents.py:131` | `os.path.basename(...)` | no behavioral change |
| `migrate_tasks_to_experiment_dirs.py:62` | `_basename(full_path)` | no behavioral change |
| `migrate_jobs_to_experiment_dirs.py:75` | `_basename(full_path)` | no behavioral change |
| `experiment_service.py:65` | `if entry_name == base_dir: continue` (skip self-entry) | latently fixes the self-skip on remote storage (it was always falling through because `base_dir` had `s3://` and `entry_name` didn't) |

The two callers that actually compared the name against a scheme-prefixed path (`asset_download_service` and `experiment_service`) were both broken on remote storage — this fixes both. Everyone else extracts a basename, which is unchanged either way.

Implementation notes:

- The function mutates `entry` in place. The guard `if not val.startswith(_REMOTE_PATH_PREFIXES)` makes it idempotent — even if fsspec hands back a cached dict on a later call, the value won't get double-prefixed.
- `detail=True` on a *local* path is unchanged (early return), so the existing local-fs unit tests in `api/test/api/test_model_download.py` exercise the same code path as before.

## Test plan

- [x] Reproduced the bug end-to-end against a local server with `TFL_STORAGE_PROVIDER=aws`: `lab model upload <id> ./fake-model` finalizes, `lab model download <id> ./out` reports *"Model has no files to download."*
- [x] Applied the patch, restarted the API, re-ran the round-trip — `lab model download` now correctly retrieves all uploaded files (`config.json`, `model.txt`, `index.json`).
- [x] Targeted asset/model/storage/experiment_service tests: 38 passed, 1 skipped (`pytest test/api/test_model_download.py test/api/test_model_upload.py test/api/test_asset_download_service.py test/api/test_asset_upload_service.py test/api/test_model.py test/api/test_dataset_download_files.py test/api/test_experiment_service.py`)
- [x] Storage-related tests: `test/api/test_remote_workspace.py` and `test/api/test_storage_probe_service.py` — 8 passed.
- [x] Full `api/test/` suite: 282 passed, 3 skipped, 3 failures — all 3 failures (`test_teams.py`) verified pre-existing on `main` and unrelated to this change (auth-related 403s).
- [x] `ruff format` and `ruff check` — clean.