### PR TITLE
Add CLI skill rule: confirm experiment before queueing a task

### DIFF
--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -591,9 +591,10 @@ Provider configs (`api_token`, `api_key`, `ssh_key_path`) contain secrets. If th
 8. **Never use `task interactive`** unless the user specifically requests an interactive session
 9. **`job task-logs --follow`** streams continuously and blocks until the job finishes — use when the user wants real-time monitoring
 10. **Never use the deprecated `lab job logs`** — see the "Job logs: three real commands" section below.
-11. **After queuing a task, ASK the user if they'd like you to watch the logs.** Don't start streaming or polling automatically — jobs can take minutes to hours, and `--follow` blocks. Report the Job ID and ask: "Want me to watch the logs and report back?"
-12. **Never create API keys programmatically** — if auth fails, ask the user to provide an API key from the web UI
-13. **Always pass `--description/-m` when queuing a task. Generate it yourself — never ask the user.** See "Always write a run description" below.
+11. **Before queuing a task, CONFIRM the experiment with the user.** Run `lab config` to read the current default and `lab --format json experiment list` to verify it exists, then ask: "I'm about to queue this under experiment `<name>` (your current default). OK, or pick another?" Show 2–3 alternatives from `experiment list` if the current one looks stale or missing. Skip the confirmation only when the user has already named the experiment in this turn.
+12. **After queuing a task, ASK the user if they'd like you to watch the logs.** Don't start streaming or polling automatically — jobs can take minutes to hours, and `--follow` blocks. Report the Job ID and ask: "Want me to watch the logs and report back?"
+13. **Never create API keys programmatically** — if auth fails, ask the user to provide an API key from the web UI
+14. **Always pass `--description/-m` when queuing a task. Generate it yourself — never ask the user.** See "Always write a run description" below.
 
 ### Always write a run description
 


### PR DESCRIPTION
## Summary
- Adds rule `#11` to `.agents/skills/transformerlab-cli/SKILL.md`: before `lab task queue`, the agent reads `lab config` + `lab --format json experiment list`, confirms the target experiment with the user, and offers alternatives if the current default looks stale or missing.
- Skip-confirmation carve-out: when the user has already named an experiment this turn, the agent doesn't re-prompt.
- Subsequent rules renumbered (12–14).

Context: see #2029 — server currently accepts queues against non-existent `experiment_id`s, producing orphan jobs invisible in the UI. This rule keeps agents safe even before the server fix lands.

## Test plan
- [ ] Re-run a hello-world queue flow with the updated skill loaded; verify the agent reads `experiment list`, surfaces the current default, and prompts before submitting.
- [ ] Confirm the skip-confirmation carve-out triggers when the user names an experiment in the same turn.