### PR TITLE
fix: wrap get_request_logs in asyncio.to_thread to prevent event loop hang

### DIFF
--- a/api/transformerlab/routers/experiment/jobs.py
+++ b/api/transformerlab/routers/experiment/jobs.py
@@ -569,7 +569,7 @@ async def get_request_logs(
         raise HTTPException(status_code=500, detail=f"Failed to instantiate provider: {exc}") from exc
 
     try:
-        logs_text = provider_instance.get_request_logs(request_id, tail_lines=tail_lines)
+        logs_text = await asyncio.to_thread(provider_instance.get_request_logs, request_id, tail_lines=tail_lines)
     except NotImplementedError:
         raise HTTPException(
             status_code=400, detail=f"Provider type '{provider_record.type}' does not support request logs"


### PR DESCRIPTION
## Summary

The \`/experiment/{id}/jobs/{job_id}/request_logs\` handler called \`provider_instance.get_request_logs(...)\` **synchronously** inside an async function. When the underlying SkyPilot SDK call hangs (which happens, for example, when a SkyPilot client/server version skew causes a stream response to never terminate), the entire FastAPI event loop is blocked. From outside this looks like the API has crashed: process is alive, port is bound, but no request — including \`/healthcheck\` — gets a response.

This is the same call pattern fixed elsewhere in the same file (\`get_job_logs\` at line 475, \`list_jobs\` at lines 433 and 690). All other long-running provider SDK calls in this router are already wrapped in \`asyncio.to_thread\`; \`get_request_logs\` was the outlier.

## Root cause

Discovered while debugging an autoresearch session: clicking the **"Fetch Request Logs"** button in the job UI (\`EmbeddableStreamingOutput.tsx:533\`) hung the API server within seconds. \`dev.py\` log showed startup completed normally, then went silent after the click. Process stayed alive at 0% CPU, port 8338 bound, but every HTTP request timed out — including \`curl /healthcheck\`. Hard kill + restart was the only recovery.

This does **not** address the underlying SkyPilot SDK behavior that causes the call to hang in the first place (likely needs a request-side timeout). It only ensures one bad request can no longer take down the entire server.

## Test plan

- [ ] Restart the API server after pulling.
- [ ] In the job UI, open a remote (skypilot) job and click **Fetch Request Logs**.
- [ ] Observe: even if the request itself hangs, other API endpoints (\`lab status\`, \`lab job list\`, the dashboard) remain responsive.
- [ ] Optionally run \`cd api && pytest\` — no test changes were made; the fix is structural and matches the pattern at \`jobs.py:475\`.