### PR TITLE
Add Jobs Chart modal (score vs. date)

### DIFF
--- a/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { Box, Modal, ModalClose, ModalDialog, Typography } from '@mui/joy';
 import { ResponsiveLine } from '@nivo/line';
-import { isTerminalJobStatus } from 'renderer/lib/utils';
 
 interface JobsChartModalProps {
   open: boolean;
@@ -187,10 +186,13 @@ export default function JobsChartModal({
         const j = job as {
           id?: string | number;
           status?: string;
+          created_at?: string;
           job_data?: {
             score?: unknown;
             description?: unknown;
             discard?: unknown;
+            start_time?: string;
+            end_time?: string;
           };
         };
         const date = extractDate(j);
@@ -228,23 +230,10 @@ export default function JobsChartModal({
         }
 
         if (yValue === null) {
-          kind = 'no_metric';
-          const otherKeys = primaryKey
-            ? Object.keys(fields).filter((k) => k !== primaryKey)
-            : Object.keys(fields);
-          const hasOtherMetrics = otherKeys.length > 0;
-          const terminal = isTerminalJobStatus(j?.status ?? '');
-          if (!terminal) {
-            statusNote = 'Research in progress — no score for this metric yet';
-          } else if (hasOtherMetrics && primaryKey) {
-            statusNote = `No "${primaryKey}" value — this run used other metrics`;
-          } else {
-            statusNote = 'No score recorded for this metric';
-          }
-          if (discarded) {
-            statusNote = `Discarded — ${statusNote}`;
-          }
-        } else if (discarded) {
+          // Hide jobs that don't have a score for this metric.
+          continue;
+        }
+        if (discarded) {
           kind = 'discarded';
         }
 
@@ -275,20 +264,17 @@ export default function JobsChartModal({
       const span = maxY - minY || 1;
       const baseline = minY - span * 0.12;
 
-      const sorted = rows
-        .map((r) => {
-          const y = r.yValue === null ? baseline : r.yValue;
-          return {
-            x: r.x,
-            y,
-            jobId: r.jobId,
-            description: r.description,
-            kind: r.kind,
-            isBest: false,
-            metricLabel: r.metricLabel,
-            statusNote: r.statusNote,
-          } satisfies ChartPoint;
-        })
+      const sorted: ChartPoint[] = rows
+        .map((r) => ({
+          x: r.x,
+          y: r.yValue === null ? baseline : r.yValue,
+          jobId: r.jobId,
+          description: r.description,
+          kind: r.kind,
+          isBest: false,
+          metricLabel: r.metricLabel,
+          statusNote: r.statusNote,
+        }))
         .sort((a, b) => a.x.getTime() - b.x.getTime());
 
       let runningExtreme = lowerBetter ? Infinity : -Infinity;
@@ -397,10 +383,10 @@ export default function JobsChartModal({
                     key={`pt-${i}`}
                     cx={cx}
                     cy={cy}
-                    r={isBest ? 7 : 4}
+                    r={isBest ? 5 : 4}
                     fill={isBest ? BEST_COLOR : POINT_COLOR}
                     stroke={isBest ? BEST_BORDER : 'none'}
-                    strokeWidth={isBest ? 1.5 : 0}
+                    strokeWidth={0}
                   />
                 );
               })
@@ -416,7 +402,7 @@ export default function JobsChartModal({
           primaryMetric
             ? `Metric: ${primaryMetric} — green marks best so far (${lowerIsBetter ? 'lower' : 'higher'} is better)`
             : `Green marks best so far (${lowerIsBetter ? 'lower' : 'higher'} is better)`,
-          'Grey dots are discarded runs or runs without this metric.',
+          'Grey dots are discarded runs.',
         ].join(' ');
 
   return (
@@ -424,7 +410,7 @@ export default function JobsChartModal({
       <ModalDialog sx={{ width: '90vw', maxWidth: '1200px', height: '85vh' }}>
         <ModalClose />
         <Typography level="title-lg" sx={{ mb: 1 }}>
-          Jobs Chart
+          Progress Chart
         </Typography>
         <Typography level="body-sm" sx={{ mb: 2, color: 'text.tertiary' }}>
           {subtitle}

--- a/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
@@ -1,36 +1,134 @@
 import { useMemo } from 'react';
 import { Box, Modal, ModalClose, ModalDialog, Typography } from '@mui/joy';
 import { ResponsiveLine } from '@nivo/line';
+import { isTerminalJobStatus } from 'renderer/lib/utils';
 
 interface JobsChartModalProps {
   open: boolean;
   onClose: () => void;
-  jobs: any[];
+  jobs: unknown[];
 }
+
+type ChartPointKind = 'scored' | 'discarded' | 'no_metric';
 
 interface ChartPoint {
   x: Date;
   y: number;
   jobId: string;
+  description: string;
+  kind: ChartPointKind;
   isBest: boolean;
+  metricLabel: string;
+  statusNote?: string;
 }
 
 const BEST_COLOR = '#22c55e';
 const BEST_BORDER = '#15803d';
 const POINT_COLOR = '#3b82f6';
+const DISCARD_POINT_FILL = '#94a3b8';
+const DISCARD_POINT_STROKE = '#64748b';
+const NO_METRIC_POINT_FILL = '#cbd5e1';
+const NO_METRIC_POINT_STROKE = '#94a3b8';
 
-function extractScore(job: any): number | null {
-  const raw = job?.job_data?.score;
-  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
-  if (raw && typeof raw === 'object') {
-    for (const value of Object.values(raw)) {
-      if (typeof value === 'number' && Number.isFinite(value)) return value;
-    }
+function parseDiscardValue(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
   }
-  return null;
+  if (typeof value === 'number') {
+    if (value === 0 || value === 1) {
+      return Boolean(value);
+    }
+    return false;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') {
+      return true;
+    }
+    if (normalized === 'false') {
+      return false;
+    }
+    const numeric = Number.parseInt(normalized, 10);
+    if (Number.isNaN(numeric)) {
+      return false;
+    }
+    return numeric === 1;
+  }
+  return false;
 }
 
-function extractDate(job: any): Date | null {
+/** Numeric score fields only (excludes `discard` and non-numeric keys). */
+function parseNumericScoreFields(score: unknown): Record<string, number> {
+  if (typeof score === 'number' && Number.isFinite(score)) {
+    return { score };
+  }
+  if (typeof score === 'string') {
+    const parsed = Number.parseFloat(score);
+    return Number.isFinite(parsed) ? { score: parsed } : {};
+  }
+  if (score && typeof score === 'object') {
+    const out: Record<string, number> = {};
+    for (const [key, val] of Object.entries(score as Record<string, unknown>)) {
+      if (key.toLowerCase() === 'discard') continue;
+      const n = Number(val);
+      if (Number.isFinite(n)) {
+        out[key] = n;
+      }
+    }
+    return out;
+  }
+  return {};
+}
+
+function computePrimaryMetricKey(jobs: unknown[]): string | null {
+  const counts = new Map<string, number>();
+  for (const job of jobs) {
+    const fields = parseNumericScoreFields(
+      (job as { job_data?: { score?: unknown } })?.job_data?.score,
+    );
+    for (const k of Object.keys(fields)) {
+      counts.set(k, (counts.get(k) ?? 0) + 1);
+    }
+  }
+  if (counts.size === 0) {
+    return null;
+  }
+  const ranked = [...counts.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) {
+      return b[1] - a[1];
+    }
+    const aPreferred = a[0].toLowerCase() === 'score' ? 0 : 1;
+    const bPreferred = b[0].toLowerCase() === 'score' ? 0 : 1;
+    if (aPreferred !== bPreferred) {
+      return aPreferred - bPreferred;
+    }
+    return a[0].localeCompare(b[0]);
+  });
+  return ranked[0][0];
+}
+
+function resolveLowerIsBetter(jobs: unknown[]): boolean {
+  let trueCount = 0;
+  let falseCount = 0;
+  for (const job of jobs) {
+    const v = (job as { job_data?: { lower_is_better?: boolean } })?.job_data
+      ?.lower_is_better;
+    if (v === true) {
+      trueCount += 1;
+    } else if (v === false) {
+      falseCount += 1;
+    }
+  }
+  if (trueCount === 0 && falseCount === 0) {
+    return false;
+  }
+  return trueCount > falseCount;
+}
+
+function extractDate(job: {
+  created_at?: string;
+  job_data?: { start_time?: string; end_time?: string };
+}): Date | null {
   const raw =
     job?.created_at ??
     job?.job_data?.start_time ??
@@ -41,61 +139,205 @@ function extractDate(job: any): Date | null {
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
+function getJobDescription(job: {
+  job_data?: { description?: unknown };
+}): string {
+  const d = job?.job_data?.description;
+  if (typeof d === 'string') {
+    return d.trim();
+  }
+  return '';
+}
+
 export default function JobsChartModal({
   open,
   onClose,
   jobs,
 }: JobsChartModalProps) {
-  const points = useMemo<ChartPoint[]>(() => {
-    if (!Array.isArray(jobs)) return [];
-    const sorted = jobs
-      .map((job) => {
-        const score = extractScore(job);
-        const date = extractDate(job);
-        if (score === null || date === null) return null;
+  const { points, bestForStepLine, primaryMetric, lowerIsBetter, axisLegend } =
+    useMemo(() => {
+      if (!Array.isArray(jobs)) {
         return {
-          x: date,
-          y: score,
-          jobId: String(job?.id ?? ''),
-          isBest: false,
+          points: [] as ChartPoint[],
+          bestForStepLine: [] as ChartPoint[],
+          primaryMetric: null as string | null,
+          lowerIsBetter: false,
+          axisLegend: 'Score',
         };
-      })
-      .filter((p): p is ChartPoint => p !== null)
-      .sort((a, b) => a.x.getTime() - b.x.getTime());
-
-    let runningMax = -Infinity;
-    for (const p of sorted) {
-      if (p.y > runningMax) {
-        p.isBest = true;
-        runningMax = p.y;
       }
-    }
-    return sorted;
-  }, [jobs]);
 
-  const chartData = useMemo(() => {
-    const allData = points.map((p) => ({
-      x: p.x,
-      y: p.y,
-      jobId: p.jobId,
-      isBest: p.isBest,
-    }));
-    const bestData = points
-      .filter((p) => p.isBest)
-      .map((p) => ({ x: p.x, y: p.y, jobId: p.jobId, isBest: true }));
-    return [
-      { id: 'jobs', data: allData },
-      { id: 'best', data: bestData },
-    ];
-  }, [points]);
+      const primaryKey = computePrimaryMetricKey(jobs);
+      const lowerBetter = resolveLowerIsBetter(jobs);
+      const axis = primaryKey ? `Score (${primaryKey})` : 'Score';
 
-  // Custom layer: stepped line connecting the running-max points.
-  const BestStepLine = ({ series, xScale, yScale }: any) => {
-    const best = series.find((s: any) => s.id === 'best');
-    if (!best || best.data.length < 2) return null;
-    const pts = best.data.map((d: any) => ({
-      x: xScale(d.data.x),
-      y: yScale(d.data.y),
+      type RawRow = {
+        x: Date;
+        jobId: string;
+        description: string;
+        discarded: boolean;
+        kind: ChartPointKind;
+        yValue: number | null;
+        metricLabel: string;
+        statusNote?: string;
+      };
+
+      const rows: RawRow[] = [];
+
+      for (const job of jobs) {
+        const j = job as {
+          id?: string | number;
+          status?: string;
+          job_data?: {
+            score?: unknown;
+            description?: unknown;
+            discard?: unknown;
+          };
+        };
+        const date = extractDate(j);
+        if (!date) continue;
+
+        const score = j?.job_data?.score;
+        const fields = parseNumericScoreFields(score);
+        const discardFromScore =
+          score && typeof score === 'object'
+            ? (score as Record<string, unknown>).discard
+            : undefined;
+        const discarded =
+          parseDiscardValue(discardFromScore) ||
+          parseDiscardValue(j?.job_data?.discard);
+
+        const description = getJobDescription(j);
+        const jobId = String(j?.id ?? '');
+
+        let yValue: number | null = null;
+        let metricLabel = primaryKey ? primaryKey : 'score';
+        let kind: ChartPointKind = 'scored';
+        let statusNote: string | undefined;
+
+        if (primaryKey && fields[primaryKey] !== undefined) {
+          yValue = fields[primaryKey];
+          metricLabel = primaryKey;
+        } else if (!primaryKey && Object.keys(fields).length > 0) {
+          const preferred =
+            Object.entries(fields).find(([k]) => k.toLowerCase() === 'score') ??
+            Object.entries(fields)[0];
+          if (preferred) {
+            metricLabel = preferred[0];
+            yValue = preferred[1];
+          }
+        }
+
+        if (yValue === null) {
+          kind = 'no_metric';
+          const otherKeys = primaryKey
+            ? Object.keys(fields).filter((k) => k !== primaryKey)
+            : Object.keys(fields);
+          const hasOtherMetrics = otherKeys.length > 0;
+          const terminal = isTerminalJobStatus(j?.status ?? '');
+          if (!terminal) {
+            statusNote = 'Research in progress — no score for this metric yet';
+          } else if (hasOtherMetrics && primaryKey) {
+            statusNote = `No "${primaryKey}" value — this run used other metrics`;
+          } else {
+            statusNote = 'No score recorded for this metric';
+          }
+          if (discarded) {
+            statusNote = `Discarded — ${statusNote}`;
+          }
+        } else if (discarded) {
+          kind = 'discarded';
+        }
+
+        rows.push({
+          x: date,
+          jobId,
+          description,
+          discarded,
+          kind,
+          yValue,
+          metricLabel,
+          statusNote,
+        });
+      }
+
+      const scoredYs = rows
+        .filter((r) => r.yValue !== null)
+        .map((r) => r.yValue as number);
+      let minY: number;
+      let maxY: number;
+      if (scoredYs.length === 0) {
+        minY = 0;
+        maxY = 1;
+      } else {
+        minY = Math.min(...scoredYs);
+        maxY = Math.max(...scoredYs);
+      }
+      const span = maxY - minY || 1;
+      const baseline = minY - span * 0.12;
+
+      const sorted = rows
+        .map((r) => {
+          const y = r.yValue === null ? baseline : r.yValue;
+          return {
+            x: r.x,
+            y,
+            jobId: r.jobId,
+            description: r.description,
+            kind: r.kind,
+            isBest: false,
+            metricLabel: r.metricLabel,
+            statusNote: r.statusNote,
+          } satisfies ChartPoint;
+        })
+        .sort((a, b) => a.x.getTime() - b.x.getTime());
+
+      let runningExtreme = lowerBetter ? Infinity : -Infinity;
+      for (const p of sorted) {
+        if (p.kind !== 'scored') continue;
+        const better = lowerBetter
+          ? p.y < runningExtreme
+          : p.y > runningExtreme;
+        if (better) {
+          p.isBest = true;
+          runningExtreme = p.y;
+        }
+      }
+
+      const bestForLine = sorted.filter((p) => p.isBest && p.kind === 'scored');
+
+      return {
+        points: sorted,
+        bestForStepLine: bestForLine,
+        primaryMetric: primaryKey,
+        lowerIsBetter: lowerBetter,
+        axisLegend: axis,
+      };
+    }, [jobs]);
+
+  const chartData = useMemo(
+    () => [
+      {
+        id: 'jobs',
+        data: points.map((p) => ({
+          x: p.x,
+          y: p.y,
+          jobId: p.jobId,
+          description: p.description,
+          kind: p.kind,
+          isBest: p.isBest,
+          metricLabel: p.metricLabel,
+          statusNote: p.statusNote,
+        })),
+      },
+    ],
+    [points],
+  );
+
+  const BestStepLine = ({ xScale, yScale }: any) => {
+    if (bestForStepLine.length < 2) return null;
+    const pts = bestForStepLine.map((p) => ({
+      x: xScale(p.x),
+      y: yScale(p.y),
     }));
     let path = `M ${pts[0].x},${pts[0].y}`;
     for (let i = 1; i < pts.length; i++) {
@@ -112,30 +354,70 @@ export default function JobsChartModal({
     );
   };
 
-  // Custom layer: render points ourselves so we can size/color
-  // best-so-far points differently from regular points.
   const CustomPoints = ({ series, xScale, yScale }: any) => (
     <g>
-      {series.flatMap((s: any) =>
-        s.id === 'jobs'
-          ? s.data.map((d: any, i: number) => {
-              const isBest = !!d.data.isBest;
-              return (
-                <circle
-                  key={`pt-${i}`}
-                  cx={xScale(d.data.x)}
-                  cy={yScale(d.data.y)}
-                  r={isBest ? 7 : 4}
-                  fill={isBest ? BEST_COLOR : POINT_COLOR}
-                  stroke={isBest ? BEST_BORDER : 'none'}
-                  strokeWidth={isBest ? 1.5 : 0}
-                />
-              );
-            })
-          : [],
+      {series.flatMap(
+        (s: { id: string; data: { data: Record<string, unknown> }[] }) =>
+          s.id === 'jobs'
+            ? s.data.map((d: { data: Record<string, unknown> }, i: number) => {
+                const row = d.data;
+                const kind = row.kind as ChartPointKind;
+                const isBest = kind === 'scored' && !!row.isBest;
+                const cx = xScale(row.x as Date);
+                const cy = yScale(row.y as number);
+                if (kind === 'no_metric') {
+                  return (
+                    <circle
+                      key={`pt-${i}`}
+                      cx={cx}
+                      cy={cy}
+                      r={5}
+                      fill={NO_METRIC_POINT_FILL}
+                      stroke={NO_METRIC_POINT_STROKE}
+                      strokeWidth={1}
+                      strokeDasharray="3 2"
+                    />
+                  );
+                }
+                if (kind === 'discarded') {
+                  return (
+                    <circle
+                      key={`pt-${i}`}
+                      cx={cx}
+                      cy={cy}
+                      r={5}
+                      fill={DISCARD_POINT_FILL}
+                      stroke={DISCARD_POINT_STROKE}
+                      strokeWidth={1.5}
+                    />
+                  );
+                }
+                return (
+                  <circle
+                    key={`pt-${i}`}
+                    cx={cx}
+                    cy={cy}
+                    r={isBest ? 7 : 4}
+                    fill={isBest ? BEST_COLOR : POINT_COLOR}
+                    stroke={isBest ? BEST_BORDER : 'none'}
+                    strokeWidth={isBest ? 1.5 : 0}
+                  />
+                );
+              })
+            : [],
       )}
     </g>
   );
+
+  const subtitle =
+    points.length === 0
+      ? 'No jobs with a date to plot'
+      : [
+          primaryMetric
+            ? `Metric: ${primaryMetric} — green marks best so far (${lowerIsBetter ? 'lower' : 'higher'} is better)`
+            : `Green marks best so far (${lowerIsBetter ? 'lower' : 'higher'} is better)`,
+          'Grey dots are discarded runs or runs without this metric.',
+        ].join(' ');
 
   return (
     <Modal open={open} onClose={onClose}>
@@ -145,9 +427,7 @@ export default function JobsChartModal({
           Jobs Chart
         </Typography>
         <Typography level="body-sm" sx={{ mb: 2, color: 'text.tertiary' }}>
-          {points.length === 0
-            ? 'No jobs with a score and date to plot'
-            : `Score over time across ${points.length} job${points.length === 1 ? '' : 's'} — green marks the best score so far`}
+          {subtitle}
         </Typography>
         <Box
           sx={{
@@ -178,13 +458,13 @@ export default function JobsChartModal({
                 legendPosition: 'middle',
               }}
               axisLeft={{
-                legend: 'Score',
+                legend: axisLegend,
                 legendOffset: -48,
                 legendPosition: 'middle',
               }}
               enableGridX={false}
               enableGridY
-              colors={[POINT_COLOR, BEST_COLOR]}
+              colors={[POINT_COLOR]}
               lineWidth={0}
               enablePoints={false}
               layers={[
@@ -197,9 +477,18 @@ export default function JobsChartModal({
               ]}
               useMesh
               tooltip={({ point }) => {
-                const jobId = (point.data as any).jobId as string;
+                const data = point.data as {
+                  jobId?: string;
+                  description?: string;
+                  kind?: ChartPointKind;
+                  isBest?: boolean;
+                  metricLabel?: string;
+                  statusNote?: string;
+                };
+                const jobId = data.jobId ?? '';
                 const shortId = jobId ? jobId.slice(0, 8) : '';
-                const isBest = !!(point.data as any).isBest;
+                const isBest = data.kind === 'scored' && !!data.isBest;
+                const desc = data.description?.trim();
                 return (
                   <Box
                     sx={{
@@ -209,6 +498,7 @@ export default function JobsChartModal({
                       borderRadius: 'sm',
                       p: 1,
                       fontSize: 12,
+                      maxWidth: 320,
                     }}
                   >
                     <div>
@@ -218,9 +508,74 @@ export default function JobsChartModal({
                           best so far
                         </span>
                       )}
+                      {data.kind === 'discarded' && (
+                        <span
+                          style={{ color: DISCARD_POINT_STROKE, marginLeft: 6 }}
+                        >
+                          discarded
+                        </span>
+                      )}
+                      {data.kind === 'no_metric' && (
+                        <span
+                          style={{
+                            color: NO_METRIC_POINT_STROKE,
+                            marginLeft: 6,
+                          }}
+                        >
+                          no metric
+                        </span>
+                      )}
                     </div>
-                    <div>Score: {String(point.data.yFormatted)}</div>
-                    <div>{String(point.data.xFormatted)}</div>
+                    {data.kind === 'no_metric' ? (
+                      <div style={{ marginTop: 4, color: '#64748b' }}>
+                        {data.statusNote ?? 'No score for this metric'}
+                      </div>
+                    ) : (
+                      <>
+                        <div>
+                          {data.metricLabel ?? 'score'}:{' '}
+                          {String(point.data.yFormatted)}
+                        </div>
+                        {data.kind === 'discarded' && (
+                          <div
+                            style={{
+                              marginTop: 2,
+                              fontSize: 11,
+                              color: '#64748b',
+                            }}
+                          >
+                            Excluded from best-so-far line
+                          </div>
+                        )}
+                      </>
+                    )}
+                    <div style={{ marginTop: 4, opacity: 0.85 }}>
+                      {String(point.data.xFormatted)}
+                    </div>
+                    {desc ? (
+                      <Typography
+                        level="body-xs"
+                        sx={{
+                          mt: 0.75,
+                          whiteSpace: 'pre-wrap',
+                          wordBreak: 'break-word',
+                          color: 'text.secondary',
+                        }}
+                      >
+                        {desc}
+                      </Typography>
+                    ) : (
+                      <Typography
+                        level="body-xs"
+                        sx={{
+                          mt: 0.75,
+                          fontStyle: 'italic',
+                          color: 'text.tertiary',
+                        }}
+                      >
+                        No description
+                      </Typography>
+                    )}
                   </Box>
                 );
               }}
@@ -235,7 +590,7 @@ export default function JobsChartModal({
               }}
             >
               <Typography level="body-sm" sx={{ color: 'text.tertiary' }}>
-                No jobs with both a score and a date to plot
+                No jobs with a date to plot
               </Typography>
             </Box>
           )}

--- a/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
@@ -1,0 +1,161 @@
+import { useMemo } from 'react';
+import { Box, Modal, ModalClose, ModalDialog, Typography } from '@mui/joy';
+import { ResponsiveLine } from '@nivo/line';
+
+interface JobsChartModalProps {
+  open: boolean;
+  onClose: () => void;
+  jobs: any[];
+}
+
+interface ChartPoint {
+  x: Date;
+  y: number;
+  jobId: string;
+}
+
+function extractScore(job: any): number | null {
+  const raw = job?.job_data?.score;
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (raw && typeof raw === 'object') {
+    for (const value of Object.values(raw)) {
+      if (typeof value === 'number' && Number.isFinite(value)) return value;
+    }
+  }
+  return null;
+}
+
+function extractDate(job: any): Date | null {
+  const raw =
+    job?.created_at ??
+    job?.job_data?.start_time ??
+    job?.job_data?.end_time ??
+    null;
+  if (!raw) return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export default function JobsChartModal({
+  open,
+  onClose,
+  jobs,
+}: JobsChartModalProps) {
+  const points = useMemo<ChartPoint[]>(() => {
+    if (!Array.isArray(jobs)) return [];
+    return jobs
+      .map((job) => {
+        const score = extractScore(job);
+        const date = extractDate(job);
+        if (score === null || date === null) return null;
+        return { x: date, y: score, jobId: String(job?.id ?? '') };
+      })
+      .filter((p): p is ChartPoint => p !== null)
+      .sort((a, b) => a.x.getTime() - b.x.getTime());
+  }, [jobs]);
+
+  const chartData = useMemo(
+    () => [
+      {
+        id: 'jobs',
+        data: points.map((p) => ({ x: p.x, y: p.y, jobId: p.jobId })),
+      },
+    ],
+    [points],
+  );
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <ModalDialog sx={{ width: '90vw', maxWidth: '1200px', height: '85vh' }}>
+        <ModalClose />
+        <Typography level="title-lg" sx={{ mb: 1 }}>
+          Jobs Chart
+        </Typography>
+        <Typography level="body-sm" sx={{ mb: 2, color: 'text.tertiary' }}>
+          {points.length === 0
+            ? 'No jobs with a score and date to plot'
+            : `Score over time across ${points.length} job${points.length === 1 ? '' : 's'}`}
+        </Typography>
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            border: '1px solid',
+            borderColor: 'neutral.outlinedBorder',
+            borderRadius: 'sm',
+          }}
+        >
+          {points.length > 0 ? (
+            <ResponsiveLine
+              data={chartData}
+              margin={{ top: 24, right: 32, bottom: 64, left: 64 }}
+              xScale={{ type: 'time', precision: 'minute' }}
+              xFormat="time:%Y-%m-%d %H:%M"
+              yScale={{
+                type: 'linear',
+                min: 'auto',
+                max: 'auto',
+                stacked: false,
+              }}
+              axisBottom={{
+                format: '%b %d',
+                tickRotation: -30,
+                legend: 'Date',
+                legendOffset: 50,
+                legendPosition: 'middle',
+              }}
+              axisLeft={{
+                legend: 'Score',
+                legendOffset: -48,
+                legendPosition: 'middle',
+              }}
+              enableGridX={false}
+              enableGridY
+              colors={{ scheme: 'category10' }}
+              lineWidth={0}
+              pointSize={10}
+              pointBorderWidth={1}
+              pointBorderColor={{ from: 'serieColor' }}
+              useMesh
+              tooltip={({ point }) => {
+                const jobId = (point.data as any).jobId as string;
+                const shortId = jobId ? jobId.slice(0, 8) : '';
+                return (
+                  <Box
+                    sx={{
+                      bgcolor: 'background.surface',
+                      border: '1px solid',
+                      borderColor: 'neutral.outlinedBorder',
+                      borderRadius: 'sm',
+                      p: 1,
+                      fontSize: 12,
+                    }}
+                  >
+                    <div>
+                      <b>{shortId}</b>
+                    </div>
+                    <div>Score: {String(point.data.yFormatted)}</div>
+                    <div>{String(point.data.xFormatted)}</div>
+                  </Box>
+                );
+              }}
+            />
+          ) : (
+            <Box
+              sx={{
+                height: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Typography level="body-sm" sx={{ color: 'text.tertiary' }}>
+                No jobs with both a score and a date to plot
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      </ModalDialog>
+    </Modal>
+  );
+}

--- a/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
@@ -12,7 +12,12 @@ interface ChartPoint {
   x: Date;
   y: number;
   jobId: string;
+  isBest: boolean;
 }
+
+const BEST_COLOR = '#22c55e';
+const BEST_BORDER = '#15803d';
+const POINT_COLOR = '#3b82f6';
 
 function extractScore(job: any): number | null {
   const raw = job?.job_data?.score;
@@ -43,25 +48,93 @@ export default function JobsChartModal({
 }: JobsChartModalProps) {
   const points = useMemo<ChartPoint[]>(() => {
     if (!Array.isArray(jobs)) return [];
-    return jobs
+    const sorted = jobs
       .map((job) => {
         const score = extractScore(job);
         const date = extractDate(job);
         if (score === null || date === null) return null;
-        return { x: date, y: score, jobId: String(job?.id ?? '') };
+        return {
+          x: date,
+          y: score,
+          jobId: String(job?.id ?? ''),
+          isBest: false,
+        };
       })
       .filter((p): p is ChartPoint => p !== null)
       .sort((a, b) => a.x.getTime() - b.x.getTime());
+
+    let runningMax = -Infinity;
+    for (const p of sorted) {
+      if (p.y > runningMax) {
+        p.isBest = true;
+        runningMax = p.y;
+      }
+    }
+    return sorted;
   }, [jobs]);
 
-  const chartData = useMemo(
-    () => [
-      {
-        id: 'jobs',
-        data: points.map((p) => ({ x: p.x, y: p.y, jobId: p.jobId })),
-      },
-    ],
-    [points],
+  const chartData = useMemo(() => {
+    const allData = points.map((p) => ({
+      x: p.x,
+      y: p.y,
+      jobId: p.jobId,
+      isBest: p.isBest,
+    }));
+    const bestData = points
+      .filter((p) => p.isBest)
+      .map((p) => ({ x: p.x, y: p.y, jobId: p.jobId, isBest: true }));
+    return [
+      { id: 'jobs', data: allData },
+      { id: 'best', data: bestData },
+    ];
+  }, [points]);
+
+  // Custom layer: stepped line connecting the running-max points.
+  const BestStepLine = ({ series, xScale, yScale }: any) => {
+    const best = series.find((s: any) => s.id === 'best');
+    if (!best || best.data.length < 2) return null;
+    const pts = best.data.map((d: any) => ({
+      x: xScale(d.data.x),
+      y: yScale(d.data.y),
+    }));
+    let path = `M ${pts[0].x},${pts[0].y}`;
+    for (let i = 1; i < pts.length; i++) {
+      path += ` L ${pts[i].x},${pts[i - 1].y} L ${pts[i].x},${pts[i].y}`;
+    }
+    return (
+      <path
+        d={path}
+        stroke={BEST_COLOR}
+        strokeWidth={2}
+        fill="none"
+        strokeLinejoin="miter"
+      />
+    );
+  };
+
+  // Custom layer: render points ourselves so we can size/color
+  // best-so-far points differently from regular points.
+  const CustomPoints = ({ series, xScale, yScale }: any) => (
+    <g>
+      {series.flatMap((s: any) =>
+        s.id === 'jobs'
+          ? s.data.map((d: any, i: number) => {
+              const isBest = !!d.data.isBest;
+              return (
+                <circle
+                  key={`pt-${i}`}
+                  cx={xScale(d.data.x)}
+                  cy={yScale(d.data.y)}
+                  r={isBest ? 7 : 4}
+                  fill={isBest ? BEST_COLOR : POINT_COLOR}
+                  stroke={isBest ? BEST_BORDER : 'none'}
+                  strokeWidth={isBest ? 1.5 : 0}
+                />
+              );
+            })
+          : [],
+      )}
+    </g>
   );
 
   return (
@@ -74,7 +147,7 @@ export default function JobsChartModal({
         <Typography level="body-sm" sx={{ mb: 2, color: 'text.tertiary' }}>
           {points.length === 0
             ? 'No jobs with a score and date to plot'
-            : `Score over time across ${points.length} job${points.length === 1 ? '' : 's'}`}
+            : `Score over time across ${points.length} job${points.length === 1 ? '' : 's'} — green marks the best score so far`}
         </Typography>
         <Box
           sx={{
@@ -98,7 +171,7 @@ export default function JobsChartModal({
                 stacked: false,
               }}
               axisBottom={{
-                format: '%b %d',
+                format: '%b %d %H:%M',
                 tickRotation: -30,
                 legend: 'Date',
                 legendOffset: 50,
@@ -111,15 +184,22 @@ export default function JobsChartModal({
               }}
               enableGridX={false}
               enableGridY
-              colors={{ scheme: 'category10' }}
+              colors={[POINT_COLOR, BEST_COLOR]}
               lineWidth={0}
-              pointSize={10}
-              pointBorderWidth={1}
-              pointBorderColor={{ from: 'serieColor' }}
+              enablePoints={false}
+              layers={[
+                'grid',
+                'axes',
+                BestStepLine,
+                CustomPoints,
+                'mesh',
+                'crosshair',
+              ]}
               useMesh
               tooltip={({ point }) => {
                 const jobId = (point.data as any).jobId as string;
                 const shortId = jobId ? jobId.slice(0, 8) : '';
+                const isBest = !!(point.data as any).isBest;
                 return (
                   <Box
                     sx={{
@@ -133,6 +213,11 @@ export default function JobsChartModal({
                   >
                     <div>
                       <b>{shortId}</b>
+                      {isBest && (
+                        <span style={{ color: BEST_BORDER, marginLeft: 6 }}>
+                          best so far
+                        </span>
+                      )}
                     </div>
                     <div>Score: {String(point.data.yFormatted)}</div>
                     <div>{String(point.data.xFormatted)}</div>

--- a/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsChartModal.tsx
@@ -397,7 +397,7 @@ export default function JobsChartModal({
 
   const subtitle =
     points.length === 0
-      ? 'No jobs with a date to plot'
+      ? 'No jobs with a date + score to plot. Create jobs and record scores for them to appear here.'
       : [
           primaryMetric
             ? `Metric: ${primaryMetric} — green marks best so far (${lowerIsBetter ? 'lower' : 'higher'} is better)`
@@ -576,7 +576,7 @@ export default function JobsChartModal({
               }}
             >
               <Typography level="body-sm" sx={{ color: 'text.tertiary' }}>
-                No jobs with a date to plot
+                No jobs with a date + score to plot. Create jobs and record scores for them to appear here.
               </Typography>
             </Box>
           )}

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -10,7 +10,12 @@ import {
   Typography,
 } from '@mui/joy';
 
-import { PlusIcon, TerminalIcon, BookmarkIcon } from 'lucide-react';
+import {
+  PlusIcon,
+  TerminalIcon,
+  BookmarkIcon,
+  LineChartIcon,
+} from 'lucide-react';
 import { useSWRWithAuth as useSWR, useAPI } from 'renderer/lib/authContext';
 
 import * as chatAPI from 'renderer/lib/transformerlab-api-sdk';
@@ -39,6 +44,7 @@ import SafeJSONParse from '../../Shared/SafeJSONParse';
 import NewTaskModal2 from './NewTaskModal/NewTaskModal2';
 import TaskYamlEditorModal from './TaskYamlEditorModal';
 import TrackioModal from './TrackioModal';
+import JobsChartModal from './JobsChartModal';
 import {
   isDeletableJobRecordStatus,
   isJobStopPending,
@@ -91,6 +97,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
   const [compareEvalModalOpen, setCompareEvalModalOpen] = useState(false);
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const [showHidden, setShowHidden] = useState(false);
+  const [chartModalOpen, setChartModalOpen] = useState(false);
   const [viewTaskFilesFromTask, setViewTaskFilesFromTask] = useState<{
     id: string | null;
     name?: string | null;
@@ -1405,6 +1412,15 @@ export default function Tasks({ subtype }: { subtype?: string }) {
             )}
             <IconButton
               size="sm"
+              variant="outlined"
+              color="neutral"
+              onClick={() => setChartModalOpen(true)}
+              title="View jobs chart"
+            >
+              <LineChartIcon size={16} />
+            </IconButton>
+            <IconButton
+              size="sm"
               variant={showFavoritesOnly ? 'solid' : 'outlined'}
               color={showFavoritesOnly ? 'warning' : 'neutral'}
               onClick={() => setShowFavoritesOnly((prev) => !prev)}
@@ -1501,6 +1517,11 @@ export default function Tasks({ subtype }: { subtype?: string }) {
       <ViewSweepResultsModal
         jobId={viewSweepResultsFromJob}
         setJobId={(jobId: string | null) => setViewSweepResultsFromJob(jobId)}
+      />
+      <JobsChartModal
+        open={chartModalOpen}
+        onClose={() => setChartModalOpen(false)}
+        jobs={filteredJobsForDisplay}
       />
       {(() => {
         const outputJob = jobs?.find(


### PR DESCRIPTION
## Summary
- New `JobsChartModal` component that plots `job_data.score` against the job's `created_at` date
- Adds a `LineChartIcon` `IconButton` in the JobsPanel header (next to Select / Bookmark) to open the modal
- Renders with `@nivo/line` in scatter mode (`lineWidth: 0`), filtering to jobs with both a numeric score and a parseable date; shows an empty state otherwise

<img width="1214" height="980" alt="Screenshot 2026-05-04 at 12 45 49 PM" src="https://github.com/user-attachments/assets/38bcd178-9730-4717-9fa9-145e41578e0b" />

## Test plan
- [ ] Open an experiment with jobs that have `job_data.score` set (e.g. from 

eval/sweep runs)
- [ ] Click the chart icon next to the Select button in the Jobs panel header
- [ ] Verify dots appear at each job's score (Y) and `created_at` (X)
- [ ] Hover a dot — tooltip shows short job ID, score, and timestamp
- [ ] Open in an experiment with no scored jobs — verify empty state ("No jobs with both a score and a date to plot")