### PR TITLE
Drop pip install transformerlab from task templates

### DIFF
--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -135,8 +135,7 @@ resources:                             # Optional but recommended
   num_nodes: 2                         # For distributed training
   compute_provider: my-provider        # Target provider name
 setup: |                               # Optional — runs before main task
-  pip install transformerlab
-  pip install -r requirements.txt
+  pip install -r requirements.txt      # The `transformerlab` SDK is preinstalled — do NOT add `pip install transformerlab`
 run: python main.py                    # Required — main entry point
 envs:                                  # Optional environment variables
   HF_TOKEN: "${HF_TOKEN}"
@@ -226,8 +225,7 @@ lab.error(message="Something went wrong")                # Mark job as FAILED
 **task.yaml:**
 ```yaml
 name: hello-world
-setup: pip install transformerlab
-run: python main.py
+run: python main.py                    # No `setup:` needed — the `transformerlab` SDK is preinstalled in the task environment
 resources:
   cpus: 2
   memory: 4

--- a/api/transformerlab/galleries/examples/autotrain-sft/task.yaml
+++ b/api/transformerlab/galleries/examples/autotrain-sft/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/autotrain-sft
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install autotrain-advanced bitsandbytes transformerlab wandb"
+setup: "uv pip install autotrain-advanced bitsandbytes wandb"
 run: "python autotrain-sft/train.py"
 envs:
   WANDB_PROJECT: "autotrain-sft-training"

--- a/api/transformerlab/galleries/examples/basic-evals-metrics/task.yaml
+++ b/api/transformerlab/galleries/examples/basic-evals-metrics/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/basic-evals-metrics
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab datasets pandas RestrictedPython==8.0.0;"
+setup: "uv pip install datasets pandas RestrictedPython==8.0.0;"
 run: "python basic-evals-metrics/train.py"
 envs:
   PYTHONUNBUFFERED: "1"

--- a/api/transformerlab/galleries/examples/batch-image-gen-flux/task.yaml
+++ b/api/transformerlab/galleries/examples/batch-image-gen-flux/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/batch-image-gen-flux
 resources:
   accelerators: "RTX3090:1"
-setup: "sudo apt update && sudo apt install -y libopenblas-dev curl && git clone https://github.com/antirez/flux2.c && cd flux2.c && make blas && ./download_model.sh && uv pip install transformerlab"
+setup: "sudo apt update && sudo apt install -y libopenblas-dev curl && git clone https://github.com/antirez/flux2.c && cd flux2.c && make blas && ./download_model.sh"
 run: "python batch-image-gen-flux/main.py"
 parameters:
   prompts:

--- a/api/transformerlab/galleries/examples/demo-eval-task/task.yaml
+++ b/api/transformerlab/galleries/examples/demo-eval-task/task.yaml
@@ -2,7 +2,7 @@ name: sample-eval-task
 resources:
   cpus: 2
   memory: 4
-setup: "uv pip install transformerlab datasets;"
+setup: "uv pip install datasets;"
 run: "python demo-eval-task/fake_evals.py"
 github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/demo-eval-task

--- a/api/transformerlab/galleries/examples/demo-generate-task/task.yaml
+++ b/api/transformerlab/galleries/examples/demo-generate-task/task.yaml
@@ -4,5 +4,5 @@ github_repo_dir: api/transformerlab/galleries/examples/demo-generate-task
 resources:
   cpus: 2
   memory: 4
-setup: "uv pip install transformerlab datasets;"
+setup: "uv pip install datasets;"
 run: "python demo-generate-task/fake_generate.py"

--- a/api/transformerlab/galleries/examples/diffusion-train/task.yaml
+++ b/api/transformerlab/galleries/examples/diffusion-train/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/diffusion-train
 resources:
   accelerators: "A100-80GB:1"
-setup: "uv pip install transformerlab diffusers peft safetensors torch torchvision accelerate 'datasets==4.4.2' 'pyarrow==22.0.0' huggingface_hub 'transformers==4.57.3'"
+setup: "uv pip install diffusers peft safetensors torch torchvision accelerate 'datasets==4.4.2' 'pyarrow==22.0.0' huggingface_hub 'transformers==4.57.3'"
 run: "python diffusion-train/train.py"
 envs:
   WANDB_PROJECT: "stable-diffusion-training"

--- a/api/transformerlab/galleries/examples/eleutherai-lm-evaluation-harness/task.yaml
+++ b/api/transformerlab/galleries/examples/eleutherai-lm-evaluation-harness/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/eleutherai-lm-evaluation-harness
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab lm_eval==0.4.7 pandas torch"
+setup: "uv pip install lm_eval==0.4.7 pandas torch"
 run: "python eleutherai-lm-evaluation-harness/train.py"
 envs:
   PYTHONUNBUFFERED: "1"

--- a/api/transformerlab/galleries/examples/embedding-model-train/task.yaml
+++ b/api/transformerlab/galleries/examples/embedding-model-train/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/embedding-model-train
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab numpy==1.26.4 pyarrow==15.0.0 fsspec==2023.9.0 huggingface-hub==0.36.0 transformers==4.57.3 datasets==2.16.0 sentence-transformers==5.2.0 torch==2.9.1 accelerate==1.12.0"
+setup: "uv pip install numpy==1.26.4 pyarrow==15.0.0 fsspec==2023.9.0 huggingface-hub==0.36.0 transformers==4.57.3 datasets==2.16.0 sentence-transformers==5.2.0 torch==2.9.1 accelerate==1.12.0"
 run: "python embedding-model-train/train.py"
 envs:
   WANDB_PROJECT: "embedding-model-training"

--- a/api/transformerlab/galleries/examples/gguf_exporter/task.yaml
+++ b/api/transformerlab/galleries/examples/gguf_exporter/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/gguf_exporter
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab huggingface-hub torch; sudo apt update; sudo apt install -y git;"
+setup: "uv pip install huggingface-hub torch; sudo apt update; sudo apt install -y git;"
 run: "python gguf_exporter/train.py"
 envs:
   PYTHONUNBUFFERED: "1"

--- a/api/transformerlab/galleries/examples/gpt-oss/task.yaml
+++ b/api/transformerlab/galleries/examples/gpt-oss/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/gpt-oss
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab datasets transformers==4.57.3 torch trl peft lm_eval==0.4.7;sudo apt update;sudo apt install -y libgl1 libglib2.0-0;"
+setup: "uv pip install datasets transformers==4.57.3 torch trl peft lm_eval==0.4.7;sudo apt update;sudo apt install -y libgl1 libglib2.0-0;"
 run: "python gpt-oss/train.py"
 envs:
   PYTHONUNBUFFERED: "1"

--- a/api/transformerlab/galleries/examples/grpo-multi-gpu-train/task.yaml
+++ b/api/transformerlab/galleries/examples/grpo-multi-gpu-train/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/grpo-multi-gpu-train
 resources:
   accelerators: "A100-80GB:1"
-setup: "uv pip install trl bitsandbytes accelerate transformerlab datasets jinja2 wandb"
+setup: "uv pip install trl bitsandbytes accelerate datasets jinja2 wandb"
 run: "python grpo-multi-gpu-train/train.py"
 envs:
   WANDB_PROJECT: "grpo-multi-gpu-training"

--- a/api/transformerlab/galleries/examples/llamafile_exporter/task.yaml
+++ b/api/transformerlab/galleries/examples/llamafile_exporter/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/llamafile_exporter
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab huggingface-hub; sudo apt update; sudo apt install -y curl;"
+setup: "uv pip install huggingface-hub; sudo apt update; sudo apt install -y curl;"
 run: "python llamafile_exporter/train.py"
 envs:
   PYTHONUNBUFFERED: "1"

--- a/api/transformerlab/galleries/examples/lora-trainer-multi-gpu/task.yaml
+++ b/api/transformerlab/galleries/examples/lora-trainer-multi-gpu/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/lora-trainer-multi-gpu
 resources:
   accelerators: "RTX3090:2"
-setup: "uv pip install transformers trl peft bitsandbytes accelerate transformerlab datasets wandb"
+setup: "uv pip install transformers trl peft bitsandbytes accelerate datasets wandb"
 run: "python lora-trainer-multi-gpu/train.py"
 envs:
   WANDB_PROJECT: "lora-multi-gpu-training"

--- a/api/transformerlab/galleries/examples/mlx_exporter/task.yaml
+++ b/api/transformerlab/galleries/examples/mlx_exporter/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/mlx_exporter
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab mlx==0.29.3 mlx-lm==0.28.3 huggingface-hub;"
+setup: "uv pip install mlx==0.29.3 mlx-lm==0.28.3 huggingface-hub;"
 run: "python mlx_exporter/train.py"
 envs:
   PYTHONUNBUFFERED: "1"

--- a/api/transformerlab/galleries/examples/mlx_lora_train/task.yaml
+++ b/api/transformerlab/galleries/examples/mlx_lora_train/task.yaml
@@ -1,7 +1,7 @@
 name: mlx-lora-train-task
 github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/mlx_lora_train
-setup: "source ~/venv/bin/activate; uv pip install transformerlab mlx mlx-lm datasets jinja2 transformers huggingface-hub pyyaml wandb"
+setup: "source ~/venv/bin/activate; uv pip install mlx mlx-lm datasets jinja2 transformers huggingface-hub pyyaml wandb"
 run: "source ~/venv/bin/activate; cd ~/mlx_lora_train && python train.py"
 envs:
   PYTHONUNBUFFERED: "1"

--- a/api/transformerlab/galleries/examples/mnist-jax-train/task.yaml
+++ b/api/transformerlab/galleries/examples/mnist-jax-train/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/mnist-jax-train
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab jax flax optax matplotlib wandb && uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126"
+setup: "uv pip install jax flax optax matplotlib wandb && uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126"
 run: "python mnist-jax-train/train.py"
 envs:
   WANDB_PROJECT: "mnist-jax-training-project"

--- a/api/transformerlab/galleries/examples/mnist-train/task.yaml
+++ b/api/transformerlab/galleries/examples/mnist-train/task.yaml
@@ -4,7 +4,7 @@ github_repo_dir: api/transformerlab/galleries/examples/mnist-train
 resources:
   cpus: 2
   memory: 4
-setup: "uv pip install torch torchvision wandb transformerlab matplotlib"
+setup: "uv pip install torch torchvision wandb matplotlib"
 run: "python mnist-train/mnist_train.py"
 envs:
   WANDB_API_KEY: "{{secret._WANDB_API_KEY}}"

--- a/api/transformerlab/galleries/examples/nanochat/task.yaml
+++ b/api/transformerlab/galleries/examples/nanochat/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/nanochat
 resources:
   accelerators: "H100:8"
-setup: "uv pip install transformerlab torch torchvision torchaudio transformers datasets wandb;sudo apt update;sudo apt install -y curl git build-essential;"
+setup: "uv pip install torch torchvision torchaudio transformers datasets wandb;sudo apt update;sudo apt install -y curl git build-essential;"
 run: "python nanochat/train.py"
 envs:
   WANDB_PROJECT: "nanochat-training"

--- a/api/transformerlab/galleries/examples/new-task-test/task.yaml
+++ b/api/transformerlab/galleries/examples/new-task-test/task.yaml
@@ -4,7 +4,7 @@ github_repo_dir: api/transformerlab/galleries/examples/new-task-test
 resources:
   cpus: 2
   memory: 4
-setup: "uv pip install transformerlab wandb"
+setup: "uv pip install wandb"
 run: "python new-task-test/train.py"
 envs:
   WANDB_PROJECT: "my-training-project"

--- a/api/transformerlab/galleries/examples/objective-eval/task.yaml
+++ b/api/transformerlab/galleries/examples/objective-eval/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/objective-eval
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab deepeval==2.8.2 bert-score==0.3.13 datasets==3.6.0 seaborn==0.13.2 tensorboardx==2.6.2.2 rouge_score==0.1.2 pandas nltk"
+setup: "uv pip install deepeval==2.8.2 bert-score==0.3.13 datasets==3.6.0 seaborn==0.13.2 tensorboardx==2.6.2.2 rouge_score==0.1.2 pandas nltk"
 run: "python objective-eval/train.py"
 envs:
   PYTHONUNBUFFERED: "1"

--- a/api/transformerlab/galleries/examples/sample-task/task.yaml
+++ b/api/transformerlab/galleries/examples/sample-task/task.yaml
@@ -4,7 +4,7 @@ github_repo_dir: api/transformerlab/galleries/examples/sample-task
 resources:
   cpus: 2
   memory: 4
-setup: "uv pip install transformerlab wandb"
+setup: "uv pip install wandb"
 run: "python sample-task/train.py"
 envs:
   WANDB_PROJECT: "my-training-project"

--- a/api/transformerlab/galleries/examples/trl-training-evals/task.yaml
+++ b/api/transformerlab/galleries/examples/trl-training-evals/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/trl-training-evals
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install transformerlab datasets transformers==4.57.3 torch pandas trl==0.26.2 wandb lm_eval==0.4.7;sudo apt update;sudo apt install -y libgl1 libglib2.0-0;"
+setup: "uv pip install datasets transformers==4.57.3 torch pandas trl==0.26.2 wandb lm_eval==0.4.7;sudo apt update;sudo apt install -y libgl1 libglib2.0-0;"
 run: "python trl-training-evals/train.py"
 envs:
   WANDB_PROJECT: "trl-training-project"

--- a/api/transformerlab/galleries/examples/unsloth-grpo-train/task.yaml
+++ b/api/transformerlab/galleries/examples/unsloth-grpo-train/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/unsloth-grpo-train
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install trl==0.24.0 bitsandbytes==0.49.2 unsloth==2026.3.3 unsloth-zoo==2026.3.1 transformerlab datasets==4.3.0 torch==2.10.0"
+setup: "uv pip install trl==0.24.0 bitsandbytes==0.49.2 unsloth==2026.3.3 unsloth-zoo==2026.3.1 datasets==4.3.0 torch==2.10.0"
 run: "python unsloth-grpo-train/train.py"
 envs:
   WANDB_PROJECT: "unsloth-grpo-training"

--- a/api/transformerlab/galleries/examples/unsloth-llm-train/task.yaml
+++ b/api/transformerlab/galleries/examples/unsloth-llm-train/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/unsloth-llm-train
 resources:
   accelerators: "RTX3090:1"
-setup: "uv pip install unsloth==2025.12.5 transformers==4.57.3 torch==2.10.0 datasets huggingface-hub torch transformerlab wandb"
+setup: "uv pip install unsloth==2025.12.5 transformers==4.57.3 torch==2.10.0 datasets huggingface-hub torch wandb"
 run: "python unsloth-llm-train/train.py"
 envs:
   WANDB_PROJECT: "unsloth-llm-training"

--- a/api/transformerlab/galleries/examples/unsloth-text-to-speech-train/task.yaml
+++ b/api/transformerlab/galleries/examples/unsloth-text-to-speech-train/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/unsloth-text-to-speech-train
 resources:
   accelerators: "RTX3090:1"
-setup: uv pip install torch unsloth transformers==4.52.3 snac transformerlab "datasets==3.6.0" librosa soundfile "torch==2.10.0"
+setup: uv pip install torch unsloth transformers==4.52.3 snac "datasets==3.6.0" librosa soundfile "torch==2.10.0"
 run: "python unsloth-text-to-speech-train/train.py"
 envs:
   WANDB_PROJECT: "unsloth-text-to-speech-training"

--- a/api/transformerlab/galleries/examples/video-diffusion/task.yaml
+++ b/api/transformerlab/galleries/examples/video-diffusion/task.yaml
@@ -6,7 +6,7 @@ resources:
 envs:
   PYTHONUNBUFFERED: "1"
   HF_TOKEN: "{{secret._HF_TOKEN}}"
-setup: "uv pip install diffusers 'transformers>=4.41.0' 'peft>=0.17.0' accelerate ftfy huggingface-hub opencv-python transformerlab imageio-ffmpeg"
+setup: "uv pip install diffusers 'transformers>=4.41.0' 'peft>=0.17.0' accelerate ftfy huggingface-hub opencv-python imageio-ffmpeg"
 parameters:
   model_id: "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
   prompt: "A cat walks on the grass, realistic"

--- a/api/transformerlab/galleries/examples/yolo-train-task/task.yaml
+++ b/api/transformerlab/galleries/examples/yolo-train-task/task.yaml
@@ -3,7 +3,7 @@ github_repo_url: https://github.com/transformerlab/transformerlab-app
 github_repo_dir: api/transformerlab/galleries/examples/yolo-train-task
 resources:
   accelerators: "RTX3090:1"
-setup: "sudo apt update && sudo apt install -y libgl1-mesa-glx libglib2.0-0 && pip install datasets transformers==4.57.3 torch==2.9.1 wandb ultralytics transformerlab"
+setup: "sudo apt update && sudo apt install -y libgl1-mesa-glx libglib2.0-0 && pip install datasets transformers==4.57.3 torch==2.9.1 wandb ultralytics"
 run: "python yolo-train-task/yolo_train_script.py"
 envs:
   WANDB_API_KEY: "{{secret._WANDB_API_KEY}}"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.46"
+version = "0.0.47"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/templates/task_init/task.yaml
+++ b/cli/src/transformerlab_cli/templates/task_init/task.yaml
@@ -12,9 +12,10 @@ resources:
   # num_nodes: 1             # >1 for distributed training
 
 # Commands that run on the remote machine BEFORE `run`. Use this for
-# installing deps, downloading data, etc.
-setup: |
-  pip install transformerlab
+# installing extra deps, downloading data, etc. The `transformerlab` SDK
+# is preinstalled, so you do NOT need `pip install transformerlab` here.
+# setup: |
+#   pip install -r requirements.txt
 
 # Main entry point. This is the command that executes your task.
 run: python main.py

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.46"
+version = "0.0.47"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- The `transformerlab` SDK is preinstalled in the task execution environment, so `pip install transformerlab` in `setup:` is redundant.
- Updated the `transformerlab-cli` skill examples (task.yaml structure block and the hello-world example) to omit it and explicitly note it's preinstalled — agents kept re-adding the line because the skill modeled it.
- Updated the `lab task init` template (`cli/src/transformerlab_cli/templates/task_init/task.yaml`) to comment out the `setup:` block with the same note, so freshly initialized tasks don't ship with the unnecessary install.

## Test plan
- [x] `cd cli && python -m pytest tests/ -k "init or template"` — 11 passed
- [ ] Spot-check `lab task init` output to confirm the new template renders as expected