### PR TITLE
docs(skill): clarify REST API rule — workaround forbidden, reading source encouraged

### DIFF
--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -411,7 +411,7 @@ Provider configs (`api_token`, `api_key`, `ssh_key_path`) contain secrets. If th
 
 ## Agent-Specific Rules
 
-1. **NEVER use the REST API unless the user explicitly asks for it.** The CLI is the supported interface. If a CLI command appears missing or broken, run `lab <command> --help` first and check this skill — do not reach for `curl`. Using the REST API as a workaround is a hard rule violation.
+1. **NEVER call the REST API as a workaround for the CLI.** The CLI is the supported interface — don't reach for `curl` because a CLI command appears missing or broken. Run `lab <command> --help` first and check this skill. *Reading* the API source under `api/transformerlab/` (routers, services) when debugging a CLI failure is fine and often necessary; the rule is against substituting `curl` for `lab`, not against understanding what the server does.
 2. **Always run `lab <command> --help` before assuming a flag exists.** Don't guess `--provider`, `--gpu`, etc. The CLI's flag surface is small and changes; verify before invoking.
 3. **Use `--format json`** when you need to parse output, but be prepared to fall back to pretty output parsing if it doesn't work
 4. **`--no-interactive` on `task queue` silently uses the DEFAULT provider (Local).** There is no `--provider` flag. To target a specific provider, you must drive the interactive prompts (see "Selecting a provider" below).
@@ -511,15 +511,17 @@ lab job request-logs JOB_ID   # provider launch/provisioning logs
 
 Use `lab job info JOB_ID` — it shows `cluster_name` and provisioning state. For more detail use `lab job request-logs JOB_ID` (provider launch logs). If a cluster never provisioned, the request-logs will show why (wrong accelerator type, quota, etc.).
 
-## Do NOT use the REST API
+## Do NOT call the REST API as a CLI workaround
 
-The CLI is the supported, sanctioned interface. **Never call the REST API directly with `curl` unless the user explicitly asks you to.** If the CLI seems to be missing a capability:
+The CLI is the supported, sanctioned interface. **Never call the REST API with `curl` because a CLI command appears missing or broken** — that's the rule. If a CLI command seems missing or wrong:
 
 1. Run `lab <command> --help` and `lab <subcommand> --help` to verify
 2. Re-read this skill for the right pattern (e.g. interactive prompts via stdin)
 3. Tell the user the CLI doesn't support it — don't silently switch to `curl`
 
 This applies to launching jobs, fetching logs, checking cluster status, and everything else.
+
+**Reading the API source code is encouraged.** When debugging *why* a CLI call is failing — wrong response, silent filter, unexpected output — opening files under `api/transformerlab/` (routers, services) is the right move. That's investigation, not a workaround. The rule is against substituting `curl` calls for `lab` calls, not against understanding what the server does.
 
 ## Command Overview
 
@@ -601,17 +603,17 @@ With non-zero exit code.
 - Connection refused → check server URL with `lab config`, verify server is running
 - "No compute providers available" → add a provider in team settings first, or check `provider list`
 
-## When to Use CLI vs REST API vs Browser
+## When to Use CLI vs Reading API Source vs Browser
 
-| Use CLI for | Use REST API for | Use Browser for |
+| Use CLI for | Read API source for | Use Browser for |
 |---|---|---|
-| Login, config, status checks | Launching jobs when CLI fails | Creating experiments |
-| Listing tasks and jobs | Getting provider logs | Configuring tasks via forms |
-| Streaming job logs (`--follow`) | Checking cluster status | Visual UI verification |
-| Adding tasks from local dirs | Any operation where CLI returns errors | Creating API keys |
-| Downloading artifacts | Debugging failed jobs | Managing team settings |
+| Login, config, status checks | Understanding why a CLI call returned wrong data | Creating experiments |
+| Listing tasks and jobs | Tracing what `/model/finalize` etc. actually do on the server | Configuring tasks via forms |
+| Streaming job logs (`--follow`) | Confirming whether a CLI failure is client-side or server-side | Visual UI verification |
+| Adding tasks from local dirs | Reading a router/service to spot silent filters or unhandled errors | Creating API keys |
+| Downloading artifacts | Sanity-checking response shapes before reporting a bug | Managing team settings |
 
-**When to fall back to REST API:** If any CLI command returns "Not Found", "Method Not Allowed", or "No compute providers available", the server API may have changed. Use the OpenAPI spec (`/openapi.json`) to find correct endpoints and call them directly with `curl`.
+**If a CLI command appears missing, broken, or returns unexpected output:** investigate (run `--help`, re-read this skill, read the relevant router/service under `api/transformerlab/`), then tell the user what you found. **Don't** silently fall back to `curl` against the REST API or `/openapi.json` — that's the workaround pattern this skill explicitly forbids.
 
 ## Deep-Dive References
 


### PR DESCRIPTION
## Why

The transformerlab-cli skill's REST-API rule was binary in a way that caused real friction. It conflated:

1. **Calling the REST API with \`curl\` as a substitute for a missing/broken CLI command** — a genuine hard-rule violation that should be forbidden.
2. **Reading the API source code under \`api/transformerlab/\` to understand a CLI failure** — which is normal, often necessary debugging. (We needed it to track down the storage.ls scheme bug fixed in #1949.)

Worse, the existing skill itself contradicted its own rule: the **\"When to fall back to REST API\"** paragraph at the bottom of the file explicitly told the agent to call \`/openapi.json\` with \`curl\` when CLI commands errored, directly contradicting the dedicated rule three sections earlier.

## What changed

Three places in \`.agents/skills/transformerlab-cli/SKILL.md\`:

1. **Rule #1 in \"Agent-Specific Rules\"** (\`NEVER use the REST API...\` → \`NEVER call the REST API as a workaround for the CLI...\`): explicitly endorses *reading* API source code as part of debugging.

2. **Dedicated \"Do NOT use the REST API\" section**: renamed to \"Do NOT call the REST API as a CLI workaround\". Adds a paragraph: **\"Reading the API source code is encouraged.\"**

3. **\"CLI vs REST API vs Browser\" table**: renamed to \"CLI vs Reading API Source vs Browser\". The middle column is now concrete debugging uses (\"Tracing what /model/finalize actually does on the server\", \"Reading a router/service to spot silent filters\") instead of curl invocations. The contradictory \"fall back to REST API\" paragraph below is replaced by one that says: investigate (\`--help\`, skill, source), then tell the user.

## Test plan

- [x] \`git diff --stat\` shows only the SKILL.md edit (13 insertions, 11 deletions, no surrounding-line drift).
- [x] Searched the file for any remaining contradictory advice — the three places that mentioned \"fall back to REST API\" / \"call them directly with curl\" / \"Use REST API for\" are all consistent now.
- [x] Independent of #1949, #1951, #1952. Branched off latest \`main\`.