### PR TITLE
Fix cli transport errors and report correctly

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.45"
+version = "0.0.46"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/interactive.py
+++ b/cli/src/transformerlab_cli/commands/interactive.py
@@ -301,7 +301,7 @@ def _poll_until_ready(experiment_id: str, job_id: int, timeout: int) -> dict:
 
         try:
             # Check job status — only keep polling if in an active state
-            jobs_resp = api.get(jobs_url, timeout=10.0)
+            jobs_resp = api.get(jobs_url, timeout=10.0, reraise_transport=True)
             if jobs_resp.status_code == 200:
                 job = next((j for j in jobs_resp.json() if j.get("id") == job_id), None)
                 if job:
@@ -321,7 +321,7 @@ def _poll_until_ready(experiment_id: str, job_id: int, timeout: int) -> dict:
 
         # Stream new log lines to give the user feedback
         try:
-            logs_resp = api.get(logs_url, timeout=10.0)
+            logs_resp = api.get(logs_url, timeout=10.0, reraise_transport=True)
             if logs_resp.status_code == 200:
                 logs_data = logs_resp.json()
                 logs_text = logs_data.get("logs", "") if isinstance(logs_data, dict) else ""
@@ -337,7 +337,7 @@ def _poll_until_ready(experiment_id: str, job_id: int, timeout: int) -> dict:
             pass
 
         try:
-            response = api.get(tunnel_url, timeout=10.0)
+            response = api.get(tunnel_url, timeout=10.0, reraise_transport=True)
             if response.status_code == 200:
                 data = response.json()
                 if data.get("is_ready"):

--- a/cli/src/transformerlab_cli/commands/job_monitor/job_monitor.py
+++ b/cli/src/transformerlab_cli/commands/job_monitor/job_monitor.py
@@ -1,4 +1,5 @@
 from transformerlab_cli.commands.job_monitor.JobMonitorApp import JobMonitorApp
+from transformerlab_cli.util import api as api_mod
 from transformerlab_cli.util.config import load_config
 from transformerlab_cli.util.shared import set_base_url
 
@@ -6,8 +7,12 @@ from transformerlab_cli.util.shared import set_base_url
 def run_monitor() -> None:
     config = load_config()
     set_base_url(config.get("server"))
-    app = JobMonitorApp()
-    app.run()
+    api_mod.set_reraise_transport_errors(True)
+    try:
+        app = JobMonitorApp()
+        app.run()
+    finally:
+        api_mod.set_reraise_transport_errors(False)
 
 
 if __name__ == "__main__":

--- a/cli/src/transformerlab_cli/commands/task.py
+++ b/cli/src/transformerlab_cli/commands/task.py
@@ -475,6 +475,7 @@ def _validate_task_yaml_content(
             response = api.post_text(f"/experiment/{experiment_id}/task/validate", **post_kwargs)
     else:
         response = api.post_text(f"/experiment/{experiment_id}/task/validate", **post_kwargs)
+
     if response.status_code != 200:
         try:
             detail = response.json().get("detail", response.text)

--- a/cli/src/transformerlab_cli/util/api.py
+++ b/cli/src/transformerlab_cli/util/api.py
@@ -75,7 +75,7 @@ def _send(
     content: bytes | str | None = None,
     data=None,
     files=None,
-    json=None,
+    json_body=None,
     reraise_transport: bool | None = None,
 ) -> httpx.Response:
     url = f"{BASE_URL()}{path}"
@@ -96,7 +96,7 @@ def _send(
                 content=content,
                 data=data,
                 files=files,
-                json=json,
+                json=json_body,
             )
     except httpx.RequestError as e:
         _transport_failure(e, reraise=reraise)
@@ -178,7 +178,7 @@ def post_json(
     Returns:
         httpx.Response: The response object from the HTTP request.
     """
-    return _send("POST", path, timeout=timeout, json=json_data, reraise_transport=reraise_transport)
+    return _send("POST", path, timeout=timeout, json_body=json_data, reraise_transport=reraise_transport)
 
 
 def post_text(
@@ -261,7 +261,7 @@ def patch(
     Returns:
         httpx.Response: The response object from the HTTP request.
     """
-    return _send("PATCH", path, timeout=timeout, json=json_data, reraise_transport=reraise_transport)
+    return _send("PATCH", path, timeout=timeout, json_body=json_data, reraise_transport=reraise_transport)
 
 
 def delete(path: str, timeout: float = 10.0, reraise_transport: bool | None = None) -> httpx.Response:

--- a/cli/src/transformerlab_cli/util/api.py
+++ b/cli/src/transformerlab_cli/util/api.py
@@ -7,6 +7,20 @@ from transformerlab_cli.util.auth import api_key
 from transformerlab_cli.util.config import get_config
 from transformerlab_cli.util.ui import console
 
+_reraise_transport_errors: bool = False
+
+
+def set_reraise_transport_errors(enabled: bool) -> None:
+    """When True, HTTP transport errors propagate instead of exiting (job monitor TUI)."""
+    global _reraise_transport_errors
+    _reraise_transport_errors = enabled
+
+
+def _should_reraise_transport(reraise_transport: bool | None) -> bool:
+    if reraise_transport is not None:
+        return reraise_transport
+    return _reraise_transport_errors
+
 
 def _request_headers() -> dict:
     """Build request headers: Authorization and optional X-Team-Id from config."""
@@ -17,7 +31,83 @@ def _request_headers() -> dict:
     return headers
 
 
-def get(path: str, timeout: float = 10.0, follow_redirects: bool = True) -> httpx.Response:
+def describe_request_error(exc: httpx.RequestError) -> str:
+    """
+    Summarize transport-layer failures (no HTTP response) for CLI users.
+
+    Used when requests time out, connections are refused, DNS fails, etc.
+    """
+    try:
+        url = str(exc.request.url) if exc.request is not None else BASE_URL()
+    except Exception:
+        url = BASE_URL()
+
+    if isinstance(exc, httpx.TimeoutException):
+        return (
+            f"Request to {url} timed out. The API may be unreachable or slow, or a dependent backend service "
+            "(such as an AI model endpoint) may not be responding. If this command supports --timeout, try "
+            "increasing it."
+        )
+    return f"Could not complete request to {url}: {exc}"
+
+
+def _transport_failure(exc: httpx.RequestError, *, reraise: bool) -> None:
+    if reraise:
+        raise exc
+    from transformerlab_cli.state import cli_state
+
+    detail = describe_request_error(exc)
+    if cli_state.output_format == "json":
+        print(json.dumps({"error": "API request failed", "detail": detail}))
+    else:
+        console.print(f"[error]Error:[/error] {detail}")
+    raise typer.Exit(1)
+
+
+def _send(
+    method: str,
+    path: str,
+    *,
+    timeout: float | None,
+    follow_redirects: bool = True,
+    merged_request_headers: dict | None = None,
+    extra_headers: dict | None = None,
+    content: bytes | str | None = None,
+    data=None,
+    files=None,
+    json=None,
+    reraise_transport: bool | None = None,
+) -> httpx.Response:
+    url = f"{BASE_URL()}{path}"
+    if merged_request_headers is not None:
+        headers = dict(merged_request_headers)
+    else:
+        headers = _request_headers()
+    if extra_headers:
+        headers = {**headers, **extra_headers}
+    reraise = _should_reraise_transport(reraise_transport)
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            return client.request(
+                method=method,
+                url=url,
+                headers=headers,
+                follow_redirects=follow_redirects,
+                content=content,
+                data=data,
+                files=files,
+                json=json,
+            )
+    except httpx.RequestError as e:
+        _transport_failure(e, reraise=reraise)
+
+
+def get(
+    path: str,
+    timeout: float = 10.0,
+    follow_redirects: bool = True,
+    reraise_transport: bool | None = None,
+) -> httpx.Response:
     """
     Makes a GET HTTP request to the specified URL.
 
@@ -25,45 +115,57 @@ def get(path: str, timeout: float = 10.0, follow_redirects: bool = True) -> http
         path (str): The API path to send the request to.
         timeout (float): Request timeout in seconds. Default is 10.0.
         follow_redirects (bool): Whether to follow redirects. Default is True.
+        reraise_transport: If True, connection/timeout errors propagate. If None, use
+            set_reraise_transport_errors() (job monitor sets True for background workers).
 
     Returns:
         httpx.Response: The response object from the HTTP request.
     """
-    with httpx.Client(timeout=timeout) as client:
-        response = client.request(
-            method="GET",
-            url=f"{BASE_URL()}{path}",
-            headers=_request_headers(),
-            follow_redirects=follow_redirects,
-        )
-    return response
+    return _send(
+        "GET",
+        path,
+        timeout=timeout,
+        follow_redirects=follow_redirects,
+        reraise_transport=reraise_transport,
+    )
 
 
-def post(path: str, data: dict = None, files: dict = None, timeout: float = 60.0) -> httpx.Response:
+def post(
+    path: str,
+    data: dict = None,
+    files: dict = None,
+    timeout: float = 60.0,
+    reraise_transport: bool | None = None,
+) -> httpx.Response:
     """
     Makes a POST HTTP request to the specified URL with the given data and files.
 
     Args:
-        url (str): The URL to send the request to.
+        path (str): The API path to send the request to.
         data (dict, optional): The data to include in the POST request. Default is None.
         files (dict, optional): The files to include in the POST request. Default is None.
         timeout (float): Request timeout in seconds. Default is 60.0.
+        reraise_transport: See get().
 
     Returns:
         httpx.Response: The response object from the HTTP request.
     """
-    with httpx.Client(timeout=timeout) as client:
-        response = client.request(
-            method="POST",
-            url=f"{BASE_URL()}{path}",
-            headers=_request_headers(),
-            data=data,
-            files=files,
-        )
-    return response
+    return _send(
+        "POST",
+        path,
+        timeout=timeout,
+        data=data,
+        files=files,
+        reraise_transport=reraise_transport,
+    )
 
 
-def post_json(path: str, json_data: dict = None, timeout: float | None = 60.0) -> httpx.Response:
+def post_json(
+    path: str,
+    json_data: dict = None,
+    timeout: float | None = 60.0,
+    reraise_transport: bool | None = None,
+) -> httpx.Response:
     """
     Makes a POST HTTP request with JSON body.
 
@@ -71,21 +173,20 @@ def post_json(path: str, json_data: dict = None, timeout: float | None = 60.0) -
         path (str): The API path to send the request to.
         json_data (dict, optional): The JSON data to include in the POST request.
         timeout (float): Request timeout in seconds. Default is 60.0.
+        reraise_transport: See get().
 
     Returns:
         httpx.Response: The response object from the HTTP request.
     """
-    with httpx.Client(timeout=timeout) as client:
-        response = client.request(
-            method="POST",
-            url=f"{BASE_URL()}{path}",
-            headers=_request_headers(),
-            json=json_data,
-        )
-    return response
+    return _send("POST", path, timeout=timeout, json=json_data, reraise_transport=reraise_transport)
 
 
-def post_text(path: str, text: str, timeout: float = 60.0) -> httpx.Response:
+def post_text(
+    path: str,
+    text: str,
+    timeout: float = 60.0,
+    reraise_transport: bool | None = None,
+) -> httpx.Response:
     """
     Makes a POST HTTP request with a plain-text body.
 
@@ -93,20 +194,20 @@ def post_text(path: str, text: str, timeout: float = 60.0) -> httpx.Response:
         path (str): The API path to send the request to.
         text (str): The text content to include in the POST request body.
         timeout (float): Request timeout in seconds. Default is 60.0.
+        reraise_transport: See get().
 
     Returns:
         httpx.Response: The response object from the HTTP request.
     """
-    headers = _request_headers()
-    headers["Content-Type"] = "text/plain"
-    with httpx.Client(timeout=timeout) as client:
-        response = client.request(
-            method="POST",
-            url=f"{BASE_URL()}{path}",
-            headers=headers,
-            content=text,
-        )
-    return response
+    extra = {"Content-Type": "text/plain"}
+    return _send(
+        "POST",
+        path,
+        timeout=timeout,
+        content=text,
+        extra_headers=extra,
+        reraise_transport=reraise_transport,
+    )
 
 
 def put(
@@ -114,6 +215,7 @@ def put(
     content: bytes = None,
     headers: dict = None,
     timeout: float = 300.0,
+    reraise_transport: bool | None = None,
 ) -> httpx.Response:
     """
     Makes a PUT HTTP request with raw bytes body.
@@ -123,24 +225,30 @@ def put(
         content (bytes, optional): Raw bytes to send as the request body.
         headers (dict, optional): Additional headers to merge into the request.
         timeout (float): Request timeout in seconds. Default is 300.0.
+        reraise_transport: See get().
 
     Returns:
         httpx.Response: The response object from the HTTP request.
     """
-    merged_headers = _request_headers()
+    merged = _request_headers()
     if headers:
-        merged_headers.update(headers)
-    with httpx.Client(timeout=timeout) as client:
-        response = client.request(
-            method="PUT",
-            url=f"{BASE_URL()}{path}",
-            headers=merged_headers,
-            content=content,
-        )
-    return response
+        merged = {**merged, **headers}
+    return _send(
+        "PUT",
+        path,
+        timeout=timeout,
+        merged_request_headers=merged,
+        content=content,
+        reraise_transport=reraise_transport,
+    )
 
 
-def patch(path: str, json_data: dict = None, timeout: float = 60.0) -> httpx.Response:
+def patch(
+    path: str,
+    json_data: dict = None,
+    timeout: float = 60.0,
+    reraise_transport: bool | None = None,
+) -> httpx.Response:
     """
     Makes a PATCH HTTP request with JSON body.
 
@@ -148,38 +256,27 @@ def patch(path: str, json_data: dict = None, timeout: float = 60.0) -> httpx.Res
         path (str): The API path to send the request to.
         json_data (dict, optional): The JSON data to include in the PATCH request.
         timeout (float): Request timeout in seconds. Default is 60.0.
+        reraise_transport: See get().
 
     Returns:
         httpx.Response: The response object from the HTTP request.
     """
-    with httpx.Client(timeout=timeout) as client:
-        response = client.request(
-            method="PATCH",
-            url=f"{BASE_URL()}{path}",
-            headers=_request_headers(),
-            json=json_data,
-        )
-    return response
+    return _send("PATCH", path, timeout=timeout, json=json_data, reraise_transport=reraise_transport)
 
 
-def delete(path: str, timeout: float = 10.0) -> httpx.Response:
+def delete(path: str, timeout: float = 10.0, reraise_transport: bool | None = None) -> httpx.Response:
     """
     Makes a DELETE HTTP request.
 
     Args:
         path (str): The API path to send the request to.
         timeout (float): Request timeout in seconds. Default is 10.0.
+        reraise_transport: See get().
 
     Returns:
         httpx.Response: The response object from the HTTP request.
     """
-    with httpx.Client(timeout=timeout) as client:
-        response = client.request(
-            method="DELETE",
-            url=f"{BASE_URL()}{path}",
-            headers=_request_headers(),
-        )
-    return response
+    return _send("DELETE", path, timeout=timeout, reraise_transport=reraise_transport)
 
 
 def check_server_status():

--- a/cli/tests/commands/test_task.py
+++ b/cli/tests/commands/test_task.py
@@ -2,12 +2,30 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 from typer.testing import CliRunner
 from transformerlab_cli.commands.task import build_launch_payload
 from transformerlab_cli.main import app
 from tests.helpers import strip_ansi
 
 runner = CliRunner()
+
+
+def _cli_output(result) -> str:
+    """Typer/Rich may write to stdout and/or stderr; combine for assertions."""
+    return strip_ansi((result.stdout or "") + (result.stderr or ""))
+
+
+def _patch_api_httpx_read_timeout():
+    """Force transport timeout inside transformerlab_cli.util.api (not task.api.post_text)."""
+    req = httpx.Request("POST", "http://lab.example/experiment/exp1/task/validate")
+    exc = httpx.ReadTimeout("timed out", request=req)
+    mock_client_instance = MagicMock()
+    mock_client_instance.request.side_effect = exc
+    mock_cm = MagicMock()
+    mock_cm.__enter__ = MagicMock(return_value=mock_client_instance)
+    mock_cm.__exit__ = MagicMock(return_value=None)
+    return patch("transformerlab_cli.util.api.httpx.Client", return_value=mock_cm)
 
 
 SAMPLE_TASKS = [
@@ -301,6 +319,35 @@ def test_task_upload_calls_upload_endpoint(_mock_exp, mock_post_json, _mock_get,
     assert result.exit_code == 0, result.output
     submit_path = mock_post_json.call_args_list[-1].args[0]
     assert submit_path == "/experiment/exp1/task/t1/upload?upload_id=up-1"
+
+
+@patch("transformerlab_cli.commands.task.require_current_experiment", return_value="exp1")
+def test_task_validate_friendly_message_on_timeout(_mock_exp):
+    """Validation timeouts show a clear message instead of a traceback."""
+    with _patch_api_httpx_read_timeout():
+        with runner.isolated_filesystem():
+            task_yaml = Path("task.yaml")
+            task_yaml.write_text("name: demo\nrun: echo hello\n", encoding="utf-8")
+            result = runner.invoke(app, ["task", "validate"])
+    assert result.exit_code == 1, _cli_output(result)
+    out = _cli_output(result)
+    assert "timed out" in out.lower()
+    assert "api may be unreachable" in out.lower()
+
+
+@patch("transformerlab_cli.commands.task.require_current_experiment", return_value="exp1")
+def test_task_validate_json_on_timeout(_mock_exp):
+    """JSON output includes structured error on transport failure."""
+    with _patch_api_httpx_read_timeout():
+        with runner.isolated_filesystem():
+            task_yaml = Path("task.yaml")
+            task_yaml.write_text("name: demo\nrun: echo hello\n", encoding="utf-8")
+            result = runner.invoke(app, ["--format", "json", "task", "validate"])
+    assert result.exit_code == 1, _cli_output(result)
+    combined = (result.stdout or "") + (result.stderr or "")
+    payload = json.loads(combined.strip())
+    assert payload["error"] == "API request failed"
+    assert "timed out" in payload["detail"].lower()
 
 
 @patch("transformerlab_cli.commands.task.api.post_text", return_value=_mock_resp({"valid": True}))

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.45"
+version = "0.0.46"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Now any time there's a transport error, we show it correctly:

```
╰ lab --format json job list
{"error": "API request failed", "detail": "Could not complete request to http://localhost:8338/experiment/gamma/jobs/list?type=REMOTE: [Errno 61] Connection refused"}
```