### PR TITLE
Remove all backward compatibility code in API+CLI+SDK

### DIFF
--- a/api/localprovider_pyproject.toml
+++ b/api/localprovider_pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "soundfile==0.13.1",
   "tensorboardX==2.6.2.2",
   "timm==1.0.15",
-  "transformerlab==0.1.37",
+  "transformerlab==0.1.38",
   "transformerlab-inference==0.2.52",
   "transformers==4.57.1",
   "wandb==0.23.1",

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "python-dotenv==1.1.0",
   "python-multipart==0.0.20",
   "sqlalchemy[asyncio]==2.0.40",
-  "transformerlab==0.1.37",
+  "transformerlab==0.1.38",
   "transformerlab-inference==0.2.52",
   "uvicorn==0.35.0",
   "watchfiles==1.0.5",

--- a/api/test/api/test_model_service.py
+++ b/api/test/api/test_model_service.py
@@ -66,29 +66,6 @@ async def test_list_installed_models_non_hf_with_model_filename(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_list_installed_models_non_hf_directory_model(monkeypatch):
-    """A non-HuggingFace directory-based model (no model_filename) with files is marked local."""
-    from transformerlab.services import model_service
-
-    model = make_model("MyOrg/dir-model", source="local", model_filename="")
-    monkeypatch.setattr(model_service.ModelService, "list_all", AsyncMock(return_value=[model]))
-    monkeypatch.setattr(model_service, "get_models_dir", AsyncMock(return_value="/models"))
-
-    monkeypatch.setattr(model_service.storage, "join", lambda *parts: "/".join(parts))
-    monkeypatch.setattr(model_service.storage, "exists", AsyncMock(return_value=True))
-    monkeypatch.setattr(model_service.storage, "isdir", AsyncMock(return_value=True))
-    monkeypatch.setattr(
-        model_service.storage,
-        "ls",
-        AsyncMock(return_value=["/models/dir-model/weights.bin", "/models/dir-model/index.json"]),
-    )
-
-    result = await model_service.list_installed_models()
-    assert len(result) == 1
-    assert result[0]["stored_in_filesystem"] is True
-
-
-@pytest.mark.asyncio
 async def test_list_installed_models_non_hf_directory_only_index(monkeypatch):
     """A non-HuggingFace directory with only index.json is NOT marked as local."""
     from transformerlab.services import model_service

--- a/api/transformerlab/routers/experiment/task.py
+++ b/api/transformerlab/routers/experiment/task.py
@@ -1166,10 +1166,10 @@ async def import_task_from_gallery(
             interactive_type = gallery_entry.get("interactive_type") or gallery_entry.get("id") or "custom"
             interactive_gallery_id = gallery_entry.get("id")
 
-            # Resolve task setup/command from the gallery entry's source:
+            # Resolve task setup/run from the gallery entry's source:
             # 1. github_repo_url + github_repo_dir -> fetch task.yaml from GitHub
             # 2. local_task_dir -> read task.yaml from local filesystem
-            # 3. inline setup/command fields on the gallery entry
+            # 3. inline setup/run fields on the gallery entry
             github_repo_url = gallery_entry.get("github_repo_url")
             github_repo_dir = gallery_entry.get("github_repo_dir")
             github_repo_branch = gallery_entry.get("github_repo_branch")
@@ -1197,7 +1197,7 @@ async def import_task_from_gallery(
                 "plugin": "remote_orchestrator",
                 "experiment_id": experimentId,
                 "cluster_name": task_name,
-                "run": source_yaml_data.get("run", source_yaml_data.get("command", "")),
+                "run": source_yaml_data.get("run", ""),
                 "setup": source_yaml_data.get("setup", "") or gallery_entry.get("setup", ""),
                 "interactive_type": interactive_type,
                 "subtype": "interactive",

--- a/api/transformerlab/services/model_service.py
+++ b/api/transformerlab/services/model_service.py
@@ -18,13 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 async def list_installed_models() -> list:
-    """
-    TODO: Clean this up to remove legacy code.
-
-    Legacy function for getting a list of models from all sources.
-
-    Check both the filesystem and workspace for models.
-    """
+    """Get a list of installed models with filesystem metadata attached."""
 
     # Use SDK to get all models from the filesystem
     models = await ModelService.list_all()
@@ -37,7 +31,6 @@ async def list_installed_models() -> list:
         # model_filename can be:
         # - A filename (e.g., "model.gguf") for file-based models
         # - "." for directory-based models (indicates the directory itself)
-        # - Empty string for legacy models (should be treated as directory-based)
         model_filename = model.get("json_data", {}).get("model_filename", "")
         is_huggingface = model.get("json_data", {}).get("source", "") == "huggingface"
         has_model_filename = model_filename != ""
@@ -51,27 +44,12 @@ async def list_installed_models() -> list:
             # Remove the Starting TransformerLab/ prefix to handle the save_transformerlab_model function
             potential_path = storage.join(models_dir, secure_filename("/".join(model_id.split("/")[1:])))
 
-        # Check if model should be considered local:
-        # 1. If it has a model_filename set (and is not a HuggingFace model, OR is a HuggingFace model stored locally), OR
-        # 2. If the directory exists and has files other than index.json
+        # A model is considered local if model_filename is set (non-HF) or if the
+        # HF model has model_filename and the file/directory exists locally.
         is_local_model = False
         if not is_huggingface:
-            # For non-HuggingFace models, check if it has model_filename or files in directory
             if has_model_filename:
                 is_local_model = True
-            elif await storage.exists(potential_path) and await storage.isdir(potential_path):
-                # Check if directory has files other than index.json
-                try:
-                    files = await storage.ls(potential_path, detail=False)
-                    # Extract basenames from full paths returned by storage.ls()
-                    file_basenames = [posixpath.basename(f.rstrip("/")) for f in files]
-                    # Filter out index.json and other metadata files
-                    model_files = [f for f in file_basenames if f not in ["index.json", "_tlab_provenance.json"]]
-                    if model_files:
-                        is_local_model = True
-                except (OSError, PermissionError):
-                    # If we can't read the directory, skip it
-                    pass
         elif is_huggingface and has_model_filename:
             # For HuggingFace models, if they have a model_filename and the file/directory exists locally,
             # treat them as stored locally (e.g., downloaded GGUF files)
@@ -128,9 +106,6 @@ async def list_installed_models() -> list:
             elif model_filename:
                 # Other file-based models - append the filename
                 model["local_path"] = storage.join(model["local_path"], model_filename)
-            else:
-                # Legacy model without model_filename but with files - use directory path
-                model["local_path"] = model["local_path"]
 
     return models
 

--- a/api/transformerlab/services/task_service.py
+++ b/api/transformerlab/services/task_service.py
@@ -22,30 +22,6 @@ _PROTECTED_METADATA_KEYS = frozenset({"id", "experiment_id", "type", "plugin", "
 DEFAULT_TASK_YAML = 'name: my-task\nresources:\n  cpus: 2\n  memory: 4\nrun: "echo hello"'
 
 
-def _normalize_legacy_command(task: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-    """
-    Backward compatibility helper: some legacy tasks may still store their
-    entrypoint under the key "command" instead of "run". To avoid breaking
-    those when launching or exporting, expose "run" on read if it is missing
-    or empty but "command" is present. New code should only write "run".
-    """
-    if not task:
-        return task
-
-    # If run is already set and truthy, do nothing.
-    if task.get("run"):
-        return task
-
-    legacy_command = task.get("command")
-    if not legacy_command:
-        return task
-
-    # Return a shallow copy with run populated so callers always see run.
-    normalized = dict(task)
-    normalized["run"] = legacy_command
-    return normalized
-
-
 class TaskService:
     """Service for managing tasks using filesystem storage"""
 
@@ -54,35 +30,29 @@ class TaskService:
 
     async def task_get_all(self) -> List[Dict[str, Any]]:
         """Get all tasks from filesystem"""
-        tasks = await self.task_service.list_all()
-        return [_normalize_legacy_command(t) or t for t in tasks]
+        return await self.task_service.list_all()
 
     async def task_get_by_id(self, task_id: str, experiment_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """Get a specific task by ID"""
-        task = await self.task_service.get_by_id(task_id, experiment_id=experiment_id)
-        return _normalize_legacy_command(task)
+        return await self.task_service.get_by_id(task_id, experiment_id=experiment_id)
 
     async def task_get_by_type(self, task_type: str) -> List[Dict[str, Any]]:
         """Get all tasks of a specific type"""
-        tasks = await self.task_service.list_by_type(task_type)
-        return [_normalize_legacy_command(t) or t for t in tasks]
+        return await self.task_service.list_by_type(task_type)
 
     async def task_get_by_experiment(self, experiment_id: str) -> List[Dict[str, Any]]:
         """Get all tasks for a specific experiment"""
-        tasks = await self.task_service.list_by_experiment(experiment_id)
-        return [_normalize_legacy_command(t) or t for t in tasks]
+        return await self.task_service.list_by_experiment(experiment_id)
 
     async def task_get_by_type_in_experiment(self, task_type: str, experiment_id: str) -> List[Dict[str, Any]]:
         """Get all tasks of a specific type in a specific experiment"""
-        tasks = await self.task_service.list_by_type_in_experiment(task_type, experiment_id)
-        return [_normalize_legacy_command(t) or t for t in tasks]
+        return await self.task_service.list_by_type_in_experiment(task_type, experiment_id)
 
     async def task_get_by_subtype_in_experiment(
         self, experiment_id: str, subtype: str, task_type: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         """Get all tasks for a specific experiment filtered by subtype and optionally by type"""
-        tasks = await self.task_service.list_by_subtype_in_experiment(experiment_id, subtype, task_type)
-        return [_normalize_legacy_command(t) or t for t in tasks]
+        return await self.task_service.list_by_subtype_in_experiment(experiment_id, subtype, task_type)
 
     async def add_task(self, task_data: Dict[str, Any]) -> str:
         """Create a new task - all fields stored directly in JSON"""

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.50"
+version = "0.0.51"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/task.py
+++ b/cli/src/transformerlab_cli/commands/task.py
@@ -273,7 +273,13 @@ def _upload_path_to_server(path_to_upload: str) -> str:
             console.print(f"[error]Error:[/error] Upload init failed ({init_resp.status_code})")
             raise typer.Exit(1)
 
-        upload_id = init_resp.json()["upload_id"]
+        try:
+            upload_id = init_resp.json().get("upload_id")
+        except ValueError:
+            upload_id = None
+        if not upload_id:
+            console.print("[error]Error:[/error] Upload init returned no upload_id.")
+            raise typer.Exit(1)
         status_resp = api.get(f"/upload/{upload_id}/status")
         already_received: set[int] = set(
             status_resp.json().get("received", []) if status_resp.status_code == 200 else []

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.50"
+version = "0.0.51"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/lab-sdk/pyproject.toml
+++ b/lab-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab"
-version = "0.1.37"
+version = "0.1.38"
 description = "Python SDK for Transformer Lab"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/lab-sdk/src/lab/lab_facade.py
+++ b/lab-sdk/src/lab/lab_facade.py
@@ -156,39 +156,24 @@ class Lab:
 
                 self._trackio_available = True
                 existing_run = context_vars.current_run.get()
-                if existing_run is None:
-                    if trackio_project_name_env:
-                        # Shared project: metrics dir should be set by compute launch (TRACKIO_DIR) before
-                        # trackio is imported; fall back for local/scripts without a provider.
-                        job_id_env = os.environ.get("_TFL_JOB_ID", "unknown")
-                        trackio_dir = (os.environ.get("TRACKIO_DIR") or "").strip()
-                        if not trackio_dir:
-                            trackio_dir = dirs.get_trackio_dir(job_id_env)
-                        os.makedirs(trackio_dir, exist_ok=True)
-                        os.environ.setdefault("TRACKIO_DIR", trackio_dir)
-                        _run_async(
-                            self._seed_trackio_shared_path_async(
-                                experiment_id or "", trackio_project_name_env, trackio_dir
-                            )
-                        )
-                        trackio.init(
-                            project=trackio_project_name_env,
-                            name=trackio_run_name_env or f"job-{job_id_env}",
-                        )
-                        self._trackio_managed = True
-                        logger.info(f"📊 Trackio auto-init enabled for shared project '{trackio_project_name_env}'")
-                    else:
-                        # Legacy: per-job project name (still avoid Trackio default under HF cache).
-                        job_id_env = os.environ.get("_TFL_JOB_ID", "unknown")
-                        trackio_dir = (os.environ.get("TRACKIO_DIR") or "").strip()
-                        if not trackio_dir:
-                            trackio_dir = dirs.get_trackio_dir(job_id_env)
-                        os.makedirs(trackio_dir, exist_ok=True)
-                        os.environ.setdefault("TRACKIO_DIR", trackio_dir)
-                        project_name = str(experiment_id or "TransformerLab")
-                        trackio.init(project=project_name)
-                        self._trackio_managed = True
-                        logger.info(f"📊 Trackio auto-init enabled for project '{project_name}'")
+                if existing_run is None and trackio_project_name_env:
+                    # Shared project: metrics dir should be set by compute launch (TRACKIO_DIR) before
+                    # trackio is imported; fall back for local/scripts without a provider.
+                    job_id_env = os.environ.get("_TFL_JOB_ID", "unknown")
+                    trackio_dir = (os.environ.get("TRACKIO_DIR") or "").strip()
+                    if not trackio_dir:
+                        trackio_dir = dirs.get_trackio_dir(job_id_env)
+                    os.makedirs(trackio_dir, exist_ok=True)
+                    os.environ.setdefault("TRACKIO_DIR", trackio_dir)
+                    _run_async(
+                        self._seed_trackio_shared_path_async(experiment_id or "", trackio_project_name_env, trackio_dir)
+                    )
+                    trackio.init(
+                        project=trackio_project_name_env,
+                        name=trackio_run_name_env or f"job-{job_id_env}",
+                    )
+                    self._trackio_managed = True
+                    logger.info(f"📊 Trackio auto-init enabled for shared project '{trackio_project_name_env}'")
             except Exception:
                 # Silently ignore any Trackio issues; lab core behavior must not be affected
                 self._trackio_available = False
@@ -1701,27 +1686,28 @@ class Lab:
             _run_async(self._job.update_job_data_field("wandb_run_url", clean_url))
             logger.info(f"📊 Captured wandb run URL: {clean_url}")
 
-    def capture_trackio_metadata(self, db_path: str, project: Optional[str] = None) -> str:
+    def capture_trackio_metadata(self, db_path: str) -> str:
         """
-        Save a local Trackio metrics directory or database file into this job's artifacts and
-        record its location in job_data.
+        Save a local Trackio metrics directory or database file into the shared
+        trackio_runs project directory for this experiment.
 
-        This is a sync wrapper around the async implementation.
+        This is a sync wrapper around the async implementation. Requires
+        TLAB_TRACKIO_PROJECT_NAME to be set.
 
         Args:
             db_path: Path to the Trackio directory (or single DB file) on the current machine.
-            project: Optional Trackio project name to record for convenience when launching dashboards.
 
         Returns:
-            The destination path under this job's artifacts directory where the Trackio data was saved.
+            The destination path where the Trackio data was saved.
         """
-        return _run_async(self.async_capture_trackio_metadata(db_path, project))
+        return _run_async(self.async_capture_trackio_metadata(db_path))
 
-    async def async_capture_trackio_metadata(self, db_path: str, project: Optional[str] = None) -> str:
+    async def async_capture_trackio_metadata(self, db_path: str) -> str:
         """
         Async implementation of capture_trackio_metadata().
-        When TLAB_TRACKIO_PROJECT_NAME is set (shared project), copies to trackio_runs/{experiment_id}/{project_name}/
-        and does not write trackio_db_artifact_path (dashboard derives path).
+        Requires TLAB_TRACKIO_PROJECT_NAME (shared project); copies to
+        trackio_runs/{experiment_id}/{project_name}/ and does not write
+        trackio_db_artifact_path (dashboard derives path).
         """
         self._ensure_initialized()
 
@@ -1734,47 +1720,29 @@ class Lab:
             raise FileNotFoundError(f"Trackio path does not exist: {src}")
 
         trackio_project_name_env = (os.environ.get("TLAB_TRACKIO_PROJECT_NAME") or "").strip()
-        if trackio_project_name_env and self._experiment is not None:
-            # Shared project: copy to trackio_runs/{experiment_id}/{project_name}/ (merge, do not rm)
-            workspace_dir = await dirs.get_workspace_dir()
-            trackio_dir = storage.join(
-                workspace_dir,
-                "trackio_runs",
-                secure_filename(str(self._experiment.id)),
-                secure_filename(trackio_project_name_env),
+        if not (trackio_project_name_env and self._experiment is not None):
+            raise RuntimeError(
+                "TLAB_TRACKIO_PROJECT_NAME env var and an experiment context are required to capture Trackio metadata."
             )
-            await storage.makedirs(trackio_dir, exist_ok=True)
-            if os.path.isdir(src):
-                await storage.copy_dir(src, trackio_dir)
-            else:
-                base_name = posixpath.basename(src)
-                dest_file = storage.join(trackio_dir, base_name)
-                await storage.copy_file(src, dest_file)
-            # Do not write trackio_db_artifact_path; dashboard derives from trackio_project_name
-            logger.info(f"📊 Saved Trackio metrics to shared project: {trackio_dir}")
-            return trackio_dir
+
+        # Shared project: copy to trackio_runs/{experiment_id}/{project_name}/ (merge, do not rm)
+        workspace_dir = await dirs.get_workspace_dir()
+        trackio_dir = storage.join(
+            workspace_dir,
+            "trackio_runs",
+            secure_filename(str(self._experiment.id)),
+            secure_filename(trackio_project_name_env),
+        )
+        await storage.makedirs(trackio_dir, exist_ok=True)
+        if os.path.isdir(src):
+            await storage.copy_dir(src, trackio_dir)
         else:
-            # Legacy: per-job artifacts/trackio
-            artifacts_dir = await self._job.get_artifacts_dir()  # type: ignore[union-attr]
-            trackio_dir = storage.join(artifacts_dir, "trackio")
-
-            if await storage.exists(trackio_dir):
-                await storage.rm_tree(trackio_dir)
-            await storage.makedirs(trackio_dir, exist_ok=True)
-
-            if os.path.isdir(src):
-                await storage.copy_dir(src, trackio_dir)
-            else:
-                base_name = posixpath.basename(src)
-                dest_file = storage.join(trackio_dir, base_name)
-                await storage.copy_file(src, dest_file)
-
-            await self._job.update_job_data_field("trackio_db_artifact_path", trackio_dir)  # type: ignore[union-attr]
-            if project is not None and isinstance(project, str) and project.strip() != "":
-                await self._job.update_job_data_field("trackio_project", project.strip())  # type: ignore[union-attr]
-
-            logger.info(f"📊 Saved Trackio metrics for job to: {trackio_dir}")
-            return trackio_dir
+            base_name = posixpath.basename(src)
+            dest_file = storage.join(trackio_dir, base_name)
+            await storage.copy_file(src, dest_file)
+        # Do not write trackio_db_artifact_path; dashboard derives from trackio_project_name
+        logger.info(f"📊 Saved Trackio metrics to shared project: {trackio_dir}")
+        return trackio_dir
 
     async def _seed_trackio_shared_path_async(self, experiment_id: str, project_name: str, dest_dir: str) -> None:
         """If shared project path exists, copy its contents into dest_dir (seed for new run)."""
@@ -1805,7 +1773,7 @@ class Lab:
             current_project = context_vars.current_project.get()
             if current_project:
                 db_path = str(TRACKIO_DIR)
-                self.capture_trackio_metadata(db_path=db_path, project=str(current_project))
+                self.capture_trackio_metadata(db_path=db_path)
         except Exception:
             # Completely best-effort; ignore all errors here
             return

--- a/lab-sdk/src/lab/remote_trap.py
+++ b/lab-sdk/src/lab/remote_trap.py
@@ -236,7 +236,7 @@ def main(argv: List[str] | None = None) -> int:
         cmd_parts = args
 
     if not cmd_parts:
-        print("Error: No command provided to run. The task may be missing a 'run' or 'command' field.", file=sys.stderr)
+        print("Error: No command provided to run. The task may be missing a 'run' field.", file=sys.stderr)
         _set_live_status("Remote command crashed")
         return 1
 

--- a/lab-sdk/src/lab/task_template.py
+++ b/lab-sdk/src/lab/task_template.py
@@ -218,32 +218,24 @@ class TaskTemplate(BaseLabResource):
                 task = await TaskTemplate.get(task_id, experiment_id=experiment_id)
                 return await task.get_metadata()
             except FileNotFoundError:
-                pass
-
-        # Legacy fallback location for pre-migration tasks.
-        try:
-            task = await TaskTemplate.get(task_id)
-            return await task.get_metadata()
-        except FileNotFoundError:
-            pass
+                return None
 
         # Best-effort fallback for callers that only know task_id:
         # scan experiment-scoped task folders to locate a matching id.
-        if not experiment_id:
-            try:
-                experiments_dir = await get_experiments_dir()
-                if await storage.isdir(experiments_dir):
-                    exp_entries = await storage.ls(experiments_dir, detail=False)
-                    for exp_path in exp_entries:
-                        if not await storage.isdir(exp_path):
-                            continue
-                        exp_id = exp_path.rstrip("/").split("/")[-1]
-                        candidate = await get_experiment_task_dir(exp_id, task_id)
-                        if await storage.isdir(candidate):
-                            task = await TaskTemplate.get(task_id, experiment_id=exp_id)
-                            return await task.get_metadata()
-            except Exception:
-                return None
+        try:
+            experiments_dir = await get_experiments_dir()
+            if await storage.isdir(experiments_dir):
+                exp_entries = await storage.ls(experiments_dir, detail=False)
+                for exp_path in exp_entries:
+                    if not await storage.isdir(exp_path):
+                        continue
+                    exp_id = exp_path.rstrip("/").split("/")[-1]
+                    candidate = await get_experiment_task_dir(exp_id, task_id)
+                    if await storage.isdir(candidate):
+                        task = await TaskTemplate.get(task_id, experiment_id=exp_id)
+                        return await task.get_metadata()
+        except Exception:
+            return None
         return None
 
     @staticmethod

--- a/lab-sdk/tests/test_lab_facade.py
+++ b/lab-sdk/tests/test_lab_facade.py
@@ -448,6 +448,7 @@ def test_lab_capture_trackio_metadata_directory(tmp_path, monkeypatch):
     ws.mkdir()
     monkeypatch.setenv("TFL_HOME_DIR", str(home))
     monkeypatch.setenv("TFL_WORKSPACE_DIR", str(ws))
+    monkeypatch.setenv("TLAB_TRACKIO_PROJECT_NAME", "my-project")
 
     from lab.lab_facade import Lab
 
@@ -459,16 +460,14 @@ def test_lab_capture_trackio_metadata_directory(tmp_path, monkeypatch):
     trackio_src.mkdir()
     (trackio_src / "metrics.sqlite").write_text("db")
 
-    dest_path = lab.capture_trackio_metadata(str(trackio_src), project="my-project")
+    dest_path = lab.capture_trackio_metadata(str(trackio_src))
 
     assert os.path.exists(dest_path)
     assert os.path.isdir(dest_path)
-    # The copied DB file should exist under the destination
+    # The copied DB file should exist under the shared project destination
     assert os.path.exists(os.path.join(dest_path, "metrics.sqlite"))
-
-    job_data = lab.get_job_data()
-    assert job_data.get("trackio_db_artifact_path") == dest_path
-    assert job_data.get("trackio_project") == "my-project"
+    assert "trackio_runs" in dest_path
+    assert "my-project" in dest_path
 
 
 def test_lab_save_dataset(tmp_path, monkeypatch):

--- a/src/renderer/components/Experiment/Interactive/Interactive.tsx
+++ b/src/renderer/components/Experiment/Interactive/Interactive.tsx
@@ -649,7 +649,7 @@ export default function Interactive() {
           }
 
           defaultSetup = template.setup || '';
-          defaultRun = template.run || template.command || '';
+          defaultRun = template.run || '';
           templateId = template.id;
           galleryTemplate = template;
         } else {

--- a/src/renderer/components/Experiment/Tasks/Tasks.tsx
+++ b/src/renderer/components/Experiment/Tasks/Tasks.tsx
@@ -900,7 +900,7 @@ export default function Tasks({ subtype }: { subtype?: string }) {
           }
 
           defaultSetup = template.setup || '';
-          defaultRun = template.run || template.command || '';
+          defaultRun = template.run || '';
           templateId = template.id;
         } else {
           throw new Error('Failed to fetch interactive gallery');


### PR DESCRIPTION
As discussed with @dadmobile earlier, this removes all the code we have in our codebase for backward compatiblity
- Covers `command->run` backward compat code
- Covers older trackio paths code
-  lab-sdk/src/lab/task_template.py get_by_id: removed the legacy lookup at the pre-migration workspace/task/<id> location. Tasks not under experiments/<exp>/tasks/<id> will no longer resolve.