### PR TITLE
Remove legacy code to handle old numeric experiment IDs

### DIFF
--- a/api/localprovider_pyproject.toml
+++ b/api/localprovider_pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "soundfile==0.13.1",
   "tensorboardX==2.6.2.2",
   "timm==1.0.15",
-  "transformerlab==0.1.35",
+  "transformerlab==0.1.36",
   "transformerlab-inference==0.2.52",
   "transformers==4.57.1",
   "wandb==0.23.1",

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "python-dotenv==1.1.0",
   "python-multipart==0.0.20",
   "sqlalchemy[asyncio]==2.0.40",
-  "transformerlab==0.1.35",
+  "transformerlab==0.1.36",
   "transformerlab-inference==0.2.52",
   "uvicorn==0.35.0",
   "watchfiles==1.0.5",

--- a/lab-sdk/pyproject.toml
+++ b/lab-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab"
-version = "0.1.35"
+version = "0.1.36"
 description = "Python SDK for Transformer Lab"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/lab-sdk/src/lab/task.py
+++ b/lab-sdk/src/lab/task.py
@@ -69,33 +69,7 @@ class Task(BaseLabResource):
 
     async def get_metadata(self):
         """Get task metadata"""
-        data = await self.get_json_data()
-
-        # Fix experiment_id if it's a digit - convert to experiment name
-        if data.get("experiment_id") and str(data["experiment_id"]).isdigit():
-            experiment_name = await self._get_experiment_name_by_id(data["experiment_id"])
-            if experiment_name:
-                data["experiment_id"] = experiment_name
-                # Save the corrected data back to the file
-                await self._set_json_data(data)
-
-        return data
-
-    async def _get_experiment_name_by_id(self, experiment_id):
-        """Get experiment name by ID, return None if not found"""
-        try:
-            from .experiment import Experiment
-
-            # Get all experiments and search for one with matching db_experiment_id
-            all_experiments = await Experiment.get_all()
-            for exp_data in all_experiments:
-                if exp_data.get("db_experiment_id") == int(experiment_id):
-                    return exp_data.get("name", experiment_id)
-
-            # If no match found, return the original ID
-            return experiment_id
-        except Exception:
-            return experiment_id
+        return await self.get_json_data()
 
     @staticmethod
     async def list_all():

--- a/lab-sdk/src/lab/task_template.py
+++ b/lab-sdk/src/lab/task_template.py
@@ -149,33 +149,7 @@ class TaskTemplate(BaseLabResource):
 
     async def get_metadata(self):
         """Get task metadata"""
-        data = await self.get_json_data()
-
-        # Fix experiment_id if it's a digit - convert to experiment name
-        if data.get("experiment_id") and str(data["experiment_id"]).isdigit():
-            experiment_name = await self._get_experiment_name_by_id(data["experiment_id"])
-            if experiment_name:
-                data["experiment_id"] = experiment_name
-                # Save the corrected data back to the file
-                await self._set_json_data(data)
-
-        return data
-
-    async def _get_experiment_name_by_id(self, experiment_id):
-        """Get experiment name by ID, return None if not found"""
-        try:
-            from .experiment import Experiment
-
-            # Get all experiments and search for one with matching db_experiment_id
-            all_experiments = await Experiment.get_all()
-            for exp_data in all_experiments:
-                if exp_data.get("db_experiment_id") == int(experiment_id):
-                    return exp_data.get("name", experiment_id)
-
-            # If no match found, return the original ID
-            return experiment_id
-        except Exception:
-            return experiment_id
+        return await self.get_json_data()
 
     @staticmethod
     async def list_all():


### PR DESCRIPTION
This removes a fall back where we try to handle old experiments that were made in the database with a numeric ID.  I think we can/should delete this code because:

1. It is a trap door that can make getting an experiment slow, and now we have new parallelized code (like task list load) that could potentially hit this en masse.
2. We deleted the migration we used to have for this. So I think we've given up on supporting migrating anybody with a 2025 workspace to the new platform.