### PR TITLE
docs(skill): document lab model upload and download in transformerlab-cli skill

### DIFF
--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -263,6 +263,44 @@ lab model edit GROUP_ID --name "New Name" --description "Updated description"
 lab model delete GROUP_ID --yes
 ```
 
+### Uploading model files
+
+```bash
+# Upload local files/directories to a model on the server.
+# Creates the model if it doesn't exist; MODEL_ID is what you'll use
+# in subsequent lab model commands.
+lab model upload MODEL_ID ./path/to/model-dir
+
+# Multiple paths in one call
+lab model upload MODEL_ID ./tokenizer.json ./config.json
+
+# Overwrite server-side files that already exist
+lab model upload MODEL_ID ./path/to/model-dir --force
+```
+
+The server runs a finalize step at the end of `upload`. Finalize fails with `cannot finalize: no config.json present. Upload one first.` unless the upload includes a `config.json` at the root with at least an `architectures` field. Minimal example:
+
+```json
+{
+  "model_type": "fake",
+  "architectures": ["LlamaForCausalLM"],
+  "hidden_size": 4096
+}
+```
+
+For real models this is the standard HuggingFace `config.json`. The server records `architectures[0]` as the model architecture.
+
+Re-running `lab model upload` against the same `MODEL_ID` skips files that already exist on the server and exits with code 2 (skipped some, did not fail). Use `--force` to overwrite.
+
+### Downloading model files
+
+```bash
+# Download a previously-uploaded model to <dest>/<MODEL_ID>/
+lab model download MODEL_ID ./local-models
+```
+
+The server streams every file in the model directory; the destination directory is created if missing, and files land under `<dest>/<MODEL_ID>/`.
+
 ### Publishing a model from a job
 
 After a training job completes, publish its output model to the registry:
@@ -561,6 +599,8 @@ This applies to launching jobs, fetching logs, checking cluster status, and ever
 | `lab model create <asset_id>` | Create a new model group + first version (`--name`, `--description`, `--tag`) | No |
 | `lab model edit <id>` | Edit model group name or description | No |
 | `lab model delete <id>` | Delete a model group and all versions (`--yes` to skip prompt) | No |
+| `lab model upload <id> <path...>` | Upload local files/dirs to a model (creates if needed; `--force` to overwrite) | No |
+| `lab model download <id> <dest>` | Download a model's files to `<dest>/<id>/` | No |
 | `lab dataset list` | List all dataset groups | No |
 | `lab dataset info <id>` | Show dataset group details (by group_id or group_name) | No |
 | `lab dataset upload <id> <files...>` | Upload local files to a dataset (creates if needed) | No |

--- a/.agents/skills/transformerlab-cli/references/commands.md
+++ b/.agents/skills/transformerlab-cli/references/commands.md
@@ -369,6 +369,32 @@ Delete a model group and all its versions.
 |---|---|
 | `--yes` / `-y` | Skip confirmation prompt. **Always use in automated workflows.** |
 
+### `model upload <model_id> <paths...>`
+
+Upload local files or directories to a model on the server. Creates the model if it does not exist. The `model_id` is the identifier used in subsequent `lab model` commands.
+
+| Option | Description |
+|---|---|
+| `--force` | Overwrite files that already exist on the server. |
+
+```bash
+lab model upload my-model ./path/to/model-dir
+lab model upload my-model ./tokenizer.json ./config.json
+lab model upload my-model ./path --force
+```
+
+The server runs a finalize step at the end of `upload` and requires a `config.json` at the root with at least an `architectures` field (`architectures[0]` is recorded as the model architecture). Without it, finalize fails with `cannot finalize: no config.json present. Upload one first.`
+
+Re-running `upload` against the same `model_id` skips files that already exist on the server and exits with code 2 (skipped some, did not fail). Use `--force` to overwrite.
+
+### `model download <model_id> <dest>`
+
+Download every file in a model's directory on the server to `<dest>/<model_id>/`. The destination directory is created if missing.
+
+```bash
+lab model download my-model ./local-models
+```
+
 ---
 
 ## Dataset Commands


### PR DESCRIPTION
## Why

The transformerlab-cli agent skill listed model commands as only `list/info/create/edit/delete`. It did not mention `lab model upload` or `lab model download`, both of which are real commands. Because of this gap, an agent recently told a user "the CLI doesn't support uploading local model files," which is wrong — the user had to push back with `lab model --help` to correct it.

## What changed

- `.agents/skills/transformerlab-cli/SKILL.md`
  - Added `### Uploading model files` and `### Downloading model files` subsections under `## Managing Models`, before `### Publishing a model from a job`.
  - Documented `--force`, the required `config.json` (with `architectures`) for finalize, and the re-upload exit-code-2 skip behavior.
  - Added `lab model upload` and `lab model download` rows to the `## Command Overview` table.
- `.agents/skills/transformerlab-cli/references/commands.md`
  - Added `### model upload <model_id> <paths...>` and `### model download <model_id> <dest>` entries in the Model Commands section, matching the surrounding style.

(Note: `.agents/skills/` and `.claude/skills/` are hardlinked, so a single edit covers both paths.)

## Independence

This PR is purely a docs change to the agent skill. It is independent of any open feature/fix PRs around model upload behavior.