### PR TITLE
fix(api): register uploaded models in asset_versions on finalize

### DIFF
--- a/api/transformerlab/routers/model.py
+++ b/api/transformerlab/routers/model.py
@@ -1,8 +1,15 @@
+import logging
 from typing import Annotated
+
 from fastapi import APIRouter, Body, Depends, Header, HTTPException
 from huggingface_hub import HfApi
 
-from transformerlab.services import model_service, asset_upload_service, asset_download_service
+from transformerlab.services import (
+    asset_download_service,
+    asset_upload_service,
+    asset_version_service,
+    model_service,
+)
 from transformerlab.services.cache_service import cached
 from transformerlab.services.permission_service import require_permission
 from transformerlab.services.upload_service import (
@@ -15,6 +22,8 @@ from lab import storage
 
 from werkzeug.utils import secure_filename
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["model"])
 
@@ -305,7 +314,31 @@ async def model_finalize(model_id: str):
     json_data.setdefault("source", "transformerlab")
     await model_obj.set_metadata(name=metadata.get("name", model_id), json_data=json_data)
 
-    return {"status": "success", "architecture": architecture}
+    # Register the model in the asset_versions registry so it appears in the
+    # Model Registry UI alongside models created via `lab model create`. We
+    # treat the model_id as both the group name (display) and asset_id (the
+    # on-disk identifier the registry resolves back to). Re-uploads are a
+    # no-op once a group exists — overwriting files in place shouldn't spawn
+    # phantom v2/v3 versions that all point at the same directory.
+    registered = False
+    try:
+        existing_groups = await asset_version_service.list_groups("model")
+        already_registered = any(g.get("group_name") == model_id for g in existing_groups)
+        if not already_registered:
+            await asset_version_service.create_version(
+                asset_type="model",
+                group_name=model_id,
+                asset_id=model_id,
+                version_label="v1",
+                tag="latest",
+            )
+            registered = True
+    except Exception as exc:
+        # Registration is a convenience layer — files are already on disk and
+        # finalize itself succeeded. Surface the warning but don't fail.
+        logger.warning("Could not register model %r in asset_versions: %s", model_id, exc)
+
+    return {"status": "success", "architecture": architecture, "registered": registered}
 
 
 @router.get("/model/files", summary="List all files within a model directory.")


### PR DESCRIPTION
**Stacked on #1949** — review/merge that one first. Diff shown here is only the new commit (`843cb2ab7`); GitHub will auto-retarget this PR to `main` once #1949 merges.

## Summary

`lab model upload <id>` writes files to the filesystem but never created an `asset_versions` group/version, so the new model was invisible to:

- `lab model list` / `lab model info`
- The Model Registry UI tab at `/zoo/registry`
- `/model/registry_versions` (selectors that pick from the registry)

…even though `lab model download <id>` correctly retrieves the files. The CLI's other `model` commands (`list`, `info`, `create`, `edit`, `delete`) all operate on the registry, so users naturally expected upload to register too. This bridges the gap inside `/model/finalize`.

## Behavior

After files are uploaded and architecture is detected, `/model/finalize` now also registers an `asset_versions` group/version:

- `group_name = model_id` (display + lookup key)
- `asset_id   = model_id` (the on-disk identifier the registry resolves back to)
- `version_label = v1`, `tag = latest`

**Idempotent**: if a group with `group_name == model_id` already exists, registration is skipped. Re-uploading weights to the same model_id won't spawn phantom v2/v3 entries pointing at the same on-disk directory.

**Failure semantics**: registration runs *after* `set_metadata` succeeds. If the registry call fails for any reason, log a warning and still return the architecture — files are already on disk, and the user can fall back to `lab model create` to register manually rather than be stuck after a successful upload.

The response now includes `"registered": bool` (additive) so the CLI/UI can tell whether this finalize created a new registry entry or no-op'd because one already existed.

## Test plan

- [x] Reproduced the original bug end-to-end against a local server (S3-backed storage): `lab model upload registry-debug-001 ./fake-model` succeeded but the model was missing from `lab model list` and `/zoo/registry`.
- [x] With this patch:
  - `lab model upload registry-debug-001 ...` → finalized; `registered: true`.
  - `lab model list` → group present, `version_count: 1`, `tag: latest`.
  - **Re-upload of same id** → still `version_count: 1` (idempotent).
  - `lab model download registry-debug-001` → all 3 files retrieved (no regression).
- [x] `pytest test/api/test_model_upload.py test/api/test_model_download.py test/api/test_model.py test/api/test_asset_upload_service.py test/api/test_asset_download_service.py` → 29 passed, 1 skipped. Existing finalize tests assert only `body["architecture"]`, so the new `"registered"` field is purely additive.
- [x] `ruff format` + `ruff check` — clean.

## Notes for reviewers

- The UI's `/zoo/registry` tab queries `/asset_versions/groups?asset_type=model`, which is **not** cached, so newly-uploaded models appear immediately on refresh.
- `/model/list` (`@cached(ttl=7d)`) and `/model/registry_versions` (`@cached(ttl=1h)`) have a pre-existing staleness issue with `lab model create` too — out of scope for this PR.
- This change does not affect file finalization itself; if something is wrong with registration we still complete the upload contract (architecture detected, files written, metadata set).