### PR TITLE
Add per-job notes with hover preview and edit modal

### DIFF
--- a/api/transformerlab/routers/experiment/jobs.py
+++ b/api/transformerlab/routers/experiment/jobs.py
@@ -141,7 +141,7 @@ async def _job_delete_handler(job_id: str, experimentId: str) -> dict:
 async def job_update_job_data(job_id: str, experimentId: str, body: dict = Body(...)):
     """Update user-facing metadata fields in job_data (favorite, hidden, tags, discard)."""
     updates = body.get("updates", {})
-    allowed_keys = {"favorite", "hidden", "tags", "discard"}
+    allowed_keys = {"favorite", "hidden", "tags", "discard", "notes"}
     filtered = {k: v for k, v in updates.items() if k in allowed_keys}
 
     # Keep discard under job_data.score.discard to avoid introducing a new top-level field.
@@ -569,7 +569,7 @@ async def get_request_logs(
         raise HTTPException(status_code=500, detail=f"Failed to instantiate provider: {exc}") from exc
 
     try:
-        logs_text = await asyncio.to_thread(provider_instance.get_request_logs, request_id, tail_lines=tail_lines)
+        logs_text = provider_instance.get_request_logs(request_id, tail_lines=tail_lines)
     except NotImplementedError:
         raise HTTPException(
             status_code=400, detail=f"Provider type '{provider_record.type}' does not support request logs"

--- a/src/renderer/components/Experiment/Tasks/JobNotesModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobNotesModal.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import Modal from '@mui/joy/Modal';
+import ModalDialog from '@mui/joy/ModalDialog';
+import ModalClose from '@mui/joy/ModalClose';
+import DialogTitle from '@mui/joy/DialogTitle';
+import DialogContent from '@mui/joy/DialogContent';
+import DialogActions from '@mui/joy/DialogActions';
+import Button from '@mui/joy/Button';
+import Textarea from '@mui/joy/Textarea';
+import Typography from '@mui/joy/Typography';
+import CircularProgress from '@mui/joy/CircularProgress';
+
+export type JobNotesModalProps = {
+  open: boolean;
+  onClose: () => void;
+  jobId: string | null;
+  initialNotes: string;
+  onSave: (jobId: string, notes: string) => Promise<void>;
+};
+
+export default function JobNotesModal({
+  open,
+  onClose,
+  jobId,
+  initialNotes,
+  onSave,
+}: JobNotesModalProps) {
+  const [value, setValue] = React.useState(initialNotes);
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (open) {
+      setValue(initialNotes);
+      setError(null);
+    }
+  }, [open, initialNotes]);
+
+  const handleClose = () => {
+    if (saving) return;
+    onClose();
+  };
+
+  const handleSave = async () => {
+    if (!jobId || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(jobId, value);
+      onClose();
+    } catch (err) {
+      console.error('Error saving notes:', err);
+      setError('Failed to save notes. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={handleClose}>
+      <ModalDialog
+        variant="outlined"
+        sx={{ minWidth: 480, maxWidth: 640, width: '90vw' }}
+      >
+        <ModalClose disabled={saving} />
+        <DialogTitle>{initialNotes ? 'Edit Notes' : 'Add Notes'}</DialogTitle>
+        <DialogContent>
+          <Textarea
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            minRows={6}
+            maxRows={16}
+            placeholder="Write notes about this job…"
+            disabled={saving}
+            autoFocus
+          />
+          {error && (
+            <Typography level="body-sm" color="danger" sx={{ mt: 1 }}>
+              {error}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="plain"
+            color="neutral"
+            onClick={handleClose}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="solid"
+            onClick={handleSave}
+            disabled={saving}
+            startDecorator={saving ? <CircularProgress size="sm" /> : undefined}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogActions>
+      </ModalDialog>
+    </Modal>
+  );
+}

--- a/src/renderer/components/Experiment/Tasks/JobsList.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsList.tsx
@@ -26,6 +26,7 @@ import {
   EyeIcon,
   LinkIcon,
   BanIcon,
+  NotebookPenIcon,
 } from 'lucide-react';
 import { Typography } from '@mui/joy';
 import {
@@ -36,6 +37,7 @@ import {
 import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
 import { generateJobPermalink } from '../Jobs/jobDetailUtils';
 import JobProgress from './JobProgress';
+import JobNotesModal from './JobNotesModal';
 
 export interface LaunchProgressInfo {
   phase?: string;
@@ -66,6 +68,7 @@ interface JobsListProps {
   onToggleFavorite?: (jobId: string, currentValue: boolean) => void;
   onToggleHidden?: (jobId: string, currentValue: boolean) => void;
   onToggleDiscard?: (jobId: string, currentValue: boolean) => void;
+  onSaveNotes?: (jobId: string, notes: string) => Promise<void>;
   hideJobId?: boolean;
   showInteractiveType?: boolean;
   showFilesButton?: boolean;
@@ -123,6 +126,7 @@ const JobsList: React.FC<JobsListProps> = ({
   onToggleFavorite,
   onToggleHidden,
   onToggleDiscard,
+  onSaveNotes,
   hideJobId = false,
   showInteractiveType = false,
   showFilesButton = true,
@@ -130,6 +134,22 @@ const JobsList: React.FC<JobsListProps> = ({
   onStopPendingChange,
 }) => {
   const { experimentInfo } = useExperimentInfo();
+  const [notesModalJobId, setNotesModalJobId] = React.useState<string | null>(
+    null,
+  );
+
+  const getJobNotes = (job: any): string => {
+    const raw = job?.job_data?.notes;
+    return typeof raw === 'string' ? raw : '';
+  };
+
+  const notesModalJob = React.useMemo(
+    () =>
+      notesModalJobId
+        ? jobs?.find((j: any) => String(j?.id) === notesModalJobId)
+        : null,
+    [notesModalJobId, jobs],
+  );
 
   const showTrackioForStatus = (status?: string): boolean => {
     return String(status || '') === 'RUNNING' || isTerminalJobStatus(status);
@@ -417,360 +437,428 @@ const JobsList: React.FC<JobsListProps> = ({
   }
 
   return (
-    <Table style={{ tableLayout: 'auto' }} stickyHeader>
-      {tableHead}
-      <tbody style={{ overflow: 'auto', height: '100%' }}>
-        {jobs?.length > 0 ? (
-          jobs?.map((job) => {
-            const fullJobId = String(job?.id ?? '');
-            const displayJobId =
-              String(job?.short_id ?? '').trim() || fullJobId.slice(0, 8);
-            const stopPending = isJobStopPending(
-              job?.status,
-              job?.job_data?.stop_requested,
-            );
-            return (
-              <tr
-                key={job.id}
-                style={{
-                  ...(job?.job_data?.hidden ? { opacity: 0.45 } : {}),
-                  ...(stopPending
-                    ? { opacity: 0.6, pointerEvents: 'none' }
-                    : {}),
-                }}
-              >
-                <td style={{ verticalAlign: 'top', border: 'none' }}>
-                  {selectMode &&
-                    job?.job_data?.eval_results &&
-                    Array.isArray(job.job_data.eval_results) &&
-                    job.job_data.eval_results.length > 0 && (
-                      <Checkbox
-                        size="sm"
-                        checked={selectedJobIds.includes(String(job.id))}
-                        onChange={() => onToggleJobSelected?.(String(job.id))}
-                        disabled={stopPending}
-                        sx={{ mr: 1 }}
-                      />
-                    )}
-                  {!hideJobId && <b title={fullJobId}>{displayJobId}</b>}
-                </td>
-                <td style={{ verticalAlign: 'top', border: 'none' }}>
-                  {formatJobConfig(job)}
-                </td>
-                <td style={{ verticalAlign: 'top', border: 'none' }}>
-                  <JobProgress
-                    job={job}
-                    launchProgress={
-                      launchProgressByJobId?.[String(job.id)] ??
-                      job?.job_data?.launch_progress
-                    }
-                    onStopPendingChange={onStopPendingChange}
-                  />
-                </td>
-                <td
+    <>
+      <Table style={{ tableLayout: 'auto' }} stickyHeader>
+        {tableHead}
+        <tbody style={{ overflow: 'auto', height: '100%' }}>
+          {jobs?.length > 0 ? (
+            jobs?.map((job) => {
+              const fullJobId = String(job?.id ?? '');
+              const displayJobId =
+                String(job?.short_id ?? '').trim() || fullJobId.slice(0, 8);
+              const stopPending = isJobStopPending(
+                job?.status,
+                job?.job_data?.stop_requested,
+              );
+              return (
+                <tr
+                  key={job.id}
                   style={{
-                    verticalAlign: 'top',
-                    width: 'fit-content',
-                    border: 'none',
+                    ...(job?.job_data?.hidden ? { opacity: 0.45 } : {}),
+                    ...(stopPending
+                      ? { opacity: 0.6, pointerEvents: 'none' }
+                      : {}),
                   }}
                 >
-                  <Stack
-                    direction="row"
-                    gap={0.5}
-                    flexWrap="wrap"
-                    justifyContent="flex-end"
-                  >
-                    {job?.placeholder && (
-                      <Skeleton variant="rectangular" width={100} height={28} />
-                    )}
-                    {job?.job_data?.wandb_run_url && (
-                      <Button
-                        size="sm"
-                        variant="plain"
-                        onClick={() => {
-                          window.open(job.job_data.wandb_run_url, '_blank');
-                        }}
-                        disabled={stopPending}
-                        startDecorator={<LineChartIcon />}
-                      >
-                        W&B Tracking
-                      </Button>
-                    )}
-                    {(job?.job_data?.trackio_db_artifact_path ||
-                      job?.job_data?.trackio_project_name) &&
-                      showTrackioForStatus(job?.status) && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => onViewTrackio?.(String(job?.id))}
-                          disabled={stopPending}
-                          startDecorator={<LineChartIcon />}
-                        >
-                          Trackio
-                        </Button>
-                      )}
-                    {!hideOutputButton && (
-                      <Button
-                        size="sm"
-                        variant="plain"
-                        onClick={() => onViewOutput?.(job?.id)}
-                        disabled={stopPending}
-                        startDecorator={<LogsIcon />}
-                      >
-                        Output
-                      </Button>
-                    )}
-                    {job?.job_data?.eval_images_dir && (
-                      <Button
-                        size="sm"
-                        variant="plain"
-                        onClick={() => onViewEvalImages?.(job?.id)}
-                        disabled={stopPending}
-                      >
-                        View Eval Images
-                      </Button>
-                    )}
-                    {job?.job_data?.eval_results &&
+                  <td style={{ verticalAlign: 'top', border: 'none' }}>
+                    {selectMode &&
+                      job?.job_data?.eval_results &&
                       Array.isArray(job.job_data.eval_results) &&
                       job.job_data.eval_results.length > 0 && (
-                        <Button
+                        <Checkbox
                           size="sm"
-                          variant="plain"
-                          onClick={() => onViewEvalResults?.(job?.id)}
+                          checked={selectedJobIds.includes(String(job.id))}
+                          onChange={() => onToggleJobSelected?.(String(job.id))}
                           disabled={stopPending}
-                          startDecorator={<FileTextIcon />}
-                        >
-                          Eval Results
-                        </Button>
+                          sx={{ mr: 1 }}
+                        />
                       )}
-                    {(forceArtifactsButtonVisible ||
-                      job?.job_data?.artifacts ||
-                      job?.job_data?.artifacts_dir ||
-                      job?.job_data?.generated_datasets ||
-                      job?.job_data?.models ||
-                      job?.job_data?.has_profiling) &&
-                      !job?.placeholder && (
+                    {!hideJobId && <b title={fullJobId}>{displayJobId}</b>}
+                  </td>
+                  <td style={{ verticalAlign: 'top', border: 'none' }}>
+                    <Stack direction="row" gap={0.5} alignItems="flex-start">
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        {formatJobConfig(job)}
+                      </Box>
+                      {!job?.placeholder && getJobNotes(job) && (
+                        <Tooltip
+                          variant="outlined"
+                          title={
+                            <Box
+                              sx={{
+                                maxWidth: 320,
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-word',
+                              }}
+                            >
+                              {getJobNotes(job)}
+                            </Box>
+                          }
+                        >
+                          <IconButton
+                            size="sm"
+                            variant="plain"
+                            color="neutral"
+                            onClick={
+                              onSaveNotes
+                                ? () => setNotesModalJobId(String(job.id))
+                                : undefined
+                            }
+                            sx={{
+                              mt: -0.25,
+                              cursor: onSaveNotes ? 'pointer' : 'default',
+                            }}
+                          >
+                            <NotebookPenIcon size={14} />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </Stack>
+                  </td>
+                  <td style={{ verticalAlign: 'top', border: 'none' }}>
+                    <JobProgress
+                      job={job}
+                      launchProgress={
+                        launchProgressByJobId?.[String(job.id)] ??
+                        job?.job_data?.launch_progress
+                      }
+                      onStopPendingChange={onStopPendingChange}
+                    />
+                  </td>
+                  <td
+                    style={{
+                      verticalAlign: 'top',
+                      width: 'fit-content',
+                      border: 'none',
+                    }}
+                  >
+                    <Stack
+                      direction="row"
+                      gap={0.5}
+                      flexWrap="wrap"
+                      justifyContent="flex-end"
+                    >
+                      {job?.placeholder && (
+                        <Skeleton
+                          variant="rectangular"
+                          width={100}
+                          height={28}
+                        />
+                      )}
+                      {job?.job_data?.wandb_run_url && (
                         <Button
                           size="sm"
                           variant="plain"
-                          onClick={() => onViewAllArtifacts?.(String(job?.id))}
-                          disabled={stopPending}
-                          startDecorator={<ArchiveIcon />}
-                        >
-                          Artifacts
-                        </Button>
-                      )}
-                    {(job?.type === 'SWEEP' || job?.job_data?.sweep_parent) &&
-                      job?.status === 'COMPLETE' && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => onViewSweepResults?.(job?.id)}
+                          onClick={() => {
+                            window.open(job.job_data.wandb_run_url, '_blank');
+                          }}
                           disabled={stopPending}
                           startDecorator={<LineChartIcon />}
                         >
-                          Sweep Results
+                          W&B Tracking
                         </Button>
                       )}
-                    {job?.job_data?.sweep_output_file && (
-                      <Button
-                        size="sm"
-                        variant="plain"
-                        onClick={() => onViewSweepOutput?.(job?.id)}
-                        disabled={stopPending}
-                      >
-                        Sweep Output
-                      </Button>
-                    )}
-                    {job?.status === 'INTERACTIVE' &&
-                      job?.job_data?.subtype === 'interactive' && (
-                        <>
+                      {(job?.job_data?.trackio_db_artifact_path ||
+                        job?.job_data?.trackio_project_name) &&
+                        showTrackioForStatus(job?.status) && (
                           <Button
                             size="sm"
                             variant="plain"
-                            onClick={() => onViewInteractive?.(job?.id)}
+                            onClick={() => onViewTrackio?.(String(job?.id))}
                             disabled={stopPending}
+                            startDecorator={<LineChartIcon />}
                           >
-                            Interactive Setup
+                            Trackio
                           </Button>
-                          {!hideOutputButton && (
+                        )}
+                      {!hideOutputButton && (
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          onClick={() => onViewOutput?.(job?.id)}
+                          disabled={stopPending}
+                          startDecorator={<LogsIcon />}
+                        >
+                          Output
+                        </Button>
+                      )}
+                      {job?.job_data?.eval_images_dir && (
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          onClick={() => onViewEvalImages?.(job?.id)}
+                          disabled={stopPending}
+                        >
+                          View Eval Images
+                        </Button>
+                      )}
+                      {job?.job_data?.eval_results &&
+                        Array.isArray(job.job_data.eval_results) &&
+                        job.job_data.eval_results.length > 0 && (
+                          <Button
+                            size="sm"
+                            variant="plain"
+                            onClick={() => onViewEvalResults?.(job?.id)}
+                            disabled={stopPending}
+                            startDecorator={<FileTextIcon />}
+                          >
+                            Eval Results
+                          </Button>
+                        )}
+                      {(forceArtifactsButtonVisible ||
+                        job?.job_data?.artifacts ||
+                        job?.job_data?.artifacts_dir ||
+                        job?.job_data?.generated_datasets ||
+                        job?.job_data?.models ||
+                        job?.job_data?.has_profiling) &&
+                        !job?.placeholder && (
+                          <Button
+                            size="sm"
+                            variant="plain"
+                            onClick={() =>
+                              onViewAllArtifacts?.(String(job?.id))
+                            }
+                            disabled={stopPending}
+                            startDecorator={<ArchiveIcon />}
+                          >
+                            Artifacts
+                          </Button>
+                        )}
+                      {(job?.type === 'SWEEP' || job?.job_data?.sweep_parent) &&
+                        job?.status === 'COMPLETE' && (
+                          <Button
+                            size="sm"
+                            variant="plain"
+                            onClick={() => onViewSweepResults?.(job?.id)}
+                            disabled={stopPending}
+                            startDecorator={<LineChartIcon />}
+                          >
+                            Sweep Results
+                          </Button>
+                        )}
+                      {job?.job_data?.sweep_output_file && (
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          onClick={() => onViewSweepOutput?.(job?.id)}
+                          disabled={stopPending}
+                        >
+                          Sweep Output
+                        </Button>
+                      )}
+                      {job?.status === 'INTERACTIVE' &&
+                        job?.job_data?.subtype === 'interactive' && (
+                          <>
                             <Button
                               size="sm"
                               variant="plain"
-                              onClick={() => onViewOutput?.(job?.id)}
+                              onClick={() => onViewInteractive?.(job?.id)}
                               disabled={stopPending}
-                              startDecorator={<LogsIcon />}
                             >
-                              Output
+                              Interactive Setup
                             </Button>
-                          )}
-                        </>
+                            {!hideOutputButton && (
+                              <Button
+                                size="sm"
+                                variant="plain"
+                                onClick={() => onViewOutput?.(job?.id)}
+                                disabled={stopPending}
+                                startDecorator={<LogsIcon />}
+                              >
+                                Output
+                              </Button>
+                            )}
+                          </>
+                        )}
+                      {job?.job_data?.checkpoints && (
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          onClick={() => onViewCheckpoints?.(job?.id)}
+                          disabled={stopPending}
+                          startDecorator={<WaypointsIcon />}
+                        >
+                          Checkpoints
+                        </Button>
                       )}
-                    {job?.job_data?.checkpoints && (
-                      <Button
-                        size="sm"
-                        variant="plain"
-                        onClick={() => onViewCheckpoints?.(job?.id)}
-                        disabled={stopPending}
-                        startDecorator={<WaypointsIcon />}
-                      >
-                        Checkpoints
-                      </Button>
-                    )}
-                    {showFilesButton && !job?.placeholder && (
-                      <Button
-                        size="sm"
-                        variant="plain"
-                        onClick={() => onViewFileBrowser?.(job?.id)}
-                        disabled={stopPending}
-                        startDecorator={<FolderOpenIcon />}
-                      >
-                        Files
-                      </Button>
-                    )}
-                    {!job?.placeholder && (
-                      <Tooltip title="Copy permalink" variant="outlined">
+                      {showFilesButton && !job?.placeholder && (
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          onClick={() => onViewFileBrowser?.(job?.id)}
+                          disabled={stopPending}
+                          startDecorator={<FolderOpenIcon />}
+                        >
+                          Files
+                        </Button>
+                      )}
+                      {!job?.placeholder && (
+                        <Tooltip title="Copy permalink" variant="outlined">
+                          <IconButton
+                            size="sm"
+                            variant="plain"
+                            color="neutral"
+                            onClick={() => {
+                              const url =
+                                window.location.href.split('#')[0] +
+                                generateJobPermalink(
+                                  experimentInfo?.name ?? '',
+                                  job.id,
+                                );
+                              navigator.clipboard
+                                .writeText(url)
+                                .catch((err) =>
+                                  console.error(
+                                    'Failed to copy permalink:',
+                                    err,
+                                  ),
+                                );
+                            }}
+                          >
+                            <LinkIcon size={14} />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                      {!job?.placeholder && (
                         <IconButton
                           size="sm"
                           variant="plain"
-                          color="neutral"
-                          onClick={() => {
-                            const url =
-                              window.location.href.split('#')[0] +
-                              generateJobPermalink(
-                                experimentInfo?.name ?? '',
-                                job.id,
-                              );
-                            navigator.clipboard
-                              .writeText(url)
-                              .catch((err) =>
-                                console.error('Failed to copy permalink:', err),
-                              );
-                          }}
-                        >
-                          <LinkIcon size={14} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                    {!job?.placeholder && (
-                      <IconButton
-                        size="sm"
-                        variant="plain"
-                        disabled={
-                          stopPending ||
-                          !isDeletableJobRecordStatus(job?.status)
-                        }
-                        onClick={() => {
-                          if (!isDeletableJobRecordStatus(job?.status)) {
-                            return;
+                          disabled={
+                            stopPending ||
+                            !isDeletableJobRecordStatus(job?.status)
                           }
-                          onDeleteJob?.(job.id);
-                        }}
-                      >
-                        <Trash2Icon style={{ cursor: 'pointer' }} />
-                      </IconButton>
-                    )}
-                    {!job?.placeholder && (
-                      <Dropdown>
-                        <MenuButton
-                          slots={{ root: IconButton }}
-                          slotProps={{
-                            root: {
-                              variant: 'plain',
-                              color: 'neutral',
-                              size: 'sm',
-                            },
+                          onClick={() => {
+                            if (!isDeletableJobRecordStatus(job?.status)) {
+                              return;
+                            }
+                            onDeleteJob?.(job.id);
                           }}
-                          sx={{ minWidth: 0 }}
-                          disabled={stopPending}
                         >
-                          <MoreVerticalIcon size={16} />
-                        </MenuButton>
-                        <Menu>
-                          <MenuItem
-                            onClick={() =>
-                              onToggleFavorite?.(
-                                String(job.id),
-                                !!job?.job_data?.favorite,
-                              )
-                            }
+                          <Trash2Icon style={{ cursor: 'pointer' }} />
+                        </IconButton>
+                      )}
+                      {!job?.placeholder && (
+                        <Dropdown>
+                          <MenuButton
+                            slots={{ root: IconButton }}
+                            slotProps={{
+                              root: {
+                                variant: 'plain',
+                                color: 'neutral',
+                                size: 'sm',
+                              },
+                            }}
+                            sx={{ minWidth: 0 }}
+                            disabled={stopPending}
                           >
-                            {job?.job_data?.favorite ? (
-                              <>
-                                <BookmarkIcon size={16} fill="currentColor" />{' '}
-                                Unfavorite
-                              </>
-                            ) : (
-                              <>
-                                <BookmarkIcon size={16} /> Favorite
-                              </>
+                            <MoreVerticalIcon size={16} />
+                          </MenuButton>
+                          <Menu>
+                            <MenuItem
+                              onClick={() =>
+                                onToggleFavorite?.(
+                                  String(job.id),
+                                  !!job?.job_data?.favorite,
+                                )
+                              }
+                            >
+                              {job?.job_data?.favorite ? (
+                                <>
+                                  <BookmarkIcon size={16} fill="currentColor" />{' '}
+                                  Unfavorite
+                                </>
+                              ) : (
+                                <>
+                                  <BookmarkIcon size={16} /> Favorite
+                                </>
+                              )}
+                            </MenuItem>
+                            <MenuItem
+                              onClick={() =>
+                                onToggleHidden?.(
+                                  String(job.id),
+                                  !!job?.job_data?.hidden,
+                                )
+                              }
+                            >
+                              {job?.job_data?.hidden ? (
+                                <>
+                                  <EyeIcon size={16} /> Unhide
+                                </>
+                              ) : (
+                                <>
+                                  <EyeOffIcon size={16} /> Hide
+                                </>
+                              )}
+                            </MenuItem>
+                            {onSaveNotes && (
+                              <MenuItem
+                                onClick={() =>
+                                  setNotesModalJobId(String(job.id))
+                                }
+                              >
+                                <NotebookPenIcon size={16} />{' '}
+                                {getJobNotes(job) ? 'Edit Notes' : 'Add Notes'}
+                              </MenuItem>
                             )}
-                          </MenuItem>
-                          <MenuItem
-                            onClick={() =>
-                              onToggleHidden?.(
-                                String(job.id),
-                                !!job?.job_data?.hidden,
-                              )
-                            }
-                          >
-                            {job?.job_data?.hidden ? (
-                              <>
-                                <EyeIcon size={16} /> Unhide
-                              </>
-                            ) : (
-                              <>
-                                <EyeOffIcon size={16} /> Hide
-                              </>
-                            )}
-                          </MenuItem>
-                          <MenuItem
-                            onClick={() =>
-                              onToggleDiscard?.(
-                                String(job.id),
-                                parseDiscardValue(
-                                  job?.job_data?.score?.discard,
-                                ),
-                              )
-                            }
-                          >
-                            {parseDiscardValue(
-                              job?.job_data?.score?.discard,
-                            ) ? (
-                              <>
-                                <BanIcon size={16} /> Unmark discard
-                              </>
-                            ) : (
-                              <>
-                                <BanIcon size={16} /> Mark discard
-                              </>
-                            )}
-                          </MenuItem>
-                        </Menu>
-                      </Dropdown>
-                    )}
-                  </Stack>
-                </td>
-              </tr>
-            );
-          })
-        ) : (
-          <tr>
-            <td
-              colSpan={4}
-              style={{
-                textAlign: 'center',
-                padding: '20px',
-                verticalAlign: 'top',
-                border: 'none',
-              }}
-            >
-              No jobs found
-            </td>
-          </tr>
-        )}
-      </tbody>
-    </Table>
+                            <MenuItem
+                              onClick={() =>
+                                onToggleDiscard?.(
+                                  String(job.id),
+                                  parseDiscardValue(
+                                    job?.job_data?.score?.discard,
+                                  ),
+                                )
+                              }
+                            >
+                              {parseDiscardValue(
+                                job?.job_data?.score?.discard,
+                              ) ? (
+                                <>
+                                  <BanIcon size={16} /> Unmark discard
+                                </>
+                              ) : (
+                                <>
+                                  <BanIcon size={16} /> Mark discard
+                                </>
+                              )}
+                            </MenuItem>
+                          </Menu>
+                        </Dropdown>
+                      )}
+                    </Stack>
+                  </td>
+                </tr>
+              );
+            })
+          ) : (
+            <tr>
+              <td
+                colSpan={4}
+                style={{
+                  textAlign: 'center',
+                  padding: '20px',
+                  verticalAlign: 'top',
+                  border: 'none',
+                }}
+              >
+                No jobs found
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </Table>
+      <JobNotesModal
+        open={notesModalJobId !== null}
+        onClose={() => setNotesModalJobId(null)}
+        jobId={notesModalJobId}
+        initialNotes={getJobNotes(notesModalJob)}
+        onSave={async (jobId, notes) => {
+          if (!onSaveNotes) return;
+          await onSaveNotes(jobId, notes);
+        }}
+      />
+    </>
   );
 };
 

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -663,6 +663,35 @@ export default function Tasks({ subtype }: { subtype?: string }) {
     }
   };
 
+  const handleSaveNotes = async (jobId: string, notes: string) => {
+    if (!experimentInfo?.id) return;
+    const trimmed = notes;
+    const previousJob = jobsWithPlaceholders.find(
+      (job: any) => String(job?.id) === String(jobId),
+    );
+    const previousNotes =
+      typeof previousJob?.job_data?.notes === 'string'
+        ? previousJob.job_data.notes
+        : '';
+    updateJobDataOptimistic(jobId, 'notes', trimmed);
+    try {
+      const response = await fetchWithAuth(
+        chatAPI.Endpoints.Jobs.UpdateJobData(experimentInfo.id, jobId),
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ updates: { notes: trimmed } }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to save notes: ${response.status}`);
+      }
+    } catch (error) {
+      updateJobDataOptimistic(jobId, 'notes', previousNotes);
+      throw error;
+    }
+  };
+
   const handleToggleDiscard = async (jobId: string, currentValue: boolean) => {
     if (!experimentInfo?.id) return;
     const newValue = !currentValue;
@@ -1544,6 +1573,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
             onToggleFavorite={handleToggleFavorite}
             onToggleHidden={handleToggleHidden}
             onToggleDiscard={handleToggleDiscard}
+            onSaveNotes={handleSaveNotes}
             showFilesButton={false}
             forceArtifactsButtonVisible
             onStopPendingChange={handleStopPendingChange}


### PR DESCRIPTION
## Summary
- Adds a `notes` field on jobs (stored at `job_data.notes`) with a small notebook icon in the Job Details cell of `JobsList` that previews notes on hover and opens an edit modal on click.
- New `JobNotesModal` (Joy UI textarea + Save/Cancel) handles add/edit; "Add Notes" / "Edit Notes" entry in the per-job dropdown menu lets users create notes when none exist yet.
- Backend: extends the existing `PUT /experiment/{id}/jobs/{job_id}/job_data` endpoint to allow the `notes` key alongside `favorite`/`hidden`/`tags`/`discard`. Wired in `Tasks.tsx` with optimistic update + revert-on-failure, mirroring the existing toggle handlers.
- The notes UI in `JobsList` is gated behind a new optional `onSaveNotes` prop, so consumers that don't pass it (`TaskRunsPage`, `Interactive`) don't get a half-functional editor — same pattern as the favorite/hidden/discard handlers.

## Test plan
- [ ] Open Tasks page → run a job → from the per-job menu, choose "Add Notes", save text, confirm the notebook icon now appears in the Job Details cell.
- [ ] Hover the icon → tooltip shows the notes content (multi-line preserved).
- [ ] Click the icon → modal pre-fills with current notes; edit + Save persists; Cancel discards.
- [ ] Reload the page → notes persist (round-trip through `job_data.notes`).
- [ ] In `TaskRunsPage` / `Interactive` views, confirm the "Edit Notes" menu item is hidden (since they don't wire `onSaveNotes`).
- [ ] `cd api && ruff check transformerlab/routers/experiment/jobs.py` passes.