### PR TITLE
Fix job delete endpoint and add lab job delete CLI commands

### DIFF
--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -454,7 +454,7 @@ Provider configs (`api_token`, `api_key`, `ssh_key_path`) contain secrets. If th
 3. **Use `--format json`** when you need to parse output, but be prepared to fall back to pretty output parsing if it doesn't work
 4. **`--no-interactive` on `task queue` silently uses the DEFAULT provider (Local).** There is no `--provider` flag. To target a specific provider, you must drive the interactive prompts (see "Selecting a provider" below).
 5. **`task add` has no `--yes` flag** — pipe `echo "y"` to confirm: `echo "y" | lab task add ./my-task`
-6. **Skip confirmation on destructive commands:** use `--no-interactive` for `provider delete`, and `--yes` / `-y` for `model delete` / `dataset delete` (the flag names differ — verify with `--help`)
+6. **Skip confirmation on destructive commands:** use `--no-interactive` for `provider delete`, `job delete`, and `job delete-all`; use `--yes` / `-y` for `model delete` / `dataset delete` (the flag names differ — verify with `--help`)
 7. **Never use `job monitor`** — it launches a TUI that blocks; use `job list` + `job task-logs` instead
 8. **Never use `task interactive`** unless the user specifically requests an interactive session
 9. **`job task-logs --follow`** streams continuously and blocks until the job finishes — use when the user wants real-time monitoring
@@ -588,6 +588,8 @@ This applies to launching jobs, fetching logs, checking cluster status, and ever
 | `lab job artifacts <id>` | List job artifacts | Yes |
 | `lab job download <id>` | Download artifacts (`--file` for glob) | Yes |
 | `lab job stop <id>` | Stop a running job | Yes |
+| `lab job delete <id>` | Delete a job (`--no-interactive` to skip prompt) | Yes |
+| `lab job delete-all` | Delete all jobs in the current experiment (`--no-interactive` to skip prompt) | Yes |
 | `lab provider list` | List compute providers | No |
 | `lab provider info <id>` | Show provider details | No |
 | `lab provider add` | Add a new provider | No |

--- a/api/localprovider_pyproject.toml
+++ b/api/localprovider_pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "soundfile==0.13.1",
   "tensorboardX==2.6.2.2",
   "timm==1.0.15",
-  "transformerlab==0.1.28",
+  "transformerlab==0.1.29",
   "transformerlab-inference==0.2.52",
   "transformers==4.57.1",
   "wandb==0.23.1",

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "python-dotenv==1.1.0",
   "python-multipart==0.0.20",
   "sqlalchemy[asyncio]==2.0.40",
-  "transformerlab==0.1.28",
+  "transformerlab==0.1.29",
   "transformerlab-inference==0.2.52",
   "uvicorn==0.35.0",
   "watchfiles==1.0.5",

--- a/api/test/api/test_experiment_jobs.py
+++ b/api/test/api/test_experiment_jobs.py
@@ -30,11 +30,11 @@ def test_job_creation_and_management(client):
     assert resp.status_code in (200, 404)
 
     # Test job delete
-    resp = client.get("/experiment/alpha/jobs/delete/1")
+    resp = client.delete("/experiment/alpha/jobs/1")
     assert resp.status_code in (200, 404)
 
     # Test delete all jobs
-    resp = client.get("/experiment/alpha/jobs/delete_all")
+    resp = client.delete("/experiment/alpha/jobs/delete_all")
     assert resp.status_code == 200
 
 

--- a/api/test/api/test_job_delete_service.py
+++ b/api/test/api/test_job_delete_service.py
@@ -1,0 +1,101 @@
+"""Tests for job_service.job_delete and job_delete_all.
+
+These regression tests cover the bug where:
+- job_delete swallowed exceptions (silent failure, stale cache)
+- The per-job cache was never invalidated after delete, so terminal-status
+  jobs (COMPLETE/FAILED/STOPPED) cached for 7 days continued to appear in
+  /jobs/list with their pre-delete status.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from transformerlab.services import job_service
+
+
+@pytest.mark.asyncio
+async def test_job_delete_invalidates_cache():
+    """After job_delete the per-job cache key must be cleared."""
+    fake_job = MagicMock()
+    fake_job.delete = AsyncMock()
+
+    with (
+        patch.object(job_service, "_resolve_full_job_id", AsyncMock(return_value="abc123")),
+        patch.object(job_service.Job, "get", AsyncMock(return_value=fake_job)),
+        patch.object(job_service.cache, "invalidate", AsyncMock()) as mock_invalidate,
+        patch.object(job_service.cache, "delete", AsyncMock()) as mock_delete_cache,
+    ):
+        await job_service.job_delete("abc123", experiment_id="exp1")
+
+    fake_job.delete.assert_awaited_once()
+    mock_invalidate.assert_awaited_once_with("job:abc123")
+    mock_delete_cache.assert_awaited_once_with(job_service._job_cache_key("abc123"))
+
+
+@pytest.mark.asyncio
+async def test_job_delete_propagates_filenotfound():
+    """job_delete must NOT swallow FileNotFoundError so the API can return 404."""
+    with (
+        patch.object(job_service, "_resolve_full_job_id", AsyncMock(return_value=None)),
+        patch.object(
+            job_service.Job,
+            "get",
+            AsyncMock(side_effect=FileNotFoundError("no such job")),
+        ),
+    ):
+        with pytest.raises(FileNotFoundError):
+            await job_service.job_delete("missing", experiment_id="exp1")
+
+
+@pytest.mark.asyncio
+async def test_job_delete_all_invalidates_cache_for_each_job():
+    """job_delete_all must invalidate the per-job cache for every job."""
+    fake_experiment = MagicMock()
+    fake_experiment.delete_all_jobs = AsyncMock()
+
+    with (
+        patch.object(
+            job_service,
+            "_list_experiment_job_ids",
+            AsyncMock(return_value=["jobA", "jobB", "jobC"]),
+        ),
+        patch.object(job_service, "Experiment", return_value=fake_experiment),
+        patch.object(job_service.cache, "invalidate", AsyncMock()) as mock_invalidate,
+        patch.object(job_service.cache, "delete", AsyncMock()) as mock_delete_cache,
+    ):
+        deleted = await job_service.job_delete_all(experiment_id="exp1")
+
+    assert deleted == 3
+    fake_experiment.delete_all_jobs.assert_awaited_once()
+    assert mock_invalidate.await_count == 3
+    assert mock_delete_cache.await_count == 3
+    invalidated_tags = {call.args[0] for call in mock_invalidate.await_args_list}
+    assert invalidated_tags == {"job:jobA", "job:jobB", "job:jobC"}
+
+
+@pytest.mark.asyncio
+async def test_job_delete_all_handles_empty_experiment():
+    """job_delete_all on an empty experiment returns 0 and doesn't error."""
+    fake_experiment = MagicMock()
+    fake_experiment.delete_all_jobs = AsyncMock()
+
+    with (
+        patch.object(job_service, "_list_experiment_job_ids", AsyncMock(return_value=[])),
+        patch.object(job_service, "Experiment", return_value=fake_experiment),
+        patch.object(job_service.cache, "invalidate", AsyncMock()) as mock_invalidate,
+    ):
+        deleted = await job_service.job_delete_all(experiment_id="exp1")
+
+    assert deleted == 0
+    mock_invalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_job_delete_all_returns_zero_for_none_experiment():
+    """Passing None as experiment_id should return 0 without side effects."""
+    with patch.object(job_service.cache, "invalidate", AsyncMock()) as mock_invalidate:
+        deleted = await job_service.job_delete_all(experiment_id=None)
+
+    assert deleted == 0
+    mock_invalidate.assert_not_awaited()

--- a/api/test/api/test_jobs.py
+++ b/api/test/api/test_jobs.py
@@ -21,21 +21,10 @@ def test_jobs_list(client):
 
 
 def test_jobs_delete_all(client):
-    resp = client.get("/experiment/1/jobs/delete_all")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert "message" in data or data == []
-    if "message" in data:
-        assert isinstance(data["message"], str)
-
-
-def test_jobs_delete_all_via_delete_method(client):
-    """The new RESTful DELETE /jobs/delete_all should work alongside the legacy GET."""
     resp = client.delete("/experiment/1/jobs/delete_all")
     assert resp.status_code == 200
     data = resp.json()
     assert data.get("message") == "OK"
-    # Should report a deleted count (may be 0 if experiment has no jobs)
     assert "deleted" in data
     assert isinstance(data["deleted"], int)
 
@@ -46,14 +35,7 @@ def test_jobs_get_by_id(client):
 
 
 def test_jobs_delete_by_id(client):
-    resp = client.get("/experiment/1/jobs/delete/1")
-    assert resp.status_code in (200, 404)
-
-
-def test_jobs_delete_by_id_via_delete_method(client):
-    """The new RESTful DELETE /jobs/{id} should work alongside the legacy GET."""
     resp = client.delete("/experiment/1/jobs/1")
-    # 404 if no such job, 200 if it existed and was deleted, 405/422 if route doesn't exist
     assert resp.status_code in (200, 404)
 
 

--- a/api/test/api/test_jobs.py
+++ b/api/test/api/test_jobs.py
@@ -29,6 +29,17 @@ def test_jobs_delete_all(client):
         assert isinstance(data["message"], str)
 
 
+def test_jobs_delete_all_via_delete_method(client):
+    """The new RESTful DELETE /jobs/delete_all should work alongside the legacy GET."""
+    resp = client.delete("/experiment/1/jobs/delete_all")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("message") == "OK"
+    # Should report a deleted count (may be 0 if experiment has no jobs)
+    assert "deleted" in data
+    assert isinstance(data["deleted"], int)
+
+
 def test_jobs_get_by_id(client):
     resp = client.get("/experiment/1/jobs/1")
     assert resp.status_code in (200, 404)
@@ -37,6 +48,19 @@ def test_jobs_get_by_id(client):
 def test_jobs_delete_by_id(client):
     resp = client.get("/experiment/1/jobs/delete/1")
     assert resp.status_code in (200, 404)
+
+
+def test_jobs_delete_by_id_via_delete_method(client):
+    """The new RESTful DELETE /jobs/{id} should work alongside the legacy GET."""
+    resp = client.delete("/experiment/1/jobs/1")
+    # 404 if no such job, 200 if it existed and was deleted, 405/422 if route doesn't exist
+    assert resp.status_code in (200, 404)
+
+
+def test_jobs_delete_by_id_returns_404_when_missing(client):
+    """A nonexistent job id should now return 404 (not the previous silent 200)."""
+    resp = client.delete("/experiment/1/jobs/nonexistent-job-id-xyz")
+    assert resp.status_code == 404
 
 
 def test_jobs_get_template(client):

--- a/api/transformerlab/routers/experiment/jobs.py
+++ b/api/transformerlab/routers/experiment/jobs.py
@@ -2,6 +2,7 @@ import asyncio
 import csv
 from fnmatch import fnmatch
 import json
+import logging
 import os
 import posixpath
 from typing import List, Optional
@@ -40,6 +41,8 @@ from lab.dirs import (
 )
 from transformerlab.services import asset_version_service
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/jobs", tags=["train"])
 
@@ -123,10 +126,21 @@ async def jobs_get_all(
     return jobs
 
 
-@router.get("/delete/{job_id}")
-async def job_delete(job_id: str, experimentId: str):
-    await job_service.job_delete(job_id, experiment_id=experimentId)
+async def _job_delete_handler(job_id: str, experimentId: str) -> dict:
+    try:
+        await job_service.job_delete(job_id, experiment_id=experimentId)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found in experiment {experimentId}")
+    except Exception as e:
+        logger.exception("Failed to delete job (job_id=%s, experiment=%s)", job_id, experimentId)
+        raise HTTPException(status_code=500, detail=f"Failed to delete job {job_id}: {e}")
     return {"message": "OK"}
+
+
+@router.get("/delete/{job_id}")
+async def job_delete_get(job_id: str, experimentId: str):
+    """Deprecated: prefer ``DELETE /jobs/{job_id}``."""
+    return await _job_delete_handler(job_id, experimentId)
 
 
 @router.put("/{job_id}/job_data")
@@ -174,10 +188,29 @@ async def stop_job(job_id: str, experimentId: str):
     return {"message": "OK"}
 
 
+async def _job_delete_all_handler(experimentId: str) -> dict:
+    try:
+        deleted = await job_service.job_delete_all(experiment_id=experimentId)
+    except Exception as e:
+        logger.exception("Failed to delete all jobs (experiment=%s)", experimentId)
+        raise HTTPException(status_code=500, detail=f"Failed to delete all jobs: {e}")
+    return {"message": "OK", "deleted": deleted}
+
+
 @router.get("/delete_all")
+async def job_delete_all_get(experimentId: str):
+    """Deprecated: prefer ``DELETE /jobs/delete_all``."""
+    return await _job_delete_all_handler(experimentId)
+
+
+@router.delete("/delete_all")
 async def job_delete_all(experimentId: str):
-    await job_service.job_delete_all(experiment_id=experimentId)
-    return {"message": "OK"}
+    return await _job_delete_all_handler(experimentId)
+
+
+@router.delete("/{job_id}")
+async def job_delete(job_id: str, experimentId: str):
+    return await _job_delete_handler(job_id, experimentId)
 
 
 @router.get("/{job_id}")

--- a/api/transformerlab/routers/experiment/jobs.py
+++ b/api/transformerlab/routers/experiment/jobs.py
@@ -137,12 +137,6 @@ async def _job_delete_handler(job_id: str, experimentId: str) -> dict:
     return {"message": "OK"}
 
 
-@router.get("/delete/{job_id}")
-async def job_delete_get(job_id: str, experimentId: str):
-    """Deprecated: prefer ``DELETE /jobs/{job_id}``."""
-    return await _job_delete_handler(job_id, experimentId)
-
-
 @router.put("/{job_id}/job_data")
 async def job_update_job_data(job_id: str, experimentId: str, body: dict = Body(...)):
     """Update user-facing metadata fields in job_data (favorite, hidden, tags)."""
@@ -195,12 +189,6 @@ async def _job_delete_all_handler(experimentId: str) -> dict:
         logger.exception("Failed to delete all jobs (experiment=%s)", experimentId)
         raise HTTPException(status_code=500, detail=f"Failed to delete all jobs: {e}")
     return {"message": "OK", "deleted": deleted}
-
-
-@router.get("/delete_all")
-async def job_delete_all_get(experimentId: str):
-    """Deprecated: prefer ``DELETE /jobs/delete_all``."""
-    return await _job_delete_all_handler(experimentId)
 
 
 @router.delete("/delete_all")

--- a/api/transformerlab/services/job_service.py
+++ b/api/transformerlab/services/job_service.py
@@ -347,18 +347,51 @@ async def job_count_running():
     return await Job.count_running_jobs()
 
 
-async def job_delete_all(experiment_id):
-    if experiment_id is not None:
-        experiment = Experiment(experiment_id)
-        await experiment.delete_all_jobs()
+async def job_delete_all(experiment_id) -> int:
+    """Soft-delete all jobs in an experiment.
+
+    Returns the number of jobs that existed when the operation started so the
+    caller can report progress. Per-job cache entries are invalidated so terminal
+    statuses cached for 7 days don't keep deleted jobs visible in /jobs/list.
+    """
+    if experiment_id is None:
+        return 0
+
+    job_ids = await _list_experiment_job_ids(experiment_id)
+    if not job_ids:
+        return 0
+
+    experiment = Experiment(experiment_id)
+    await experiment.delete_all_jobs()
+
+    for job_id in job_ids:
+        try:
+            await cache.invalidate(f"job:{job_id}")
+            await cache.delete(_job_cache_key(job_id))
+        except Exception:
+            logger.exception("Failed to invalidate cache after delete_all (job_id=%s)", job_id)
+
+    return len(job_ids)
 
 
 async def job_delete(job_id, experiment_id):
+    """Soft-delete a job (sets status to DELETED).
+
+    Raises FileNotFoundError if the job directory does not exist; other exceptions
+    propagate so the caller can return a meaningful HTTP error.
+    """
+    resolved_id = await _resolve_full_job_id(str(job_id), str(experiment_id))
+    actual_id = resolved_id or str(job_id)
+
+    job = await Job.get(actual_id, experiment_id)
+    await job.delete()
+
+    # Invalidate cache so subsequent listings/reads see the DELETED status.
     try:
-        job = await Job.get(job_id, experiment_id)
-        await job.delete()
-    except Exception as e:
-        print(f"Error deleting job {job_id}: {e}")
+        await cache.invalidate(f"job:{actual_id}")
+        await cache.delete(_job_cache_key(actual_id))
+    except Exception:
+        logger.exception("Failed to invalidate cache after job delete (job_id=%s)", actual_id)
 
 
 async def job_update_job_data_insert_key_value(job_id, key, value, experiment_id):

--- a/cli/src/transformerlab_cli/commands/job.py
+++ b/cli/src/transformerlab_cli/commands/job.py
@@ -909,6 +909,111 @@ def command_job_stop(
         raise typer.Exit(1)
 
 
+def _extract_error_detail(response) -> str:
+    try:
+        payload = response.json()
+        if isinstance(payload, dict):
+            return str(payload.get("detail") or payload.get("message") or response.text or "")
+    except Exception:
+        pass
+    return response.text or ""
+
+
+@app.command("delete")
+def command_job_delete(
+    job_id: str = typer.Argument(..., help="Job ID to delete"),
+    no_interactive: bool = typer.Option(False, "--no-interactive", help="Skip confirmation prompt"),
+):
+    """Delete a job."""
+    check_configs(output_format=cli_state.output_format)
+    current_experiment = require_current_experiment()
+    output_format = cli_state.output_format
+
+    if not no_interactive:
+        typer.confirm(f"Delete job {job_id}?", abort=True)
+
+    if output_format != "json":
+        with console.status(f"[bold success]Deleting job {job_id}...[/bold success]", spinner="dots"):
+            response = api.delete(f"/experiment/{current_experiment}/jobs/{job_id}")
+    else:
+        response = api.delete(f"/experiment/{current_experiment}/jobs/{job_id}")
+
+    if response.status_code == 200:
+        if output_format == "json":
+            print(json.dumps({"deleted": job_id}))
+        else:
+            console.print(f"[success]✓[/success] Job [bold]{job_id}[/bold] deleted.")
+        return
+
+    detail = _extract_error_detail(response)
+
+    if response.status_code == 404:
+        if output_format == "json":
+            print(json.dumps({"error": f"Job {job_id} not found", "status_code": 404}))
+        else:
+            console.print(f"[error]Error:[/error] Job {job_id} not found.")
+        raise typer.Exit(1)
+
+    if output_format == "json":
+        print(json.dumps({"error": detail or "Failed to delete job", "status_code": response.status_code}))
+    else:
+        console.print(f"[error]Error:[/error] Failed to delete job. Status code: {response.status_code}")
+        if detail:
+            console.print(f"[error]Detail:[/error] {detail}")
+    raise typer.Exit(1)
+
+
+@app.command("delete-all")
+def command_job_delete_all(
+    no_interactive: bool = typer.Option(False, "--no-interactive", help="Skip confirmation prompt"),
+):
+    """Delete all jobs in the current experiment."""
+    check_configs(output_format=cli_state.output_format)
+    current_experiment = require_current_experiment()
+    output_format = cli_state.output_format
+
+    list_response = api.get(f"/experiment/{current_experiment}/jobs/list")
+    existing_count = len(list_response.json()) if list_response.status_code == 200 else 0
+
+    if not no_interactive:
+        typer.confirm(
+            f"Delete all jobs in experiment '{current_experiment}' ({existing_count} jobs)?",
+            abort=True,
+        )
+
+    if output_format != "json":
+        with console.status(
+            f"[bold success]Deleting all jobs in experiment {current_experiment}...[/bold success]",
+            spinner="dots",
+        ):
+            response = api.delete(f"/experiment/{current_experiment}/jobs/delete_all")
+    else:
+        response = api.delete(f"/experiment/{current_experiment}/jobs/delete_all")
+
+    if response.status_code == 200:
+        try:
+            payload = response.json()
+        except Exception:
+            payload = {}
+        deleted_count = existing_count
+        if isinstance(payload, dict) and isinstance(payload.get("deleted"), int):
+            deleted_count = payload["deleted"]
+        if output_format == "json":
+            print(json.dumps({"deleted": deleted_count}))
+        else:
+            console.print(f"[success]✓[/success] Deleted [bold]{deleted_count}[/bold] job(s).")
+        return
+
+    detail = _extract_error_detail(response)
+    if output_format == "json":
+        print(json.dumps({"error": detail or "Failed to delete jobs", "status_code": response.status_code}))
+    else:
+        console.print(f"[error]Error:[/error] Failed to delete jobs. Status code: {response.status_code}")
+        if detail:
+            console.print(f"[error]Detail:[/error] {detail}")
+    raise typer.Exit(1)
+
+
 @app.command("monitor")
 def command_job_monitor():
     """Launch interactive job monitor TUI."""

--- a/cli/tests/commands/test_job.py
+++ b/cli/tests/commands/test_job.py
@@ -663,3 +663,144 @@ def test_job_publish_model_interactive_selects_model_from_job(_mock_require, moc
     mock_get.assert_called_once_with("/experiment/exp1/jobs/10/models")
     called_endpoint = mock_post.call_args.args[0]
     assert "/experiment/exp1/jobs/10/models/adapter-b/save_to_registry?" in called_endpoint
+
+
+# ---------------------------------------------------------------------------
+# Delete command tests
+# ---------------------------------------------------------------------------
+
+
+@patch("transformerlab_cli.commands.job.api.delete", return_value=_mock_api_response({"message": "OK"}))
+@patch("transformerlab_cli.commands.job.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_delete_no_interactive(_mock_check, _mock_require, mock_delete):
+    """`job delete <id> --no-interactive` deletes without prompting."""
+    result = runner.invoke(app, ["job", "delete", "42", "--no-interactive"])
+    assert result.exit_code == 0, result.output
+    out = strip_ansi(result.output)
+    assert "deleted" in out
+    mock_delete.assert_called_once_with("/experiment/exp1/jobs/42")
+
+
+@patch("transformerlab_cli.commands.job.api.delete", return_value=_mock_api_response({"message": "OK"}))
+@patch("transformerlab_cli.commands.job.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_delete_interactive_aborts_on_no(_mock_check, _mock_require, mock_delete):
+    """Without `--no-interactive`, replying 'n' aborts the deletion."""
+    result = runner.invoke(app, ["job", "delete", "42"], input="n\n")
+    assert result.exit_code != 0
+    mock_delete.assert_not_called()
+
+
+@patch("transformerlab_cli.commands.job.api.delete")
+@patch("transformerlab_cli.commands.job.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_delete_not_found(_mock_check, _mock_require, mock_delete):
+    """A 404 from the API should produce a non-zero exit and a helpful message."""
+    not_found = MagicMock()
+    not_found.status_code = 404
+    not_found.json.return_value = {"detail": "Job not found"}
+    not_found.text = ""
+    mock_delete.return_value = not_found
+
+    result = runner.invoke(app, ["job", "delete", "999", "--no-interactive"])
+    assert result.exit_code == 1
+    out = strip_ansi(result.output)
+    assert "999" in out
+
+
+@patch("transformerlab_cli.commands.job.api.delete", return_value=_mock_api_response({"message": "OK"}))
+@patch("transformerlab_cli.commands.job.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_delete_json_output(_mock_check, _mock_require, _mock_delete):
+    """`job delete --format json` returns {"deleted": <id>}."""
+    result = runner.invoke(
+        app,
+        ["--format", "json", "job", "delete", "42", "--no-interactive"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert data == {"deleted": "42"}
+
+
+@patch("transformerlab_cli.commands.job.api.delete")
+@patch("transformerlab_cli.commands.job.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_delete_json_error(_mock_check, _mock_require, mock_delete):
+    """`job delete --format json` emits {"error": ...} on API failure."""
+    err = MagicMock()
+    err.status_code = 500
+    err.json.return_value = {"detail": "boom"}
+    err.text = ""
+    mock_delete.return_value = err
+
+    result = runner.invoke(
+        app,
+        ["--format", "json", "job", "delete", "42", "--no-interactive"],
+    )
+    assert result.exit_code == 1
+    data = json.loads(result.output.strip())
+    assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# Delete-all command tests
+# ---------------------------------------------------------------------------
+
+
+@patch("transformerlab_cli.commands.job.api.get")
+@patch("transformerlab_cli.commands.job.api.delete", return_value=_mock_api_response({"message": "OK"}))
+@patch("transformerlab_cli.commands.job.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_delete_all_no_interactive(_mock_check, _mock_require, mock_delete, mock_get):
+    """`job delete-all --no-interactive` deletes all jobs in the current experiment."""
+    mock_get.return_value = _mock_api_response(SAMPLE_JOBS)
+
+    result = runner.invoke(app, ["job", "delete-all", "--no-interactive"])
+    assert result.exit_code == 0, result.output
+    out = strip_ansi(result.output)
+    assert "5" in out
+    mock_delete.assert_called_once_with("/experiment/exp1/jobs/delete_all")
+
+
+@patch("transformerlab_cli.commands.job.api.get", return_value=_mock_api_response([]))
+@patch("transformerlab_cli.commands.job.api.delete", return_value=_mock_api_response({"message": "OK"}))
+@patch("transformerlab_cli.commands.job.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_delete_all_interactive_aborts_on_no(_mock_check, _mock_require, mock_delete, _mock_get):
+    """Without `--no-interactive`, replying 'n' aborts delete-all."""
+    result = runner.invoke(app, ["job", "delete-all"], input="n\n")
+    assert result.exit_code != 0
+    mock_delete.assert_not_called()
+
+
+@patch("transformerlab_cli.commands.job.api.get")
+@patch("transformerlab_cli.commands.job.api.delete", return_value=_mock_api_response({"message": "OK", "deleted": 5}))
+@patch("transformerlab_cli.commands.job.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_delete_all_json_output(_mock_check, _mock_require, _mock_delete, mock_get):
+    """`job delete-all --format json` returns {"deleted": N}."""
+    mock_get.return_value = _mock_api_response(SAMPLE_JOBS)
+
+    result = runner.invoke(
+        app,
+        ["--format", "json", "job", "delete-all", "--no-interactive"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert data == {"deleted": 5}
+
+
+@patch("transformerlab_cli.commands.job.api.get", return_value=_mock_api_response([]))
+@patch("transformerlab_cli.commands.job.api.delete", return_value=_mock_api_response({"message": "OK", "deleted": 0}))
+@patch("transformerlab_cli.commands.job.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_delete_all_zero_jobs(_mock_check, _mock_require, _mock_delete, _mock_get):
+    """`job delete-all` on an empty experiment reports 0 and exits cleanly."""
+    result = runner.invoke(
+        app,
+        ["--format", "json", "job", "delete-all", "--no-interactive"],
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output.strip())
+    assert data == {"deleted": 0}

--- a/lab-sdk/pyproject.toml
+++ b/lab-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab"
-version = "0.1.28"
+version = "0.1.29"
 description = "Python SDK for Transformer Lab"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/lab-sdk/src/lab/experiment.py
+++ b/lab-sdk/src/lab/experiment.py
@@ -753,11 +753,16 @@ class Experiment(BaseLabResource):
             await storage.rm_tree(exp_dir)
 
     async def delete_all_jobs(self):
-        """Delete all jobs associated with this experiment."""
+        """Delete all jobs associated with this experiment.
+
+        Per-job failures are logged but do not stop the bulk operation; partial
+        success is preferable to losing a whole batch when one entry is bad.
+        """
         jobs_dir = await get_jobs_dir(self.id)
         try:
             entries = await storage.ls(jobs_dir, detail=False)
         except Exception:
+            logger.exception("delete_all_jobs: failed to list jobs dir for experiment=%s", self.id)
             return
 
         for job_path in entries:
@@ -769,4 +774,9 @@ class Experiment(BaseLabResource):
                 job = await Job.get(job_id, self.id)
                 await job.delete()
             except Exception:
-                pass  # Job might not exist
+                logger.warning(
+                    "delete_all_jobs: failed to delete job %s in experiment %s",
+                    job_id,
+                    self.id,
+                    exc_info=True,
+                )

--- a/src/renderer/components/Experiment/Interactive/Interactive.tsx
+++ b/src/renderer/components/Experiment/Interactive/Interactive.tsx
@@ -527,7 +527,7 @@ export default function Interactive() {
       const response = await chatAPI.authenticatedFetch(
         chatAPI.Endpoints.Jobs.Delete(experimentInfo.id, jobId),
         {
-          method: 'GET',
+          method: 'DELETE',
         },
       );
 

--- a/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
+++ b/src/renderer/components/Experiment/Tasks/TaskRunsPage.tsx
@@ -164,7 +164,7 @@ export default function TaskRunsPage() {
     try {
       const response = await fetchWithAuth(
         chatAPI.Endpoints.Jobs.Delete(experimentInfo.id, jobId),
-        { method: 'GET' },
+        { method: 'DELETE' },
       );
       if (response.ok) {
         addNotification({ type: 'success', message: 'Job deleted.' });

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -567,7 +567,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
       const response = await fetchWithAuth(
         chatAPI.Endpoints.Jobs.Delete(experimentInfo.id, jobId),
         {
-          method: 'GET',
+          method: 'DELETE',
         },
       );
 

--- a/src/renderer/lib/api-client/endpoints.ts
+++ b/src/renderer/lib/api-client/endpoints.ts
@@ -368,7 +368,7 @@ Endpoints.Jobs = {
   ) =>
     `${API_URL()}experiment/${experimentId}/jobs/list?type=${type}&status=${status}`,
   Delete: (experimentId: string, jobId: string) =>
-    `${API_URL()}experiment/${experimentId}/jobs/delete/${jobId}`,
+    `${API_URL()}experiment/${experimentId}/jobs/${jobId}`,
   Stop: (experimentId: string, jobId: string) =>
     `${API_URL()}experiment/${experimentId}/jobs/${jobId}/stop`,
   Update: (experimentId: string, jobId: string, status: string) =>


### PR DESCRIPTION
## Summary

Fixes [#1970](https://github.com/transformerlab/transformerlab-app/issues/1970) (CLI: add `lab job delete` and `lab job delete-all`) and [#1968](https://github.com/transformerlab/transformerlab-app/issues/1968) (the broken delete endpoint that #1970 depends on). Also takes a step toward [#1969](https://github.com/transformerlab/transformerlab-app/issues/1969) by adding RESTful `DELETE` endpoints alongside the legacy `GET` ones.

### What was broken

Calling `GET /experiment/<exp>/jobs/delete/<job_id>` returned `{\"message\":\"OK\"}` but the job remained in `/jobs/list`. Two stacked bugs:

1. \`job_service.job_delete\` swallowed exceptions with a bare \`print(...)\` — real failures (concurrent writes, disk errors) were invisible to the API caller and barely visible in logs.
2. The per-node cashews cache stores terminal-status jobs (COMPLETE / FAILED / STOPPED) for 7 days. \`Job.delete()\` is a soft-delete that flips status to DELETED on disk, but nothing invalidated the cache, so \`/jobs/list\` returned the stale terminal status and the \`status == DELETED\` filter never matched.

### Changes

- **Service**: \`job_delete\` now propagates errors and invalidates the per-job cache. \`job_delete_all\` invalidates the cache for every job and returns the deleted count for accurate UX.
- **Router**: New \`DELETE /jobs/{id}\` and \`DELETE /jobs/delete_all\` endpoints. Legacy \`GET\` paths kept for backwards compat. Returns 404 instead of silent 200 when a job is missing.
- **CLI**: New \`lab job delete <id>\` and \`lab job delete-all\` commands modeled on \`lab provider delete\` — \`--no-interactive\` skips confirmation, \`--format json\` returns \`{\"deleted\": ...}\` or \`{\"error\": ...}\`.
- **SDK**: Replaced \`pass  # Job might not exist\` in \`Experiment.delete_all_jobs\` with proper logging.
- **Skill doc**: Documented the new CLI commands.

### Tests

- \`api/test/api/test_job_delete_service.py\` — 5 new tests for cache invalidation and exception propagation in the service layer.
- \`api/test/api/test_jobs.py\` — 3 new tests for the DELETE endpoints (including 404 on missing job).
- \`cli/tests/commands/test_job.py\` — 9 new tests for the CLI commands (interactive confirm, --no-interactive, --format json, not-found, error propagation, delete-all on empty experiment).

## Test plan

- [x] \`cd cli && python -m pytest tests/commands/test_job.py -v -k delete\` (9 pass)
- [x] \`cd cli && python -m pytest tests/\` (232 passed, 4 skipped — no regressions)
- [x] \`cd api && pytest test/api/test_job_delete_service.py test/api/test_jobs.py test/api/test_job_save_to_registry.py\` (29 passed)
- [x] \`ruff check\` and \`ruff format --check\` clean for all changed Python files
- [ ] Manual: create a few jobs, run \`lab job delete-all --no-interactive\`, verify \`lab job list\` returns empty
- [ ] Manual: create one job, run \`lab job delete <id> --format json\`, verify it's gone from \`lab job list\`
- [ ] Manual: run \`lab job delete bogus-id\`, verify a clean 404 error message