### PR TITLE
Factor out repeated user+team lookup

### DIFF
--- a/api/transformerlab/routers/experiment/experiment.py
+++ b/api/transformerlab/routers/experiment/experiment.py
@@ -15,7 +15,8 @@ from transformerlab.routers.experiment import (
     task as task_router,
 )
 from transformerlab.routers.auth import get_user_and_team
-from transformerlab.services.permission_service import check_permission, require_permission
+from transformerlab.services.permission_service import check_permission, get_user_team, require_permission
+from transformerlab.shared.models.models import TeamRole
 from transformerlab.shared.models.user_model import get_async_session
 
 from werkzeug.utils import secure_filename
@@ -57,6 +58,13 @@ async def experiments_get_all(
     experiments = await experiment_service.experiment_get_all()
     user = user_and_team["user"]
     team_id = user_and_team["team_id"]
+    user_id = str(user.id)
+
+    user_team = await get_user_team(session, user_id, team_id)
+    if user_team is None:
+        return []
+    if user_team.role == TeamRole.OWNER.value:
+        return experiments
 
     filtered_experiments = []
     for experiment in experiments:
@@ -65,11 +73,12 @@ async def experiments_get_all(
             continue
         allowed = await check_permission(
             session=session,
-            user_id=str(user.id),
+            user_id=user_id,
             team_id=team_id,
             resource_type="experiment",
             resource_id=experiment_id,
             action="read",
+            user_team=user_team,
         )
         if allowed:
             filtered_experiments.append(experiment)

--- a/api/transformerlab/services/permission_service.py
+++ b/api/transformerlab/services/permission_service.py
@@ -22,6 +22,20 @@ from transformerlab.shared.models.user_model import get_async_session
 VALID_ACTIONS = frozenset({"read", "write", "execute", "delete", "admin"})
 
 
+async def get_user_team(
+    session: AsyncSession,
+    user_id: str,
+    team_id: str,
+) -> UserTeam | None:
+    """Fetch the UserTeam membership row for a (user, team) pair, or None."""
+    stmt = select(UserTeam).where(
+        UserTeam.user_id == user_id,
+        UserTeam.team_id == team_id,
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
 async def check_permission(
     session: AsyncSession,
     user_id: str,
@@ -29,22 +43,23 @@ async def check_permission(
     resource_type: str,
     resource_id: str,
     action: str,
+    user_team: UserTeam | None = None,
 ) -> bool:
     """
     Returns True if the user may perform `action` on the given resource.
     Raises nothing — callers decide how to handle False.
     `action` must be one of VALID_ACTIONS; unknown actions are always denied.
+
+    Callers iterating over many resources for the same (user, team) should
+    fetch the membership once via `get_user_team()` and pass it as `user_team`
+    to avoid re-running that lookup per item.
     """
     if action not in VALID_ACTIONS:
         return False
 
     # Step 1: resolve membership + owner shortcut
-    stmt = select(UserTeam).where(
-        UserTeam.user_id == user_id,
-        UserTeam.team_id == team_id,
-    )
-    result = await session.execute(stmt)
-    user_team = result.scalar_one_or_none()
+    if user_team is None:
+        user_team = await get_user_team(session, user_id, team_id)
 
     if user_team is None:
         return False  # Not a member of this team


### PR DESCRIPTION
This addresses sentry issue 7417823697

N+1 Query
SELECT users_teams.user_id, users_teams.team_id, users_teams.role FROM users_teams WHERE users_teams.user_id = ? AND users_teams.team_id = ?

on /experiment/