### PR TITLE
Fix fetchWithAuth double-prefix when API_URL is a path prefix

### DIFF
--- a/src/renderer/lib/authContext.ts
+++ b/src/renderer/lib/authContext.ts
@@ -200,7 +200,10 @@ export async function fetchWithAuth(url: string, options: RequestInit = {}) {
   // Handle cases where url might be partial or full
   // Ideally fetchWithAuth is passed a relative path, but we handle both.
   let fullUrl: string;
-  if (url.startsWith('http')) {
+  if (url.startsWith('http') || url.startsWith('//') || url.startsWith('/')) {
+    // Already an absolute URL (http://...) or absolute path (/lab/...).
+    // getAPIFullPath returns the latter when API_URL is configured as a path
+    // prefix (e.g. when the app is hosted behind a reverse proxy at /lab/).
     fullUrl = url;
   } else {
     const baseUrl = API_URL();


### PR DESCRIPTION
## Summary

- `fetchWithAuth` only treated `http://`-prefixed strings as already-resolved URLs. When `TL_API_URL` is configured as a path prefix (e.g. `/lab/` for a subpath reverse-proxy deployment), `getAPIFullPath` returns `/lab/foo` and `fetchWithAuth` re-prepended the base, producing `/lab//lab/foo` → 404.
- Now also treats absolute paths (`/...`) and protocol-relative URLs (`//...`) as already-resolved. No-op for the current full-origin `API_URL` setup, since those URLs still go through the existing `http://` branch.

## Why this matters

Latent for the standard same-origin / Electron deployments (where `API_URL` is always a full origin URL). It surfaces the moment you try to host the app behind a reverse-proxy subpath (e.g. Traefik routing `/lab/*` → API).

## Test plan

- [x] Built the cloud bundle with `TL_API_URL=/lab/` and ran it behind Traefik with a `StripPrefix(/lab)` middleware.
- [x] Before the fix: every SWR call to a `useAPI`-built URL hit `/lab//lab/<path>` and returned 404. After the fix: all calls resolve to `/lab/<path>` and route correctly through the proxy.
- [x] Logged in via the UI at `http://localhost/lab/`, navigated through the wizard, opened the Tasks page, and confirmed the dashboard renders with no path-related errors.
- [ ] No change to existing same-origin / Electron flows expected — `http://`-prefixed URLs still take the same branch they always did.