### PR TITLE
Improve job list row layout

### DIFF
--- a/src/renderer/components/Experiment/Tasks/JobProgress.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobProgress.tsx
@@ -396,40 +396,58 @@ export default function JobProgress({
                 <br />
               </>
             )}
-            {/* eslint-disable-next-line no-nested-ternary, prettier/prettier */}
-            {job?.status === 'COMPLETE' &&
-              (job?.job_data?.completion_status ? (
-                job?.job_data?.completion_status === 'success' ? (
-                  <Typography level="body-sm" color="success">
-                    Success: {job?.job_data?.completion_details}
-                  </Typography>
-                ) : (
-                  <Typography level="body-sm" color="danger">
-                    Failure: {job?.job_data?.completion_details}
-                  </Typography>
-                )
-              ) : (
-                /* If we don't have a status, assume it failed */
-                <Typography level="body-sm" color="neutral" />
-              ))}
-            {job?.status === 'FAILED' && job?.job_data?.error_msg && (
-              <Typography
-                level="body-sm"
-                color="danger"
-                sx={{
-                  maxWidth: 400,
-                  maxHeight: 80,
-                  overflow: 'auto',
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-word',
-                }}
-              >
-                Error: {job.job_data.error_msg}
-              </Typography>
-            )}
           </>
         </Stack>
       )}
     </Stack>
   );
+}
+
+interface JobCompletionDetailsProps {
+  job: {
+    status: string;
+    job_data?: JobData;
+    placeholder?: boolean;
+  };
+}
+
+export function JobCompletionDetails({ job }: JobCompletionDetailsProps) {
+  if (job?.placeholder) return null;
+
+  if (job?.status === 'COMPLETE') {
+    if (job?.job_data?.completion_status === 'success') {
+      return (
+        <Typography level="body-sm" color="success">
+          Success: {job?.job_data?.completion_details}
+        </Typography>
+      );
+    }
+    if (job?.job_data?.completion_status) {
+      return (
+        <Typography level="body-sm" color="danger">
+          Failure: {job?.job_data?.completion_details}
+        </Typography>
+      );
+    }
+  }
+
+  if (job?.status === 'FAILED' && job?.job_data?.error_msg) {
+    return (
+      <Typography
+        level="body-sm"
+        color="danger"
+        sx={{
+          maxWidth: 400,
+          maxHeight: 80,
+          overflow: 'auto',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
+      >
+        Error: {job.job_data.error_msg}
+      </Typography>
+    );
+  }
+
+  return null;
 }

--- a/src/renderer/components/Experiment/Tasks/JobProgress.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobProgress.tsx
@@ -253,7 +253,6 @@ export default function JobProgress({
           )}
           {job?.job_data?.start_time && (
             <>
-              Started:{' '}
               {dayjs
                 .utc(job.job_data.start_time)
                 .local()
@@ -356,7 +355,6 @@ export default function JobProgress({
             )}
           {job?.job_data?.start_time && (
             <>
-              Started:{' '}
               {dayjs
                 .utc(job.job_data.start_time)
                 .local()
@@ -378,7 +376,6 @@ export default function JobProgress({
           <>
             {job?.job_data?.start_time && (
               <>
-                Started:{' '}
                 {dayjs
                   .utc(job?.job_data?.start_time)
                   .local()
@@ -388,7 +385,7 @@ export default function JobProgress({
             )}
             {job?.job_data?.end_time && job?.job_data?.start_time && (
               <>
-                Completed in:{' '}
+                {' '}
                 {dayjs
                   .duration(
                     dayjs(job?.job_data?.end_time).diff(

--- a/src/renderer/components/Experiment/Tasks/JobsList.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsList.tsx
@@ -173,7 +173,7 @@ const JobsList: React.FC<JobsListProps> = ({
 
   const getScoreDisplay = (
     score: unknown,
-  ): { label: string; tooltip?: string } | null => {
+  ): { label: string; tooltip?: React.ReactNode } | null => {
     if (typeof score === 'number') {
       return { label: `Score: ${formatScoreValue(score)}` };
     }
@@ -203,11 +203,15 @@ const JobsList: React.FC<JobsListProps> = ({
       const [firstMetric, firstValue] = preferredMetric;
 
       const tooltip =
-        numericEntries.length > 1
-          ? numericEntries
-              .map(([metric, val]) => `${metric}: ${formatScoreValue(val)}`)
-              .join(' | ')
-          : undefined;
+        numericEntries.length > 1 ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {numericEntries.map(([metric, val]) => (
+              <span key={metric}>
+                {metric}: {formatScoreValue(val)}
+              </span>
+            ))}
+          </Box>
+        ) : undefined;
 
       return {
         label: `${firstMetric}: ${formatScoreValue(firstValue)}`,
@@ -216,6 +220,42 @@ const JobsList: React.FC<JobsListProps> = ({
     }
 
     return null;
+  };
+
+  const renderDescriptionControl = (job: any) => {
+    const descriptionRaw =
+      typeof job?.job_data?.description === 'string'
+        ? job.job_data.description.trim()
+        : '';
+    if (!descriptionRaw) return null;
+
+    const descriptionTooltip =
+      descriptionRaw.length > 200
+        ? `${descriptionRaw.slice(0, 200)}...`
+        : descriptionRaw;
+
+    return (
+      <Tooltip
+        sx={{ maxWidth: 400 }}
+        title={descriptionTooltip}
+        placement="top"
+      >
+        <IconButton
+          size="sm"
+          variant="plain"
+          color="neutral"
+          onClick={() =>
+            setDescriptionModal({
+              open: true,
+              jobId: String(job?.id ?? ''),
+              description: descriptionRaw,
+            })
+          }
+        >
+          <NotebookPenIcon size={15} />
+        </IconButton>
+      </Tooltip>
+    );
   };
 
   const formatJobConfig = (job: any) => {
@@ -311,21 +351,24 @@ const JobsList: React.FC<JobsListProps> = ({
               <b>Title:</b> {taskName}
             </Typography>
           )}
-          {scoreDisplay && (
-            <Tooltip
-              title={scoreDisplay.tooltip || ''}
-              disableHoverListener={!scoreDisplay.tooltip}
-            >
-              <Chip
-                size="sm"
-                color="success"
-                variant="soft"
-                sx={{ mt: 0.5, width: 'fit-content' }}
+          <Stack direction="row" alignItems="center" gap={0.5} sx={{ mt: 0.5 }}>
+            {!job?.placeholder && renderDescriptionControl(job)}
+            {scoreDisplay && (
+              <Tooltip
+                title={scoreDisplay.tooltip || ''}
+                disableHoverListener={!scoreDisplay.tooltip}
               >
-                {scoreDisplay.label}
-              </Chip>
-            </Tooltip>
-          )}
+                <Chip
+                  size="sm"
+                  color="success"
+                  variant="soft"
+                  sx={{ width: 'fit-content' }}
+                >
+                  {scoreDisplay.label}
+                </Chip>
+              </Tooltip>
+            )}
+          </Stack>
         </>
       );
     }
@@ -353,21 +396,24 @@ const JobsList: React.FC<JobsListProps> = ({
               <b>Provider:</b> {providerDisplay}
             </Typography>
           )}
-          {scoreDisplay && (
-            <Tooltip
-              title={scoreDisplay.tooltip || ''}
-              disableHoverListener={!scoreDisplay.tooltip}
-            >
-              <Chip
-                size="sm"
-                color="success"
-                variant="soft"
-                sx={{ mt: 0.5, width: 'fit-content' }}
+          <Stack direction="row" alignItems="center" gap={0.5} sx={{ mt: 0.5 }}>
+            {!job?.placeholder && renderDescriptionControl(job)}
+            {scoreDisplay && (
+              <Tooltip
+                title={scoreDisplay.tooltip || ''}
+                disableHoverListener={!scoreDisplay.tooltip}
               >
-                {scoreDisplay.label}
-              </Chip>
-            </Tooltip>
-          )}
+                <Chip
+                  size="sm"
+                  color="success"
+                  variant="soft"
+                  sx={{ width: 'fit-content' }}
+                >
+                  {scoreDisplay.label}
+                </Chip>
+              </Tooltip>
+            )}
+          </Stack>
         </>
       );
     }
@@ -386,44 +432,9 @@ const JobsList: React.FC<JobsListProps> = ({
     return <b>{job.type || 'Unknown Job'}</b>;
   };
 
-  const renderDescriptionControl = (job: any) => {
-    const descriptionRaw =
-      typeof job?.job_data?.description === 'string'
-        ? job.job_data.description.trim()
-        : '';
-    if (!descriptionRaw) return null;
-
-    const descriptionTooltip =
-      descriptionRaw.length > 200
-        ? `${descriptionRaw.slice(0, 200)}...`
-        : descriptionRaw;
-
-    return (
-      <Tooltip title={descriptionTooltip} placement="top" variant="soft">
-        <IconButton
-          size="sm"
-          variant="plain"
-          color="neutral"
-          onClick={() =>
-            setDescriptionModal({
-              open: true,
-              jobId: String(job?.id ?? ''),
-              description: descriptionRaw,
-            })
-          }
-        >
-          <NotebookPenIcon size={15} />
-        </IconButton>
-      </Tooltip>
-    );
-  };
-
   const tableHead = (
     <thead>
       <tr>
-        <th style={{ width: 44, textAlign: 'center' }} aria-label="Description">
-          &nbsp;
-        </th>
         <th>Job ID</th>
         <th>Job Details</th>
         <th>Status</th>
@@ -439,9 +450,6 @@ const JobsList: React.FC<JobsListProps> = ({
         <tbody>
           {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
             <tr key={i}>
-              <td style={{ textAlign: 'center' }}>
-                <Skeleton variant="circular" width={20} height={20} />
-              </td>
               <td>
                 <Skeleton variant="text" level="title-sm" />
               </td>
@@ -490,15 +498,6 @@ const JobsList: React.FC<JobsListProps> = ({
                       : {}),
                   }}
                 >
-                  <td
-                    style={{
-                      verticalAlign: 'top',
-                      border: 'none',
-                      textAlign: 'center',
-                    }}
-                  >
-                    {!job?.placeholder && renderDescriptionControl(job)}
-                  </td>
                   <td style={{ verticalAlign: 'top', border: 'none' }}>
                     {selectMode &&
                       job?.job_data?.eval_results &&
@@ -695,7 +694,7 @@ const JobsList: React.FC<JobsListProps> = ({
                         </Button>
                       )}
                       {!job?.placeholder && (
-                        <Tooltip title="Copy permalink" variant="outlined">
+                        <Tooltip title="Copy permalink">
                           <IconButton
                             size="sm"
                             variant="plain"
@@ -826,7 +825,7 @@ const JobsList: React.FC<JobsListProps> = ({
           ) : (
             <tr>
               <td
-                colSpan={5}
+                colSpan={4}
                 style={{
                   textAlign: 'center',
                   padding: '20px',

--- a/src/renderer/components/Experiment/Tasks/JobsList.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsList.tsx
@@ -258,185 +258,90 @@ const JobsList: React.FC<JobsListProps> = ({
     );
   };
 
-  const formatJobConfig = (job: any) => {
+  const getJobName = (job: any): string => {
     const jobData = job?.job_data || {};
-    const interactiveType =
-      jobData?.interactive_type ||
-      job?.interactive_type ||
-      jobData?.template_config?.interactive_type;
 
-    // Handle sweep child jobs
     if (jobData?.parent_sweep_job_id) {
       const runIndex = jobData.sweep_run_index || 0;
       const total = jobData.sweep_total || 0;
-      const sweepParams = jobData.sweep_params || {};
-      const paramStr = Object.entries(sweepParams)
-        .map(([k, v]) => `${k}=${v}`)
-        .join(', ');
-      return (
-        <>
-          <b>
-            Sweep Run {runIndex}/{total}
-          </b>
-          {paramStr && (
-            <>
-              <br />
-              <small>{paramStr}</small>
-            </>
-          )}
-        </>
-      );
+      return `Sweep Run ${runIndex}/${total}`;
     }
 
-    // Handle sweep parent jobs
     if (jobData?.sweep_parent || job?.type === 'SWEEP') {
       const total = jobData.sweep_total || 0;
-      const sweepConfig = jobData.sweep_config || {};
-      const configStr = Object.keys(sweepConfig).join(' × ');
-      return (
-        <>
-          <b>Sweep: {total} configurations</b>
-          {configStr && (
-            <>
-              <br />
-              <small>{configStr}</small>
-            </>
-          )}
-        </>
-      );
+      return `Sweep: ${total} configurations`;
     }
 
-    // Prefer showing Cluster Name (if present) and the user identifier (name/email)
-    const clusterName = jobData?.cluster_name;
+    if (showInteractiveType) {
+      const interactiveType =
+        jobData?.interactive_type ||
+        job?.interactive_type ||
+        jobData?.template_config?.interactive_type;
+      if (interactiveType) {
+        return formatInteractiveTypeLabel(String(interactiveType));
+      }
+    }
 
-    const userInfo = jobData.user_info || {};
-    const userDisplay = userInfo.name || userInfo.email || '';
-    const providerDisplay = jobData.provider_name || job?.provider_name || '';
-    const scoreDisplay = getScoreDisplay(jobData?.score);
+    return (
+      jobData?.cluster_name ||
+      jobData?.task_name ||
+      jobData?.template_name ||
+      job?.type ||
+      'Unknown Job'
+    );
+  };
+
+  const getJobUserEmail = (job: any): string => {
+    const userInfo = job?.job_data?.user_info || {};
+    return userInfo.email || userInfo.name || '';
+  };
+
+  const formatJobConfig = (job: any) => {
+    const jobData = job?.job_data || {};
+
     if (job?.placeholder) {
       return (
         <>
-          <Skeleton variant="text" level="body-md" width={160} />
-          <Skeleton variant="text" level="body-sm" width={100} />
+          <Skeleton variant="text" level="body-sm" width={120} />
+          <Skeleton variant="text" level="body-sm" width={80} />
         </>
       );
     }
-    // Interactive jobs: show job type, submitter, provider, and title
-    if (showInteractiveType && interactiveType) {
-      const taskName = jobData?.task_name || '';
-      const typeLabel = formatInteractiveTypeLabel(String(interactiveType));
-      return (
-        <>
-          <Typography level="title-sm" fontWeight="bold">
-            {typeLabel}
-            {job?.job_data?.favorite && (
-              <>
-                {' '}
-                <BookmarkIcon size={16} fill="currentColor" />
-              </>
-            )}
+
+    const sweepParams = jobData?.parent_sweep_job_id
+      ? jobData.sweep_params || {}
+      : null;
+    const sweepParamStr = sweepParams
+      ? Object.entries(sweepParams)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(', ')
+      : '';
+
+    const sweepConfigStr =
+      jobData?.sweep_parent || job?.type === 'SWEEP'
+        ? Object.keys(jobData?.sweep_config || {}).join(' × ')
+        : '';
+
+    return (
+      <>
+        {sweepParamStr && (
+          <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+            {sweepParamStr}
           </Typography>
-          {userDisplay && (
-            <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-              <b>Submitter:</b> {userDisplay}
-            </Typography>
-          )}
-          {providerDisplay && (
-            <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-              <b>Provider:</b> {providerDisplay}
-            </Typography>
-          )}
-          {taskName && (
-            <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-              <b>Title:</b> {taskName}
-            </Typography>
-          )}
-          <Stack direction="row" alignItems="center" gap={0.5} sx={{ mt: 0.5 }}>
-            {!job?.placeholder && renderDescriptionControl(job)}
-            {scoreDisplay && (
-              <Tooltip
-                title={scoreDisplay.tooltip || ''}
-                disableHoverListener={!scoreDisplay.tooltip}
-              >
-                <Chip
-                  size="sm"
-                  color="success"
-                  variant="soft"
-                  sx={{ width: 'fit-content' }}
-                >
-                  {scoreDisplay.label}
-                </Chip>
-              </Tooltip>
-            )}
-          </Stack>
-        </>
-      );
-    }
-
-    // Build preferred details
-    if (clusterName || userDisplay || providerDisplay) {
-      return (
-        <>
-          {clusterName && (
-            <Typography level="title-sm" fontWeight="bold">
-              {clusterName}{' '}
-              {job?.job_data?.favorite && (
-                <BookmarkIcon size={16} fill="currentColor" />
-              )}
-              <br />
-            </Typography>
-          )}
-          {userDisplay && (
-            <Typography level="body-sm">
-              <b>Submitter:</b> {userDisplay}
-            </Typography>
-          )}
-          {providerDisplay && (
-            <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-              <b>Provider:</b> {providerDisplay}
-            </Typography>
-          )}
-          <Stack direction="row" alignItems="center" gap={0.5} sx={{ mt: 0.5 }}>
-            {!job?.placeholder && renderDescriptionControl(job)}
-            {scoreDisplay && (
-              <Tooltip
-                title={scoreDisplay.tooltip || ''}
-                disableHoverListener={!scoreDisplay.tooltip}
-              >
-                <Chip
-                  size="sm"
-                  color="success"
-                  variant="soft"
-                  sx={{ width: 'fit-content' }}
-                >
-                  {scoreDisplay.label}
-                </Chip>
-              </Tooltip>
-            )}
-          </Stack>
-        </>
-      );
-    }
-
-    // Fallbacks to existing info when no cluster/user available
-    if (jobData?.template_name) {
-      return (
-        <>
-          <b>Template:</b> {jobData.template_name}
-          <br />
-          <b>Type:</b> {job.type || 'Unknown'}
-        </>
-      );
-    }
-
-    return <b>{job.type || 'Unknown Job'}</b>;
+        )}
+        {sweepConfigStr && (
+          <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+            {sweepConfigStr}
+          </Typography>
+        )}
+      </>
+    );
   };
 
   const tableHead = (
     <thead>
       <tr>
         <th>Job ID</th>
-        <th>Job Details</th>
         <th>Status</th>
         <th style={{ textAlign: 'right' }}>Logs</th>
       </tr>
@@ -452,9 +357,6 @@ const JobsList: React.FC<JobsListProps> = ({
             <tr key={i}>
               <td>
                 <Skeleton variant="text" level="title-sm" />
-              </td>
-              <td>
-                <Skeleton variant="text" level="body-sm" />
               </td>
               <td>
                 <Skeleton variant="text" level="body-sm" />
@@ -511,10 +413,51 @@ const JobsList: React.FC<JobsListProps> = ({
                           sx={{ mr: 1 }}
                         />
                       )}
-                    {!hideJobId && <b title={fullJobId}>{displayJobId}</b>}
-                  </td>
-                  <td style={{ verticalAlign: 'top', border: 'none' }}>
-                    {formatJobConfig(job)}
+                    {job?.placeholder ? (
+                      <>
+                        <Skeleton variant="text" level="body-xs" width={70} />
+                        <Skeleton variant="text" level="title-sm" width={140} />
+                        <Skeleton variant="text" level="body-xs" width={120} />
+                      </>
+                    ) : (
+                      <>
+                        {!hideJobId && (
+                          <Typography
+                            level="body-xs"
+                            sx={{ color: 'text.tertiary' }}
+                            title={fullJobId}
+                          >
+                            #{displayJobId}
+                          </Typography>
+                        )}
+                        <Typography level="title-sm" fontWeight="bold">
+                          {getJobName(job)}
+                          {job?.job_data?.favorite && (
+                            <>
+                              {' '}
+                              <BookmarkIcon size={16} fill="currentColor" />
+                            </>
+                          )}
+                        </Typography>
+                        {getJobUserEmail(job) && (
+                          <Typography
+                            level="body-xs"
+                            sx={{ color: 'text.tertiary' }}
+                          >
+                            {getJobUserEmail(job)}
+                          </Typography>
+                        )}
+                        {(job?.job_data?.provider_name ||
+                          job?.provider_name) && (
+                          <Typography
+                            level="body-xs"
+                            sx={{ color: 'text.tertiary' }}
+                          >
+                            {job?.job_data?.provider_name || job?.provider_name}
+                          </Typography>
+                        )}
+                      </>
+                    )}
                   </td>
                   <td style={{ verticalAlign: 'top', border: 'none' }}>
                     <JobProgress
@@ -525,6 +468,41 @@ const JobsList: React.FC<JobsListProps> = ({
                       }
                       onStopPendingChange={onStopPendingChange}
                     />
+                    {formatJobConfig(job)}
+                    {!job?.placeholder &&
+                      (() => {
+                        const scoreDisplay = getScoreDisplay(
+                          job?.job_data?.score,
+                        );
+                        const descriptionControl =
+                          renderDescriptionControl(job);
+                        if (!scoreDisplay && !descriptionControl) return null;
+                        return (
+                          <Stack
+                            direction="row"
+                            alignItems="center"
+                            gap={0.5}
+                            sx={{ mt: 0.5 }}
+                          >
+                            {descriptionControl}
+                            {scoreDisplay && (
+                              <Tooltip
+                                title={scoreDisplay.tooltip || ''}
+                                disableHoverListener={!scoreDisplay.tooltip}
+                              >
+                                <Chip
+                                  size="sm"
+                                  color="neutral"
+                                  variant="soft"
+                                  sx={{ width: 'fit-content' }}
+                                >
+                                  {scoreDisplay.label}
+                                </Chip>
+                              </Tooltip>
+                            )}
+                          </Stack>
+                        );
+                      })()}
                   </td>
                   <td
                     style={{
@@ -825,7 +803,7 @@ const JobsList: React.FC<JobsListProps> = ({
           ) : (
             <tr>
               <td
-                colSpan={4}
+                colSpan={3}
                 style={{
                   textAlign: 'center',
                   padding: '20px',

--- a/src/renderer/components/Experiment/Tasks/JobsList.tsx
+++ b/src/renderer/components/Experiment/Tasks/JobsList.tsx
@@ -39,7 +39,7 @@ import {
 } from 'renderer/lib/utils';
 import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
 import { generateJobPermalink } from '../Jobs/jobDetailUtils';
-import JobProgress from './JobProgress';
+import JobProgress, { JobCompletionDetails } from './JobProgress';
 
 export interface LaunchProgressInfo {
   phase?: string;
@@ -338,20 +338,9 @@ const JobsList: React.FC<JobsListProps> = ({
     );
   };
 
-  const tableHead = (
-    <thead>
-      <tr>
-        <th>Job ID</th>
-        <th>Status</th>
-        <th style={{ textAlign: 'right' }}>Logs</th>
-      </tr>
-    </thead>
-  );
-
   if (loading) {
     return (
       <Table style={{ tableLayout: 'auto' }} stickyHeader>
-        {tableHead}
         <tbody>
           {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
             <tr key={i}>
@@ -379,7 +368,6 @@ const JobsList: React.FC<JobsListProps> = ({
   return (
     <>
       <Table style={{ tableLayout: 'auto' }} stickyHeader>
-        {tableHead}
         <tbody style={{ overflow: 'auto', height: '100%' }}>
           {jobs?.length > 0 ? (
             jobs?.map((job) => {
@@ -390,414 +378,455 @@ const JobsList: React.FC<JobsListProps> = ({
                 job?.status,
                 job?.job_data?.stop_requested,
               );
+              const rowOpacityStyle = {
+                ...(job?.job_data?.hidden ? { opacity: 0.45 } : {}),
+                ...(stopPending
+                  ? { opacity: 0.6, pointerEvents: 'none' as const }
+                  : {}),
+              };
               return (
-                <tr
-                  key={job.id}
-                  style={{
-                    ...(job?.job_data?.hidden ? { opacity: 0.45 } : {}),
-                    ...(stopPending
-                      ? { opacity: 0.6, pointerEvents: 'none' }
-                      : {}),
-                  }}
-                >
-                  <td style={{ verticalAlign: 'top', border: 'none' }}>
-                    {selectMode &&
-                      job?.job_data?.eval_results &&
-                      Array.isArray(job.job_data.eval_results) &&
-                      job.job_data.eval_results.length > 0 && (
-                        <Checkbox
-                          size="sm"
-                          checked={selectedJobIds.includes(String(job.id))}
-                          onChange={() => onToggleJobSelected?.(String(job.id))}
-                          disabled={stopPending}
-                          sx={{ mr: 1 }}
-                        />
-                      )}
-                    {job?.placeholder ? (
-                      <>
-                        <Skeleton variant="text" level="body-xs" width={70} />
-                        <Skeleton variant="text" level="title-sm" width={140} />
-                        <Skeleton variant="text" level="body-xs" width={120} />
-                      </>
-                    ) : (
-                      <>
-                        {!hideJobId && (
-                          <Typography
-                            level="body-xs"
-                            sx={{ color: 'text.tertiary' }}
-                            title={fullJobId}
-                          >
-                            #{displayJobId}
-                          </Typography>
-                        )}
-                        <Typography level="title-sm" fontWeight="bold">
-                          {getJobName(job)}
-                          {job?.job_data?.favorite && (
-                            <>
-                              {' '}
-                              <BookmarkIcon size={16} fill="currentColor" />
-                            </>
-                          )}
-                        </Typography>
-                        {getJobUserEmail(job) && (
-                          <Typography
-                            level="body-xs"
-                            sx={{ color: 'text.tertiary' }}
-                          >
-                            {getJobUserEmail(job)}
-                          </Typography>
-                        )}
-                        {(job?.job_data?.provider_name ||
-                          job?.provider_name) && (
-                          <Typography
-                            level="body-xs"
-                            sx={{ color: 'text.tertiary' }}
-                          >
-                            {job?.job_data?.provider_name || job?.provider_name}
-                          </Typography>
-                        )}
-                      </>
-                    )}
-                  </td>
-                  <td style={{ verticalAlign: 'top', border: 'none' }}>
-                    <JobProgress
-                      job={job}
-                      launchProgress={
-                        launchProgressByJobId?.[String(job.id)] ??
-                        job?.job_data?.launch_progress
-                      }
-                      onStopPendingChange={onStopPendingChange}
-                    />
-                    {formatJobConfig(job)}
-                    {!job?.placeholder &&
-                      (() => {
-                        const scoreDisplay = getScoreDisplay(
-                          job?.job_data?.score,
-                        );
-                        const descriptionControl =
-                          renderDescriptionControl(job);
-                        if (!scoreDisplay && !descriptionControl) return null;
-                        return (
-                          <Stack
-                            direction="row"
-                            alignItems="center"
-                            gap={0.5}
-                            sx={{ mt: 0.5 }}
-                          >
-                            {descriptionControl}
-                            {scoreDisplay && (
-                              <Tooltip
-                                title={scoreDisplay.tooltip || ''}
-                                disableHoverListener={!scoreDisplay.tooltip}
-                              >
-                                <Chip
-                                  size="sm"
-                                  color="neutral"
-                                  variant="soft"
-                                  sx={{ width: 'fit-content' }}
-                                >
-                                  {scoreDisplay.label}
-                                </Chip>
-                              </Tooltip>
-                            )}
-                          </Stack>
-                        );
-                      })()}
-                  </td>
-                  <td
-                    style={{
-                      verticalAlign: 'top',
-                      width: 'fit-content',
-                      border: 'none',
-                    }}
-                  >
-                    <Stack
-                      direction="row"
-                      gap={0.5}
-                      flexWrap="wrap"
-                      justifyContent="flex-end"
-                    >
-                      {job?.placeholder && (
-                        <Skeleton
-                          variant="rectangular"
-                          width={100}
-                          height={28}
-                        />
-                      )}
-                      {job?.job_data?.wandb_run_url && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => {
-                            window.open(job.job_data.wandb_run_url, '_blank');
+                <React.Fragment key={job.id}>
+                  {!hideJobId && !job?.placeholder && (
+                    <tr style={rowOpacityStyle}>
+                      <td
+                        colSpan={3}
+                        style={{
+                          border: 'none',
+                          paddingBottom: 0,
+                          verticalAlign: 'bottom',
+                        }}
+                      >
+                        <Typography
+                          level="body-xs"
+                          sx={{
+                            color: 'text.tertiary',
+                            borderBottom: '1px solid',
+                            borderColor: 'divider',
+                            pb: 0.25,
                           }}
-                          disabled={stopPending}
-                          startDecorator={<LineChartIcon />}
+                          title={fullJobId}
                         >
-                          W&B Tracking
-                        </Button>
-                      )}
-                      {(job?.job_data?.trackio_db_artifact_path ||
-                        job?.job_data?.trackio_project_name) &&
-                        showTrackioForStatus(job?.status) && (
-                          <Button
-                            size="sm"
-                            variant="plain"
-                            onClick={() => onViewTrackio?.(String(job?.id))}
-                            disabled={stopPending}
-                            startDecorator={<LineChartIcon />}
-                          >
-                            Trackio
-                          </Button>
-                        )}
-                      {!hideOutputButton && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => onViewOutput?.(job?.id)}
-                          disabled={stopPending}
-                          startDecorator={<LogsIcon />}
-                        >
-                          Output
-                        </Button>
-                      )}
-                      {job?.job_data?.eval_images_dir && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => onViewEvalImages?.(job?.id)}
-                          disabled={stopPending}
-                        >
-                          View Eval Images
-                        </Button>
-                      )}
-                      {job?.job_data?.eval_results &&
+                          #{displayJobId}
+                        </Typography>
+                      </td>
+                    </tr>
+                  )}
+                  <tr style={rowOpacityStyle}>
+                    <td
+                      style={{
+                        verticalAlign: 'top',
+                        border: 'none',
+                        width: 240,
+                        minWidth: 140,
+                        maxWidth: 220,
+                        wordBreak: 'break-word',
+                      }}
+                    >
+                      {selectMode &&
+                        job?.job_data?.eval_results &&
                         Array.isArray(job.job_data.eval_results) &&
                         job.job_data.eval_results.length > 0 && (
-                          <Button
+                          <Checkbox
                             size="sm"
-                            variant="plain"
-                            onClick={() => onViewEvalResults?.(job?.id)}
-                            disabled={stopPending}
-                            startDecorator={<FileTextIcon />}
-                          >
-                            Eval Results
-                          </Button>
-                        )}
-                      {(forceArtifactsButtonVisible ||
-                        job?.job_data?.artifacts ||
-                        job?.job_data?.artifacts_dir ||
-                        job?.job_data?.generated_datasets ||
-                        job?.job_data?.models ||
-                        job?.job_data?.has_profiling) &&
-                        !job?.placeholder && (
-                          <Button
-                            size="sm"
-                            variant="plain"
-                            onClick={() =>
-                              onViewAllArtifacts?.(String(job?.id))
+                            checked={selectedJobIds.includes(String(job.id))}
+                            onChange={() =>
+                              onToggleJobSelected?.(String(job.id))
                             }
                             disabled={stopPending}
-                            startDecorator={<ArchiveIcon />}
-                          >
-                            Artifacts
-                          </Button>
+                            sx={{ mr: 1 }}
+                          />
                         )}
-                      {(job?.type === 'SWEEP' || job?.job_data?.sweep_parent) &&
-                        job?.status === 'COMPLETE' && (
+                      {job?.placeholder ? (
+                        <>
+                          <Skeleton variant="text" level="body-xs" width={70} />
+                          <Skeleton
+                            variant="text"
+                            level="title-sm"
+                            width={140}
+                          />
+                          <Skeleton
+                            variant="text"
+                            level="body-xs"
+                            width={120}
+                          />
+                        </>
+                      ) : (
+                        <>
+                          <Typography level="title-sm" fontWeight="bold">
+                            {getJobName(job)}
+                            {job?.job_data?.favorite && (
+                              <>
+                                {' '}
+                                <BookmarkIcon size={16} fill="currentColor" />
+                              </>
+                            )}
+                          </Typography>
+                          {getJobUserEmail(job) && (
+                            <Typography
+                              level="body-xs"
+                              sx={{ color: 'text.tertiary' }}
+                            >
+                              {getJobUserEmail(job)}
+                            </Typography>
+                          )}
+                          {(job?.job_data?.provider_name ||
+                            job?.provider_name) && (
+                            <Typography
+                              level="body-xs"
+                              sx={{ color: 'text.tertiary' }}
+                            >
+                              {job?.job_data?.provider_name ||
+                                job?.provider_name}
+                            </Typography>
+                          )}
+                        </>
+                      )}
+                    </td>
+                    <td style={{ verticalAlign: 'top', border: 'none' }}>
+                      <JobProgress
+                        job={job}
+                        launchProgress={
+                          launchProgressByJobId?.[String(job.id)] ??
+                          job?.job_data?.launch_progress
+                        }
+                        onStopPendingChange={onStopPendingChange}
+                      />
+                      {!job?.placeholder &&
+                        (() => {
+                          const scoreDisplay = getScoreDisplay(
+                            job?.job_data?.score,
+                          );
+                          const descriptionControl =
+                            renderDescriptionControl(job);
+                          if (!scoreDisplay && !descriptionControl) return null;
+                          return (
+                            <Stack
+                              direction="row"
+                              alignItems="center"
+                              gap={0.5}
+                              sx={{ mb: 0.5 }}
+                            >
+                              {descriptionControl}
+                              {scoreDisplay && (
+                                <Tooltip
+                                  title={scoreDisplay.tooltip || ''}
+                                  disableHoverListener={!scoreDisplay.tooltip}
+                                >
+                                  <Chip
+                                    size="sm"
+                                    color="neutral"
+                                    variant="soft"
+                                    sx={{ width: 'fit-content' }}
+                                  >
+                                    {scoreDisplay.label}
+                                  </Chip>
+                                </Tooltip>
+                              )}
+                            </Stack>
+                          );
+                        })()}
+                      <JobCompletionDetails job={job} />
+                      {formatJobConfig(job)}
+                    </td>
+                    <td
+                      style={{
+                        verticalAlign: 'top',
+                        width: 'fit-content',
+                        border: 'none',
+                      }}
+                    >
+                      <Stack
+                        direction="row"
+                        gap={0.5}
+                        flexWrap="wrap"
+                        justifyContent="flex-end"
+                      >
+                        {job?.placeholder && (
+                          <Skeleton
+                            variant="rectangular"
+                            width={100}
+                            height={28}
+                          />
+                        )}
+                        {job?.job_data?.wandb_run_url && (
                           <Button
                             size="sm"
                             variant="plain"
-                            onClick={() => onViewSweepResults?.(job?.id)}
+                            onClick={() => {
+                              window.open(job.job_data.wandb_run_url, '_blank');
+                            }}
                             disabled={stopPending}
                             startDecorator={<LineChartIcon />}
                           >
-                            Sweep Results
+                            W&B Tracking
                           </Button>
                         )}
-                      {job?.job_data?.sweep_output_file && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => onViewSweepOutput?.(job?.id)}
-                          disabled={stopPending}
-                        >
-                          Sweep Output
-                        </Button>
-                      )}
-                      {job?.status === 'INTERACTIVE' &&
-                        job?.job_data?.subtype === 'interactive' && (
-                          <>
+                        {(job?.job_data?.trackio_db_artifact_path ||
+                          job?.job_data?.trackio_project_name) &&
+                          showTrackioForStatus(job?.status) && (
                             <Button
                               size="sm"
                               variant="plain"
-                              onClick={() => onViewInteractive?.(job?.id)}
+                              onClick={() => onViewTrackio?.(String(job?.id))}
                               disabled={stopPending}
+                              startDecorator={<LineChartIcon />}
                             >
-                              Interactive Setup
+                              Trackio
                             </Button>
-                            {!hideOutputButton && (
+                          )}
+                        {!hideOutputButton && (
+                          <Button
+                            size="sm"
+                            variant="plain"
+                            onClick={() => onViewOutput?.(job?.id)}
+                            disabled={stopPending}
+                            startDecorator={<LogsIcon />}
+                          >
+                            Output
+                          </Button>
+                        )}
+                        {job?.job_data?.eval_images_dir && (
+                          <Button
+                            size="sm"
+                            variant="plain"
+                            onClick={() => onViewEvalImages?.(job?.id)}
+                            disabled={stopPending}
+                          >
+                            View Eval Images
+                          </Button>
+                        )}
+                        {job?.job_data?.eval_results &&
+                          Array.isArray(job.job_data.eval_results) &&
+                          job.job_data.eval_results.length > 0 && (
+                            <Button
+                              size="sm"
+                              variant="plain"
+                              onClick={() => onViewEvalResults?.(job?.id)}
+                              disabled={stopPending}
+                              startDecorator={<FileTextIcon />}
+                            >
+                              Eval Results
+                            </Button>
+                          )}
+                        {(forceArtifactsButtonVisible ||
+                          job?.job_data?.artifacts ||
+                          job?.job_data?.artifacts_dir ||
+                          job?.job_data?.generated_datasets ||
+                          job?.job_data?.models ||
+                          job?.job_data?.has_profiling) &&
+                          !job?.placeholder && (
+                            <Button
+                              size="sm"
+                              variant="plain"
+                              onClick={() =>
+                                onViewAllArtifacts?.(String(job?.id))
+                              }
+                              disabled={stopPending}
+                              startDecorator={<ArchiveIcon />}
+                            >
+                              Artifacts
+                            </Button>
+                          )}
+                        {(job?.type === 'SWEEP' ||
+                          job?.job_data?.sweep_parent) &&
+                          job?.status === 'COMPLETE' && (
+                            <Button
+                              size="sm"
+                              variant="plain"
+                              onClick={() => onViewSweepResults?.(job?.id)}
+                              disabled={stopPending}
+                              startDecorator={<LineChartIcon />}
+                            >
+                              Sweep Results
+                            </Button>
+                          )}
+                        {job?.job_data?.sweep_output_file && (
+                          <Button
+                            size="sm"
+                            variant="plain"
+                            onClick={() => onViewSweepOutput?.(job?.id)}
+                            disabled={stopPending}
+                          >
+                            Sweep Output
+                          </Button>
+                        )}
+                        {job?.status === 'INTERACTIVE' &&
+                          job?.job_data?.subtype === 'interactive' && (
+                            <>
                               <Button
                                 size="sm"
                                 variant="plain"
-                                onClick={() => onViewOutput?.(job?.id)}
+                                onClick={() => onViewInteractive?.(job?.id)}
                                 disabled={stopPending}
-                                startDecorator={<LogsIcon />}
                               >
-                                Output
+                                Interactive Setup
                               </Button>
-                            )}
-                          </>
+                              {!hideOutputButton && (
+                                <Button
+                                  size="sm"
+                                  variant="plain"
+                                  onClick={() => onViewOutput?.(job?.id)}
+                                  disabled={stopPending}
+                                  startDecorator={<LogsIcon />}
+                                >
+                                  Output
+                                </Button>
+                              )}
+                            </>
+                          )}
+                        {job?.job_data?.checkpoints && (
+                          <Button
+                            size="sm"
+                            variant="plain"
+                            onClick={() => onViewCheckpoints?.(job?.id)}
+                            disabled={stopPending}
+                            startDecorator={<WaypointsIcon />}
+                          >
+                            Checkpoints
+                          </Button>
                         )}
-                      {job?.job_data?.checkpoints && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => onViewCheckpoints?.(job?.id)}
-                          disabled={stopPending}
-                          startDecorator={<WaypointsIcon />}
-                        >
-                          Checkpoints
-                        </Button>
-                      )}
-                      {showFilesButton && !job?.placeholder && (
-                        <Button
-                          size="sm"
-                          variant="plain"
-                          onClick={() => onViewFileBrowser?.(job?.id)}
-                          disabled={stopPending}
-                          startDecorator={<FolderOpenIcon />}
-                        >
-                          Files
-                        </Button>
-                      )}
-                      {!job?.placeholder && (
-                        <Tooltip title="Copy permalink">
+                        {showFilesButton && !job?.placeholder && (
+                          <Button
+                            size="sm"
+                            variant="plain"
+                            onClick={() => onViewFileBrowser?.(job?.id)}
+                            disabled={stopPending}
+                            startDecorator={<FolderOpenIcon />}
+                          >
+                            Files
+                          </Button>
+                        )}
+                        {!job?.placeholder && (
+                          <Tooltip title="Copy permalink">
+                            <IconButton
+                              size="sm"
+                              variant="plain"
+                              color="neutral"
+                              onClick={() => {
+                                const url =
+                                  window.location.href.split('#')[0] +
+                                  generateJobPermalink(
+                                    experimentInfo?.name ?? '',
+                                    job.id,
+                                  );
+                                navigator.clipboard
+                                  .writeText(url)
+                                  .catch((err) =>
+                                    console.error(
+                                      'Failed to copy permalink:',
+                                      err,
+                                    ),
+                                  );
+                              }}
+                            >
+                              <LinkIcon size={14} />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                        {!job?.placeholder && (
                           <IconButton
                             size="sm"
                             variant="plain"
-                            color="neutral"
-                            onClick={() => {
-                              const url =
-                                window.location.href.split('#')[0] +
-                                generateJobPermalink(
-                                  experimentInfo?.name ?? '',
-                                  job.id,
-                                );
-                              navigator.clipboard
-                                .writeText(url)
-                                .catch((err) =>
-                                  console.error(
-                                    'Failed to copy permalink:',
-                                    err,
-                                  ),
-                                );
-                            }}
-                          >
-                            <LinkIcon size={14} />
-                          </IconButton>
-                        </Tooltip>
-                      )}
-                      {!job?.placeholder && (
-                        <IconButton
-                          size="sm"
-                          variant="plain"
-                          disabled={
-                            stopPending ||
-                            !isDeletableJobRecordStatus(job?.status)
-                          }
-                          onClick={() => {
-                            if (!isDeletableJobRecordStatus(job?.status)) {
-                              return;
+                            disabled={
+                              stopPending ||
+                              !isDeletableJobRecordStatus(job?.status)
                             }
-                            onDeleteJob?.(job.id);
-                          }}
-                        >
-                          <Trash2Icon style={{ cursor: 'pointer' }} />
-                        </IconButton>
-                      )}
-                      {!job?.placeholder && (
-                        <Dropdown>
-                          <MenuButton
-                            slots={{ root: IconButton }}
-                            slotProps={{
-                              root: {
-                                variant: 'plain',
-                                color: 'neutral',
-                                size: 'sm',
-                              },
+                            onClick={() => {
+                              if (!isDeletableJobRecordStatus(job?.status)) {
+                                return;
+                              }
+                              onDeleteJob?.(job.id);
                             }}
-                            sx={{ minWidth: 0 }}
-                            disabled={stopPending}
                           >
-                            <MoreVerticalIcon size={16} />
-                          </MenuButton>
-                          <Menu>
-                            <MenuItem
-                              onClick={() =>
-                                onToggleFavorite?.(
-                                  String(job.id),
-                                  !!job?.job_data?.favorite,
-                                )
-                              }
+                            <Trash2Icon style={{ cursor: 'pointer' }} />
+                          </IconButton>
+                        )}
+                        {!job?.placeholder && (
+                          <Dropdown>
+                            <MenuButton
+                              slots={{ root: IconButton }}
+                              slotProps={{
+                                root: {
+                                  variant: 'plain',
+                                  color: 'neutral',
+                                  size: 'sm',
+                                },
+                              }}
+                              sx={{ minWidth: 0 }}
+                              disabled={stopPending}
                             >
-                              {job?.job_data?.favorite ? (
-                                <>
-                                  <BookmarkIcon size={16} fill="currentColor" />{' '}
-                                  Unfavorite
-                                </>
-                              ) : (
-                                <>
-                                  <BookmarkIcon size={16} /> Favorite
-                                </>
-                              )}
-                            </MenuItem>
-                            <MenuItem
-                              onClick={() =>
-                                onToggleHidden?.(
-                                  String(job.id),
-                                  !!job?.job_data?.hidden,
-                                )
-                              }
-                            >
-                              {job?.job_data?.hidden ? (
-                                <>
-                                  <EyeIcon size={16} /> Unhide
-                                </>
-                              ) : (
-                                <>
-                                  <EyeOffIcon size={16} /> Hide
-                                </>
-                              )}
-                            </MenuItem>
-                            <MenuItem
-                              onClick={() =>
-                                onToggleDiscard?.(
-                                  String(job.id),
-                                  parseDiscardValue(
-                                    job?.job_data?.score?.discard,
-                                  ),
-                                )
-                              }
-                            >
-                              {parseDiscardValue(
-                                job?.job_data?.score?.discard,
-                              ) ? (
-                                <>
-                                  <BanIcon size={16} /> Unmark discard
-                                </>
-                              ) : (
-                                <>
-                                  <BanIcon size={16} /> Mark discard
-                                </>
-                              )}
-                            </MenuItem>
-                          </Menu>
-                        </Dropdown>
-                      )}
-                    </Stack>
-                  </td>
-                </tr>
+                              <MoreVerticalIcon size={16} />
+                            </MenuButton>
+                            <Menu>
+                              <MenuItem
+                                onClick={() =>
+                                  onToggleFavorite?.(
+                                    String(job.id),
+                                    !!job?.job_data?.favorite,
+                                  )
+                                }
+                              >
+                                {job?.job_data?.favorite ? (
+                                  <>
+                                    <BookmarkIcon
+                                      size={16}
+                                      fill="currentColor"
+                                    />{' '}
+                                    Unfavorite
+                                  </>
+                                ) : (
+                                  <>
+                                    <BookmarkIcon size={16} /> Favorite
+                                  </>
+                                )}
+                              </MenuItem>
+                              <MenuItem
+                                onClick={() =>
+                                  onToggleHidden?.(
+                                    String(job.id),
+                                    !!job?.job_data?.hidden,
+                                  )
+                                }
+                              >
+                                {job?.job_data?.hidden ? (
+                                  <>
+                                    <EyeIcon size={16} /> Unhide
+                                  </>
+                                ) : (
+                                  <>
+                                    <EyeOffIcon size={16} /> Hide
+                                  </>
+                                )}
+                              </MenuItem>
+                              <MenuItem
+                                onClick={() =>
+                                  onToggleDiscard?.(
+                                    String(job.id),
+                                    parseDiscardValue(
+                                      job?.job_data?.score?.discard,
+                                    ),
+                                  )
+                                }
+                              >
+                                {parseDiscardValue(
+                                  job?.job_data?.score?.discard,
+                                ) ? (
+                                  <>
+                                    <BanIcon size={16} /> Unmark discard
+                                  </>
+                                ) : (
+                                  <>
+                                    <BanIcon size={16} /> Mark discard
+                                  </>
+                                )}
+                              </MenuItem>
+                            </Menu>
+                          </Dropdown>
+                        )}
+                      </Stack>
+                    </td>
+                  </tr>
+                </React.Fragment>
               );
             })
           ) : (


### PR DESCRIPTION
## Summary
- Move Job ID into its own header row above each job, separated by a divider line spanning all columns
- Remove the "Job ID / Status / Logs" column header
- Constrain the first column to a fixed 240px width with word-break wrapping so it doesn't stretch or squeeze
- Extract success/failure/error message out of `JobProgress` into a new `JobCompletionDetails` component so the score & description stack can render above the completion details

## Test plan
- [ ] Open an experiment's job list and confirm each job shows the Job ID floating above with a horizontal divider
- [ ] Verify the table no longer renders the "Job ID / Status / Logs" header row
- [ ] Confirm the first column stays at 240px regardless of title length (long titles wrap)
- [ ] For completed jobs, confirm the order in the status cell is: status chip + date + duration → score/description stack → Success/Failure message → sweep config
- [ ] Verify hidden/stopping job opacity styling still applies to both the Job ID row and content row

Before:
<img width="985" height="652" alt="Screenshot 2026-05-07 at 11 29 30 AM" src="https://github.com/user-attachments/assets/adba5658-2501-4656-bb9e-c15501d8d6f0" />


After:
<img width="1012" height="644" alt="Screenshot 2026-05-07 at 11 29 06 AM" src="https://github.com/user-attachments/assets/440c0759-06cf-4241-8ed6-1e1e7649ee18" />


