### PR TITLE
installer: use grep instead of rg for DGX Spark detection

### DIFF
--- a/api/local_provider_conda_install.sh
+++ b/api/local_provider_conda_install.sh
@@ -94,7 +94,7 @@ install_local_provider_dependencies() {
     CUDA_INDEX="cu128"
     if [ "${TLAB_FORCE_CUDA13:-}" = "1" ] || [ "${TLAB_FORCE_CUDA13:-}" = "true" ]; then
       CUDA_INDEX="cu130"
-    elif [ -r /etc/dgx-release ] && rg -iq 'DGX Spark' /etc/dgx-release; then
+    elif [ -r /etc/dgx-release ] && grep -qi 'DGX Spark' /etc/dgx-release; then
       CUDA_INDEX="cu130"
     fi
 


### PR DESCRIPTION
because rg might not necessarily be installed on a fresh system + the parallel code in api/install.sh:452 already uses grep for the same check