### PR TITLE
Optionally return slimmed down jobs list to reduce payload size

### DIFF
--- a/api/test/api/test_experiment_jobs.py
+++ b/api/test/api/test_experiment_jobs.py
@@ -14,6 +14,99 @@ def test_jobs_list_all_endpoints(client):
     resp = client.get("/experiment/alpha/jobs/list?type=TRAIN&status=QUEUED")
     assert resp.status_code in (200, 404)
 
+    # slim mode is opt-in and should still return a 2xx (or 404) response shape
+    resp = client.get("/experiment/alpha/jobs/list?slim=true")
+    assert resp.status_code in (200, 404)
+
+
+def test_slim_job_drops_heavy_keys_only():
+    """_slim_job should remove the denylisted keys but preserve everything else."""
+    from transformerlab.routers.experiment.jobs import _slim_job, _SLIM_JOB_DATA_DROPPED_KEYS
+
+    job = {
+        "id": "abc",
+        "status": "COMPLETE",
+        "type": "TRAIN",
+        "job_data": {
+            # Heavy keys that the list view does not need
+            "cluster_config": {"x": "y"},
+            "env_vars": {"TOKEN": "secret"},
+            "setup": "long shell script",
+            "run": "another long shell script",
+            "parameters": {"lr": 0.001, "batch": 32},
+            "config": {"big": "blob"},
+            "provider_launch_result": {"request_id": "req-1", "raw": "..." * 1000},
+            "cached_tunnel_info": {"host": "h", "key": "k"},
+            "file_mounts": {"/foo": "/bar"},
+            "accelerators": "A100",
+            "cpus": 8,
+            "memory": "32GB",
+            "disk_space": "200GB",
+            "num_nodes": 2,
+            "command": "bash run.sh",
+            "provider_jobs_seen_once": ["a", "b"],
+            "provider_empty_jobs_polls": 5,
+            # Keys the list view does need — these must survive
+            "description": "hello",
+            "start_time": "2025-01-01T00:00:00Z",
+            "score": {"acc": 0.9},
+            "subtype": "interactive",
+            "favorite": True,
+            "hidden": False,
+            "tags": ["a"],
+            "wandb_run_url": "https://wandb.ai/x/y/runs/z",
+            "error_msg": None,
+            "stop_requested": False,
+            "eval_results": ["/path/to/results.csv"],
+        },
+    }
+
+    slim = _slim_job(job)
+
+    # Top-level keys are untouched
+    assert slim["id"] == "abc"
+    assert slim["status"] == "COMPLETE"
+    assert slim["type"] == "TRAIN"
+
+    slim_data = slim["job_data"]
+    # Every denylisted key must be gone
+    for key in _SLIM_JOB_DATA_DROPPED_KEYS:
+        assert key not in slim_data, f"slim mode leaked heavy key: {key}"
+
+    # Frontend-relevant keys must be preserved verbatim
+    for key in (
+        "description",
+        "start_time",
+        "score",
+        "subtype",
+        "favorite",
+        "hidden",
+        "tags",
+        "wandb_run_url",
+        "error_msg",
+        "stop_requested",
+        "eval_results",
+    ):
+        assert key in slim_data, f"slim mode dropped expected key: {key}"
+        assert slim_data[key] == job["job_data"][key]
+
+    # The original job dict is not mutated (defensive copy)
+    assert "cluster_config" in job["job_data"]
+    assert "env_vars" in job["job_data"]
+
+
+def test_slim_job_handles_non_dict_job_data():
+    """_slim_job should be a no-op when job_data is missing or not a dict."""
+    from transformerlab.routers.experiment.jobs import _slim_job
+
+    # Missing job_data
+    job = {"id": "1", "status": "RUNNING"}
+    assert _slim_job(job) == job
+
+    # job_data is a string (legacy/mis-serialized) — leave it alone rather than crash
+    job_str = {"id": "2", "job_data": '{"cluster_config": "x"}'}
+    assert _slim_job(job_str) == job_str
+
 
 def test_job_creation_and_management(client):
     """Test job creation and management endpoints"""

--- a/api/test/api/test_experiment_jobs.py
+++ b/api/test/api/test_experiment_jobs.py
@@ -35,7 +35,6 @@ def test_slim_job_drops_heavy_keys_only():
             "run": "another long shell script",
             "parameters": {"lr": 0.001, "batch": 32},
             "config": {"big": "blob"},
-            "provider_launch_result": {"request_id": "req-1", "raw": "..." * 1000},
             "file_mounts": {"/foo": "/bar"},
             "accelerators": "A100",
             "cpus": 8,
@@ -58,6 +57,7 @@ def test_slim_job_drops_heavy_keys_only():
             "stop_requested": False,
             "eval_results": ["/path/to/results.csv"],
             "cached_tunnel_info": {"is_ready": True, "url": "https://x"},
+            "provider_launch_result": {"request_id": "req-1", "instance_ids": ["i-1"]},
         },
     }
 
@@ -87,6 +87,7 @@ def test_slim_job_drops_heavy_keys_only():
         "stop_requested",
         "eval_results",
         "cached_tunnel_info",
+        "provider_launch_result",
     ):
         assert key in slim_data, f"slim mode dropped expected key: {key}"
         assert slim_data[key] == job["job_data"][key]

--- a/api/test/api/test_experiment_jobs.py
+++ b/api/test/api/test_experiment_jobs.py
@@ -36,7 +36,6 @@ def test_slim_job_drops_heavy_keys_only():
             "parameters": {"lr": 0.001, "batch": 32},
             "config": {"big": "blob"},
             "provider_launch_result": {"request_id": "req-1", "raw": "..." * 1000},
-            "cached_tunnel_info": {"host": "h", "key": "k"},
             "file_mounts": {"/foo": "/bar"},
             "accelerators": "A100",
             "cpus": 8,
@@ -58,6 +57,7 @@ def test_slim_job_drops_heavy_keys_only():
             "error_msg": None,
             "stop_requested": False,
             "eval_results": ["/path/to/results.csv"],
+            "cached_tunnel_info": {"is_ready": True, "url": "https://x"},
         },
     }
 
@@ -86,6 +86,7 @@ def test_slim_job_drops_heavy_keys_only():
         "error_msg",
         "stop_requested",
         "eval_results",
+        "cached_tunnel_info",
     ):
         assert key in slim_data, f"slim mode dropped expected key: {key}"
         assert slim_data[key] == job["job_data"][key]

--- a/api/transformerlab/routers/experiment/jobs.py
+++ b/api/transformerlab/routers/experiment/jobs.py
@@ -105,7 +105,6 @@ def _job_logs_not_ready_payload(
 _SLIM_JOB_DATA_DROPPED_KEYS: frozenset[str] = frozenset(
     {
         "accelerators",
-        "cached_tunnel_info",
         "cluster_config",
         "command",
         "config",

--- a/api/transformerlab/routers/experiment/jobs.py
+++ b/api/transformerlab/routers/experiment/jobs.py
@@ -97,15 +97,57 @@ def _job_logs_not_ready_payload(
     return payload
 
 
+# Heavy job_data keys that polling list-views never need. When ?slim=true is set
+# on /jobs/list, these are stripped from each job's job_data to keep the response
+# small. Per-job detail endpoints still return the full payload. New heavy keys
+# should be added here rather than allowlisting fields, so that adding metadata
+# elsewhere doesn't silently shrink list responses.
+_SLIM_JOB_DATA_DROPPED_KEYS: frozenset[str] = frozenset(
+    {
+        "accelerators",
+        "cached_tunnel_info",
+        "cluster_config",
+        "command",
+        "config",
+        "cpus",
+        "disk_space",
+        "env_vars",
+        "file_mounts",
+        "memory",
+        "num_nodes",
+        "parameters",
+        "provider_empty_jobs_polls",
+        "provider_jobs_seen_once",
+        "provider_launch_result",
+        "run",
+        "setup",
+    }
+)
+
+
+def _slim_job(job: dict) -> dict:
+    """Return a shallow copy of ``job`` with heavy keys removed from job_data."""
+    job_data = job.get("job_data")
+    if not isinstance(job_data, dict):
+        return job
+    trimmed = {k: v for k, v in job_data.items() if k not in _SLIM_JOB_DATA_DROPPED_KEYS}
+    return {**job, "job_data": trimmed}
+
+
 @router.get("/list")
 async def jobs_get_all(
     experimentId: str,
     type: str = "",
     status: str = "",
     subtype: str = "",
+    slim: bool = False,
 ):
     """
     Return the list of jobs for an experiment, optionally filtered by type/status/subtype.
+
+    When ``slim=true``, heavy provisioning/config fields are stripped from each
+    job's ``job_data`` to keep polling payloads small. The set of stripped keys
+    is defined by ``_SLIM_JOB_DATA_DROPPED_KEYS``.
     """
     jobs = await job_service.jobs_get_all(type=type, status=status, experiment_id=experimentId)
 
@@ -121,7 +163,10 @@ async def jobs_get_all(
                     job_data = {}
             if job_data.get("subtype") == subtype:
                 filtered.append(job)
-        return filtered
+        jobs = filtered
+
+    if slim:
+        jobs = [_slim_job(job) for job in jobs]
 
     return jobs
 

--- a/api/transformerlab/routers/experiment/jobs.py
+++ b/api/transformerlab/routers/experiment/jobs.py
@@ -117,7 +117,6 @@ _SLIM_JOB_DATA_DROPPED_KEYS: frozenset[str] = frozenset(
         "parameters",
         "provider_empty_jobs_polls",
         "provider_jobs_seen_once",
-        "provider_launch_result",
         "run",
         "setup",
     }

--- a/src/renderer/lib/api-client/endpoints.ts
+++ b/src/renderer/lib/api-client/endpoints.ts
@@ -343,17 +343,17 @@ Endpoints.Experiment = {
 
 Endpoints.Jobs = {
   List: (experimentId: string) =>
-    `${API_URL()}experiment/${experimentId}/jobs/list`,
+    `${API_URL()}experiment/${experimentId}/jobs/list?slim=true`,
   ListWithFilters: (
     experimentId: string,
     type?: string,
     status?: string,
     subtype?: string,
   ) =>
-    `${API_URL()}experiment/${experimentId}/jobs/list` +
-    `${type ? `?type=${type}` : ''}` +
-    `${status ? `${type ? '&' : '?'}status=${status}` : ''}` +
-    `${subtype ? `${type || status ? '&' : '?'}subtype=${encodeURIComponent(subtype)}` : ''}`,
+    `${API_URL()}experiment/${experimentId}/jobs/list?slim=true` +
+    `${type ? `&type=${type}` : ''}` +
+    `${status ? `&status=${status}` : ''}` +
+    `${subtype ? `&subtype=${encodeURIComponent(subtype)}` : ''}`,
   Get: (experimentId: string, jobId: string) =>
     `${API_URL()}experiment/${experimentId}/jobs/${jobId}`,
   Create: (
@@ -370,7 +370,7 @@ Endpoints.Jobs = {
     type: string = '',
     status: string = '',
   ) =>
-    `${API_URL()}experiment/${experimentId}/jobs/list?type=${type}&status=${status}`,
+    `${API_URL()}experiment/${experimentId}/jobs/list?slim=true&type=${type}&status=${status}`,
   Delete: (experimentId: string, jobId: string) =>
     `${API_URL()}experiment/${experimentId}/jobs/${jobId}`,
   Stop: (experimentId: string, jobId: string) =>


### PR DESCRIPTION
Possibly fixes #2040 

Uses a blacklist strategy to remove keys that hold large amounts of data and don't seem necessary just for listing jobs.
