### PR TITLE
Fix lab task queue --no-interactive to honor is_default provider

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.49"
+version = "0.0.50"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/task.py
+++ b/cli/src/transformerlab_cli/commands/task.py
@@ -1078,7 +1078,7 @@ def queue_task(
         task_provider_id = task.get("provider_id")
         provider = next((p for p in providers if p.get("id") == task_provider_id), None)
         if not provider:
-            provider = providers[0]
+            provider = next((p for p in providers if p.get("is_default")), providers[0])
         console.print(f"[dim]Using provider: {provider.get('name')}[/dim]")
 
     parameters = task.get("parameters", {})

--- a/cli/tests/commands/test_task.py
+++ b/cli/tests/commands/test_task.py
@@ -126,6 +126,25 @@ def test_task_queue_sends_description(_mock_exp, _mock_get, _mock_providers, moc
     assert body["description"] == "hypothesis: larger batch"
 
 
+SAMPLE_PROVIDERS_MULTI = [
+    {"id": "p_other", "name": "Runpod", "is_default": False},
+    {"id": "p_default", "name": "Local", "is_default": True},
+]
+
+
+@patch("transformerlab_cli.commands.task.api.post_json", return_value=_mock_resp({"job_id": "j1"}))
+@patch("transformerlab_cli.commands.task.fetch_providers", return_value=SAMPLE_PROVIDERS_MULTI)
+@patch("transformerlab_cli.commands.task.api.get", return_value=_mock_resp(SAMPLE_TASK))
+@patch("transformerlab_cli.commands.task.require_current_experiment", return_value="exp1")
+def test_task_queue_no_interactive_picks_is_default_provider(_mock_exp, _mock_get, _mock_providers, mock_post):
+    """When the task has no provider_id pinned, --no-interactive must pick the
+    provider marked is_default=True, not just providers[0]."""
+    result = runner.invoke(app, ["task", "queue", "t1", "--no-interactive", "-m", "x"])
+    assert result.exit_code == 0, result.output
+    path, _body = mock_post.call_args.args
+    assert "p_default" in path, f"expected launch on default provider, got path: {path}"
+
+
 SAMPLE_TASK_WITH_PARAMS = {
     "id": "t1",
     "name": "finetune",

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.49"
+version = "0.0.50"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- `--no-interactive` queue path was falling back to `providers[0]` (newest by `created_at DESC`) when the task had no `provider_id`, silently ignoring `is_default`. Now picks the default-marked provider first, falling back to `providers[0]` only if none is marked.
- Mirrors existing server-side logic in `api/transformerlab/routers/experiment/task.py:710`.
- Adds regression test.