### PR TITLE
Fix bugs related to AWS Compute and fix int job id bug in sweep results modal

### DIFF
--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -628,6 +628,7 @@ if [ -x /root/.local/bin/uvx ]; then cp /root/.local/bin/uvx /usr/local/bin/uvx 
                     "cluster_id": status.cluster_name,
                     "cluster_name": status.cluster_name,
                     "backend_type": "AWS EC2",
+                    "cloud_provider": "AWS",
                     "elastic_enabled": True,
                     "max_nodes": 1,
                     "head_node_ip": (status.provider_data or {}).get("PublicIpAddress"),

--- a/src/renderer/components/Compute/Resources.tsx
+++ b/src/renderer/components/Compute/Resources.tsx
@@ -230,14 +230,13 @@ const Resources = () => {
 
     if (isFixed) {
       fixedClusters.push(cluster);
-      fixedClusters.backend_type = cluster.backend_type;
     } else {
       elasticClusters.push(cluster);
-      elasticClusters.backend_type = cluster.backend_type;
 
       // Group by cloud provider (use cloud_provider field if available, otherwise cluster_name)
       const cloudName =
         cluster.cloud_provider?.toUpperCase() ||
+        cluster.backend_type?.toUpperCase() ||
         cluster.cluster_name.toUpperCase();
       if (!cloudGroups[cloudName]) {
         cloudGroups[cloudName] = [];
@@ -268,7 +267,6 @@ const Resources = () => {
       </Box>
     );
   }
-  console.log(providers);
   return (
     <Box sx={{ maxHeight: '80vh', overflowY: 'auto', p: 3, pb: 10 }}>
       <Stack
@@ -679,6 +677,7 @@ const Resources = () => {
                         const cloudType = isFixed
                           ? backendType
                           : cluster.cloud_provider?.toUpperCase() ||
+                            cluster.backend_type?.toUpperCase() ||
                             cluster?.cluster_name.toUpperCase();
 
                         return (

--- a/src/renderer/components/Experiment/Tasks/ViewSweepResultsModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/ViewSweepResultsModal.tsx
@@ -26,7 +26,7 @@ export function SweepResultsBody({ jobId }: { jobId: string }) {
   const [sortBy, setSortBy] = useState<string | null>(null);
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
 
-  const { data, error, isLoading } = useSWR(
+  const { data, isError, isLoading } = useSWR(
     jobId && experimentInfo
       ? chatAPI.Endpoints.ComputeProvider.GetSweepResults(jobId)
       : null,
@@ -61,7 +61,7 @@ export function SweepResultsBody({ jobId }: { jobId: string }) {
       );
     }
 
-    if (error || data?.status === 'error') {
+    if (isError || data?.status === 'error') {
       return (
         <Typography level="body-md" sx={{ color: 'danger.500', py: 2 }}>
           {data?.message || 'Failed to load sweep results'}
@@ -252,7 +252,7 @@ export default function ViewSweepResultsModal({
 
   return (
     <Modal
-      open={jobId !== -1}
+      open={Boolean(jobId)}
       onClose={() => {
         setJobId(null);
       }}


### PR DESCRIPTION
- Adds missed `cloud_provider` field for AWS which is used on the Compute tab
- Also fixes a missed int job id call in sweep results modal