### PR TITLE
Let lab login confirm or edit the server URL

### DIFF
--- a/cli/src/transformerlab_cli/commands/login.py
+++ b/cli/src/transformerlab_cli/commands/login.py
@@ -20,10 +20,8 @@ def login(
 
     # Prompt for server URL, showing current value as default so user can confirm or change it
     if not server:
-        server = config.get("server")
-
-    if not server:
-        server = typer.prompt("Please enter the server URL", default=DEFAULT_BASE_URL)
+        current_server = config.get("server") or DEFAULT_BASE_URL
+        server = typer.prompt("Server URL", default=current_server)
 
     # Validate and set server URL
     from transformerlab_cli.util.config import _validate_url
@@ -40,9 +38,6 @@ def login(
     # Save server to config if it changed
     if config.get("server") != server:
         set_config("server", server)
-
-    # Show current server URL
-    console.print(f"\n[label]Current server:[/label] [value]{server}[/value]")
 
     # Ask for API key if not provided
     if not api_key:

--- a/cli/tests/commands/test_login.py
+++ b/cli/tests/commands/test_login.py
@@ -32,7 +32,7 @@ def test_logout_help():
 @patch("transformerlab_cli.commands.login.load_config", return_value={"server": "http://localhost:8338"})
 def test_login_success(_mock_load, _mock_set, _mock_set_key, _mock_user, _mock_teams):
     """Test successful login flow."""
-    result = runner.invoke(app, ["login", "--api-key", "test-key"])
+    result = runner.invoke(app, ["login", "--server", "http://localhost:8338", "--api-key", "test-key"])
     assert result.exit_code == 0
     assert "Login successful" in result.output
 
@@ -41,7 +41,7 @@ def test_login_success(_mock_load, _mock_set, _mock_set_key, _mock_user, _mock_t
 @patch("transformerlab_cli.commands.login.load_config", return_value={"server": "http://localhost:8338"})
 def test_login_failure(_mock_load, _mock_set_key):
     """Test login failure."""
-    result = runner.invoke(app, ["login", "--api-key", "bad-key"])
+    result = runner.invoke(app, ["login", "--server", "http://localhost:8338", "--api-key", "bad-key"])
     assert result.exit_code == 1
 
 


### PR DESCRIPTION
## Summary
- `lab login` now always prompts for the server URL with the currently configured server as the default. Press Enter to keep it, or type a new URL to change it.
- Previously, if a server was already saved, login silently reused it with no inline way to edit — users had to run `lab config server <URL>` separately.
- Removes the now-redundant `Current server: …` line that printed right after the prompt.

## Test plan
- [x] `cd cli && python -m pytest tests/commands/test_login.py -v` (all 6 tests pass)
- [x] `ruff check` and `ruff format --check` on the changed file
- [ ] Manual: run `lab login`, confirm the prompt shows the current server as default and accepts both Enter (confirm) and a new URL (edit)
- [ ] Manual: run `lab login --server <URL>` and confirm the prompt is skipped