### PR TITLE
[WIP] Add eval leaderboard

### DIFF
--- a/src/renderer/components/Experiment/Tasks/Evals.tsx
+++ b/src/renderer/components/Experiment/Tasks/Evals.tsx
@@ -22,6 +22,7 @@ import Trends, { TrendPoint } from 'renderer/components/Charts/Trends';
 import { normalizeJobScore } from 'renderer/lib/jobScore';
 import CompareEvalResultsModal from './CompareEvalResultsModal';
 import ViewEvalResultsModal from './ViewEvalResultsModal';
+import LeaderboardEvalModal from './LeaderboardEvalModal';
 
 interface EvalCapableJob {
   id: string;
@@ -37,6 +38,7 @@ type PageTab = 'evals' | 'trends';
 
 const COMPARE_MIN = 2;
 const COMPARE_MAX = 10;
+const LEADERBOARD_MIN = 2;
 
 const getEvalCapableJobs = (jobs: any[]): EvalCapableJob[] =>
   jobs.reduce<EvalCapableJob[]>((acc, job) => {
@@ -174,6 +176,7 @@ export default function Evals() {
   const [compareOpen, setCompareOpen] = useState(false);
   const [singleEvalJobId, setSingleEvalJobId] = useState<string | null>(null);
   const [now, setNow] = useState<number | null>(null);
+  const [leaderboardOpen, setLeaderboardOpen] = useState(false);
 
   useEffect(() => {
     if (experimentName) {
@@ -222,6 +225,11 @@ export default function Evals() {
     );
   }, [evalCapableJobs, search]);
 
+  const leaderboardJobs = useMemo(
+    () => evalCapableJobs.filter((j) => selectedIds.includes(j.id)),
+    [evalCapableJobs, selectedIds],
+  );
+
   const toggleSelected = (jobId: string) => {
     setSelectedIds((prev) => {
       if (prev.includes(jobId)) return prev.filter((id) => id !== jobId);
@@ -231,10 +239,11 @@ export default function Evals() {
   };
 
   const canCompare = selectedIds.length >= COMPARE_MIN;
+  const canOpenLeaderboard = selectedIds.length >= LEADERBOARD_MIN;
 
   const headerSubtitle =
     pageTab === 'evals'
-      ? 'Browse eval-capable jobs in this experiment. Click View to inspect a single result, or select two jobs to compare.'
+      ? 'Browse eval-capable jobs in this experiment. Click View to inspect a single result, or select two jobs to compare or rank on a leaderboard.'
       : "Score trends across this experiment's jobs.";
 
   return (
@@ -291,6 +300,13 @@ export default function Evals() {
               onClick={() => setCompareOpen(true)}
             >
               Compare selected
+            </Button>
+            <Button
+              variant="outlined"
+              disabled={!canOpenLeaderboard}
+              onClick={() => setLeaderboardOpen(true)}
+            >
+              Open leaderboard
             </Button>
             {selectedIds.length > 0 && (
               <Button variant="plain" onClick={() => setSelectedIds([])}>
@@ -464,6 +480,14 @@ export default function Evals() {
         open={singleEvalJobId !== null}
         onClose={() => setSingleEvalJobId(null)}
         jobId={singleEvalJobId}
+      />
+      <LeaderboardEvalModal
+        open={leaderboardOpen}
+        onClose={() => setLeaderboardOpen(false)}
+        jobs={leaderboardJobs.map(({ id, title, shortId }) => ({
+          id,
+          title: `${title} (${shortId})`,
+        }))}
       />
     </Box>
   );

--- a/src/renderer/components/Experiment/Tasks/LeaderboardEvalModal.tsx
+++ b/src/renderer/components/Experiment/Tasks/LeaderboardEvalModal.tsx
@@ -1,0 +1,681 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  FormLabel,
+  IconButton,
+  Modal,
+  ModalClose,
+  ModalDialog,
+  Option,
+  Select,
+  Sheet,
+  Stack,
+  Table,
+  Tooltip,
+  Typography,
+} from '@mui/joy';
+import { ArrowUpDown, Download, Eye } from 'lucide-react';
+
+import * as chatAPI from 'renderer/lib/transformerlab-api-sdk';
+import { useExperimentInfo } from 'renderer/lib/ExperimentInfoContext';
+import { fetcher } from 'renderer/lib/transformerlab-api-sdk';
+import { useSWRWithAuth as useSWR } from 'renderer/lib/authContext';
+import Chart, { type ChartMetric } from './Chart';
+import ViewEvalResultsModal from './ViewEvalResultsModal';
+import {
+  buildCategoryBreakdown,
+  buildLeaderboard,
+  toCsv,
+  toMarkdownReport,
+  type EvalReport,
+  type JobReport,
+} from './evalAggregate';
+
+export interface LeaderboardJobSelection {
+  id: string;
+  title: string;
+}
+
+interface LeaderboardEvalModalProps {
+  open: boolean;
+  onClose: () => void;
+  jobs: LeaderboardJobSelection[];
+}
+
+interface JobLoadState {
+  files: string[];
+  fileIndex: number;
+  report: EvalReport | null;
+  loading: boolean;
+  error: string | null;
+}
+
+function heatedColor(value: number, min: number, max: number): string {
+  if (!Number.isFinite(value) || max <= min) return 'transparent';
+  const t = Math.max(0, Math.min(1, (value - min) / (max - min)));
+  const h = t * 120;
+  return `hsla(${h}, 70%, 50%, 0.25)`;
+}
+
+function downloadBlob(filename: string, content: string, mime: string) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function JobReportLoader({
+  jobId,
+  fileIndex,
+  onMeta,
+  onReport,
+}: {
+  jobId: string;
+  fileIndex: number;
+  onMeta: (jobId: string, files: string[], error: string | null) => void;
+  onReport: (
+    jobId: string,
+    report: EvalReport | null,
+    loading: boolean,
+    error: string | null,
+  ) => void;
+}) {
+  const { experimentInfo } = useExperimentInfo();
+
+  const {
+    data: jobData,
+    isError: jobError,
+    isLoading: isLoadingJob,
+  } = useSWR(
+    experimentInfo?.id
+      ? chatAPI.Endpoints.Jobs.Get(experimentInfo.id, jobId)
+      : null,
+    fetcher,
+  );
+
+  const files: string[] = useMemo(() => {
+    const raw = jobData?.job_data?.eval_results;
+    return Array.isArray(raw) ? (raw as string[]) : [];
+  }, [jobData]);
+
+  useEffect(() => {
+    onMeta(jobId, files, jobError ? 'Failed to load job' : null);
+  }, [jobId, files, jobError, onMeta]);
+
+  const fetchKey =
+    experimentInfo?.id &&
+    files.length > 0 &&
+    fileIndex >= 0 &&
+    fileIndex < files.length
+      ? chatAPI.Endpoints.Experiment.GetEvalResults(
+          experimentInfo.id,
+          jobId,
+          'view',
+          fileIndex,
+        )
+      : null;
+
+  const {
+    data: reportData,
+    isError: reportError,
+    isLoading: isLoadingReport,
+  } = useSWR(fetchKey, fetcher);
+
+  useEffect(() => {
+    const loading = isLoadingJob || isLoadingReport;
+    if (loading) {
+      onReport(jobId, null, true, null);
+      return;
+    }
+    if (reportError) {
+      onReport(jobId, null, false, 'Failed to load eval results');
+      return;
+    }
+    if (reportData?.header && reportData?.body) {
+      onReport(
+        jobId,
+        {
+          header: reportData.header as string[],
+          body: reportData.body as unknown[][],
+        },
+        false,
+        null,
+      );
+      return;
+    }
+    if (files.length === 0 && !isLoadingJob) {
+      onReport(jobId, null, false, 'No eval files');
+      return;
+    }
+    onReport(jobId, null, false, null);
+  }, [
+    jobId,
+    isLoadingJob,
+    isLoadingReport,
+    reportError,
+    reportData,
+    files.length,
+    onReport,
+  ]);
+
+  return null;
+}
+
+type SortDir = 'asc' | 'desc' | null;
+
+export default function LeaderboardEvalModal({
+  open,
+  onClose,
+  jobs,
+}: LeaderboardEvalModalProps) {
+  const [states, setStates] = useState<Record<string, JobLoadState>>({});
+  const [showFileMapping, setShowFileMapping] = useState(false);
+  const [sortMetric, setSortMetric] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>(null);
+  const [drilldownMetric, setDrilldownMetric] = useState<string | null>(null);
+  const [inspectJobId, setInspectJobId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setStates((prev) => {
+      const next: Record<string, JobLoadState> = {};
+      jobs.forEach((j) => {
+        next[j.id] = prev[j.id] ?? {
+          files: [],
+          fileIndex: 0,
+          report: null,
+          loading: true,
+          error: null,
+        };
+      });
+      return next;
+    });
+  }, [open, jobs]);
+
+  const handleMeta = useCallback(
+    (jobId: string, files: string[], error: string | null) => {
+      setStates((prev) => {
+        const existing = prev[jobId];
+        if (!existing) return prev;
+        if (
+          existing.files.length === files.length &&
+          existing.files.every((f, i) => f === files[i]) &&
+          existing.error === error
+        ) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [jobId]: {
+            ...existing,
+            files,
+            fileIndex:
+              existing.fileIndex < files.length ? existing.fileIndex : 0,
+            error,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const handleReport = useCallback(
+    (
+      jobId: string,
+      report: EvalReport | null,
+      loading: boolean,
+      error: string | null,
+    ) => {
+      setStates((prev) => {
+        const existing = prev[jobId];
+        if (!existing) return prev;
+        if (
+          existing.report === report &&
+          existing.loading === loading &&
+          existing.error === (error ?? existing.error)
+        ) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [jobId]: {
+            ...existing,
+            report,
+            loading,
+            error: error ?? existing.error,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const jobReports: JobReport[] = useMemo(
+    () =>
+      jobs
+        .map((j) => ({
+          jobId: j.id,
+          jobTitle: j.title,
+          report: states[j.id]?.report ?? { header: [], body: [] },
+        }))
+        .filter((j) => j.report.header.length > 0),
+    [jobs, states],
+  );
+
+  const leaderboard = useMemo(() => buildLeaderboard(jobReports), [jobReports]);
+
+  const sortedRows = useMemo(() => {
+    const rows = [...leaderboard.rows];
+    if (!sortMetric || !sortDir) {
+      rows.sort((a, b) => b.wins - a.wins);
+      return rows;
+    }
+    rows.sort((a, b) => {
+      const av = a.cells[sortMetric]?.mean ?? -Infinity;
+      const bv = b.cells[sortMetric]?.mean ?? -Infinity;
+      if (!Number.isFinite(av) && !Number.isFinite(bv)) return 0;
+      if (!Number.isFinite(av)) return 1;
+      if (!Number.isFinite(bv)) return -1;
+      return sortDir === 'asc' ? av - bv : bv - av;
+    });
+    return rows;
+  }, [leaderboard.rows, sortMetric, sortDir]);
+
+  const minMaxByMetric = useMemo(() => {
+    const map = new Map<string, { min: number; max: number }>();
+    leaderboard.metricColumns.forEach((m) => {
+      let min = Infinity;
+      let max = -Infinity;
+      leaderboard.rows.forEach((r) => {
+        const v = r.cells[m]?.mean;
+        if (Number.isFinite(v)) {
+          if (v < min) min = v;
+          if (v > max) max = v;
+        }
+      });
+      map.set(m, { min, max });
+    });
+    return map;
+  }, [leaderboard]);
+
+  useEffect(() => {
+    if (
+      drilldownMetric &&
+      !leaderboard.metricColumns.includes(drilldownMetric)
+    ) {
+      setDrilldownMetric(null);
+    }
+  }, [drilldownMetric, leaderboard.metricColumns]);
+
+  const handleSortClick = (metric: string) => {
+    if (sortMetric !== metric) {
+      setSortMetric(metric);
+      setSortDir('desc');
+      return;
+    }
+    if (sortDir === 'desc') setSortDir('asc');
+    else if (sortDir === 'asc') {
+      setSortMetric(null);
+      setSortDir(null);
+    } else setSortDir('desc');
+  };
+
+  const drilldownChartMetrics: ChartMetric[] = useMemo(() => {
+    if (!drilldownMetric || !leaderboard.categoryColumn) return [];
+    const rows = buildCategoryBreakdown(
+      jobReports,
+      drilldownMetric,
+      leaderboard.categoryColumn,
+    );
+    const out: ChartMetric[] = [];
+    rows.forEach((row) => {
+      Object.entries(row.cells).forEach(([jobId, cell]) => {
+        const title = jobs.find((j) => j.id === jobId)?.title ?? jobId;
+        if (Number.isFinite(cell.mean)) {
+          out.push({
+            type: row.category,
+            series: title,
+            score: Number(cell.mean.toFixed(3)),
+          });
+        }
+      });
+    });
+    return out;
+  }, [drilldownMetric, jobReports, leaderboard.categoryColumn, jobs]);
+
+  const anyLoading = jobs.some((j) => states[j.id]?.loading);
+  const allFailed =
+    jobs.length > 0 &&
+    jobs.every(
+      (j) => states[j.id]?.error != null && states[j.id]?.report === null,
+    );
+
+  const handleExportMarkdown = () => {
+    const breakdowns = leaderboard.categoryColumn
+      ? leaderboard.metricColumns.map((m) => ({
+          metric: m,
+          rows: buildCategoryBreakdown(
+            jobReports,
+            m,
+            leaderboard.categoryColumn!,
+          ),
+        }))
+      : [];
+    const lookup: Record<string, string> = {};
+    jobs.forEach((j) => {
+      lookup[j.id] = j.title;
+    });
+    const md = toMarkdownReport(leaderboard, breakdowns, lookup);
+    downloadBlob('leaderboard.md', md, 'text/markdown');
+  };
+
+  const handleExportCsv = () => {
+    downloadBlob('leaderboard.csv', toCsv(leaderboard), 'text/csv');
+  };
+
+  return (
+    <>
+      <Modal open={open} onClose={onClose}>
+        <ModalDialog
+          sx={{ width: '95vw', height: '92vh', pt: 5, overflow: 'auto' }}
+        >
+          <ModalClose />
+          {open &&
+            jobs.map((j) => (
+              <JobReportLoader
+                key={`loader-${j.id}-${states[j.id]?.fileIndex ?? 0}`}
+                jobId={j.id}
+                fileIndex={states[j.id]?.fileIndex ?? 0}
+                onMeta={handleMeta}
+                onReport={handleReport}
+              />
+            ))}
+          <Stack spacing={2} sx={{ mb: 2 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                gap: 1,
+              }}
+            >
+              <Typography level="h4">
+                Eval Leaderboard ({jobs.length} jobs)
+              </Typography>
+              <Stack direction="row" spacing={1}>
+                <Button
+                  size="sm"
+                  variant="outlined"
+                  onClick={() => setShowFileMapping((v) => !v)}
+                >
+                  {showFileMapping ? 'Hide' : 'Configure'} file mapping
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outlined"
+                  startDecorator={<Download size={14} />}
+                  onClick={handleExportCsv}
+                  disabled={leaderboard.rows.length === 0}
+                >
+                  CSV
+                </Button>
+                <Button
+                  size="sm"
+                  variant="solid"
+                  startDecorator={<Download size={14} />}
+                  onClick={handleExportMarkdown}
+                  disabled={leaderboard.rows.length === 0}
+                >
+                  Markdown report
+                </Button>
+              </Stack>
+            </Box>
+
+            {showFileMapping && (
+              <Sheet variant="soft" sx={{ p: 2, borderRadius: 'sm' }}>
+                <Typography level="title-sm" sx={{ mb: 1 }}>
+                  Per-job eval file
+                </Typography>
+                <Stack spacing={1}>
+                  {jobs.map((j) => {
+                    const s = states[j.id];
+                    return (
+                      <Box
+                        key={`fm-${j.id}`}
+                        sx={{
+                          display: 'flex',
+                          gap: 2,
+                          alignItems: 'center',
+                        }}
+                      >
+                        <Typography level="body-sm" sx={{ minWidth: 200 }}>
+                          {j.title}
+                        </Typography>
+                        <FormControl sx={{ flex: 1 }}>
+                          <Select
+                            size="sm"
+                            value={s?.fileIndex ?? 0}
+                            onChange={(_, v) => {
+                              if (v === null) return;
+                              setStates((prev) => ({
+                                ...prev,
+                                [j.id]: {
+                                  ...(prev[j.id] ?? {
+                                    files: [],
+                                    fileIndex: 0,
+                                    report: null,
+                                    loading: true,
+                                    error: null,
+                                  }),
+                                  fileIndex: v as number,
+                                },
+                              }));
+                            }}
+                            disabled={!s || s.files.length === 0}
+                          >
+                            {(s?.files ?? []).map((f, idx) => (
+                              <Option key={`${j.id}-f-${idx}`} value={idx}>
+                                {f.split('/').pop() || `File ${idx + 1}`}
+                              </Option>
+                            ))}
+                          </Select>
+                        </FormControl>
+                      </Box>
+                    );
+                  })}
+                </Stack>
+              </Sheet>
+            )}
+
+            {leaderboard.droppedColumns.length > 0 && (
+              <Alert color="neutral" variant="soft">
+                Columns not present in every job were dropped:{' '}
+                <strong>{leaderboard.droppedColumns.join(', ')}</strong>
+              </Alert>
+            )}
+            {leaderboard.metricColumns.length === 0 &&
+              !anyLoading &&
+              jobReports.length > 0 && (
+                <Alert color="warning" variant="soft">
+                  No shared numeric metric columns were found across the
+                  selected jobs.
+                </Alert>
+              )}
+            {allFailed && (
+              <Alert color="danger" variant="soft">
+                Could not load eval results for any of the selected jobs.
+              </Alert>
+            )}
+          </Stack>
+
+          {anyLoading && jobReports.length === 0 ? (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                py: 6,
+                gap: 2,
+              }}
+            >
+              <CircularProgress size="lg" />
+              <Typography>Loading eval reports…</Typography>
+            </Box>
+          ) : (
+            <Box sx={{ overflow: 'auto' }}>
+              <Table stickyHeader hoverRow>
+                <thead>
+                  <tr>
+                    <th style={{ width: 32 }} aria-label="actions" />
+                    <th>Model</th>
+                    {leaderboard.metricColumns.map((m) => (
+                      <th key={`h-${m}`}>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 0.5,
+                            cursor: 'pointer',
+                          }}
+                          onClick={() => handleSortClick(m)}
+                        >
+                          {m}
+                          <ArrowUpDown size={12} />
+                          {sortMetric === m && sortDir && (
+                            <Typography level="body-xs">
+                              {sortDir === 'asc' ? '▲' : '▼'}
+                            </Typography>
+                          )}
+                        </Box>
+                      </th>
+                    ))}
+                    <th style={{ width: 60 }}>Wins</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedRows.map((row) => (
+                    <tr key={`r-${row.jobId}`}>
+                      <td>
+                        <Tooltip title="Open single-job view">
+                          <IconButton
+                            size="sm"
+                            variant="plain"
+                            onClick={() => setInspectJobId(row.jobId)}
+                          >
+                            <Eye size={14} />
+                          </IconButton>
+                        </Tooltip>
+                      </td>
+                      <td>
+                        <Typography level="body-sm">{row.jobTitle}</Typography>
+                        <Typography level="body-xs" color="neutral">
+                          {row.jobId}
+                        </Typography>
+                      </td>
+                      {leaderboard.metricColumns.map((m) => {
+                        const cell = row.cells[m];
+                        const range = minMaxByMetric.get(m);
+                        const bg =
+                          range && cell && Number.isFinite(cell.mean)
+                            ? heatedColor(cell.mean, range.min, range.max)
+                            : 'transparent';
+                        const isMax =
+                          range &&
+                          cell &&
+                          cell.mean === range.max &&
+                          range.max > range.min;
+                        return (
+                          <td
+                            key={`c-${row.jobId}-${m}`}
+                            style={{ backgroundColor: bg }}
+                          >
+                            {cell && Number.isFinite(cell.mean) ? (
+                              <Box
+                                sx={{
+                                  cursor: 'pointer',
+                                  fontWeight: isMax ? 700 : 400,
+                                }}
+                                onClick={() => setDrilldownMetric(m)}
+                              >
+                                {cell.mean.toFixed(3)}
+                                {cell.stddev > 0 && (
+                                  <Typography
+                                    level="body-xs"
+                                    color="neutral"
+                                    sx={{ ml: 0.5 }}
+                                  >
+                                    ±{cell.stddev.toFixed(2)}
+                                  </Typography>
+                                )}
+                              </Box>
+                            ) : (
+                              <Typography level="body-xs" color="neutral">
+                                —
+                              </Typography>
+                            )}
+                          </td>
+                        );
+                      })}
+                      <td>
+                        <Typography
+                          level="body-sm"
+                          sx={{ fontWeight: row.wins > 0 ? 700 : 400 }}
+                        >
+                          {row.wins}
+                        </Typography>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </Box>
+          )}
+
+          {drilldownMetric && drilldownChartMetrics.length > 0 && (
+            <Box sx={{ mt: 3 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  mb: 1,
+                }}
+              >
+                <Typography level="title-md">
+                  Per-{leaderboard.categoryColumn ?? 'category'} breakdown:{' '}
+                  {drilldownMetric}
+                </Typography>
+                <Button
+                  size="sm"
+                  variant="plain"
+                  onClick={() => setDrilldownMetric(null)}
+                >
+                  Hide
+                </Button>
+              </Box>
+              <Box sx={{ minHeight: 360 }}>
+                <Chart metrics={drilldownChartMetrics} compareChart={false} />
+              </Box>
+            </Box>
+          )}
+        </ModalDialog>
+      </Modal>
+
+      <ViewEvalResultsModal
+        open={inspectJobId !== null}
+        onClose={() => setInspectJobId(null)}
+        jobId={inspectJobId}
+      />
+    </>
+  );
+}

--- a/src/renderer/components/Experiment/Tasks/evalAggregate.test.ts
+++ b/src/renderer/components/Experiment/Tasks/evalAggregate.test.ts
@@ -1,0 +1,179 @@
+import {
+  buildCategoryBreakdown,
+  buildLeaderboard,
+  detectNumericColumns,
+  intersectHeaders,
+  toCsv,
+  toMarkdownReport,
+  type EvalReport,
+  type JobReport,
+} from './evalAggregate';
+
+const reportA: EvalReport = {
+  header: ['metric', 'score'],
+  body: [
+    ['mmlu', 0.6],
+    ['gsm8k', 0.42],
+    ['humaneval', 0.29],
+  ],
+};
+
+const reportB: EvalReport = {
+  header: ['metric', 'score'],
+  body: [
+    ['mmlu', 0.66],
+    ['gsm8k', 0.55],
+    ['humaneval', 0.38],
+  ],
+};
+
+const reportC: EvalReport = {
+  // includes an extra column "notes" not present in A/B
+  header: ['metric', 'score', 'notes'],
+  body: [
+    ['mmlu', 0.58, 'baseline'],
+    ['gsm8k', 0.38, ''],
+    ['humaneval', 0.27, ''],
+  ],
+};
+
+const jobA: JobReport = { jobId: 'a', jobTitle: 'sft-llama', report: reportA };
+const jobB: JobReport = { jobId: 'b', jobTitle: 'sft-qwen', report: reportB };
+const jobC: JobReport = { jobId: 'c', jobTitle: 'baseline', report: reportC };
+
+describe('intersectHeaders', () => {
+  it('returns common header columns across reports', () => {
+    const { common, dropped } = intersectHeaders([reportA, reportB, reportC]);
+    expect(common).toEqual(['metric', 'score']);
+    expect(dropped).toEqual(['notes']);
+  });
+
+  it('is case-insensitive', () => {
+    const r1: EvalReport = { header: ['Metric', 'Score'], body: [] };
+    const r2: EvalReport = { header: ['metric', 'score'], body: [] };
+    const { common } = intersectHeaders([r1, r2]);
+    expect(common).toHaveLength(2);
+  });
+
+  it('returns empty common when reports share no columns', () => {
+    const r1: EvalReport = { header: ['a'], body: [] };
+    const r2: EvalReport = { header: ['b'], body: [] };
+    const { common, dropped } = intersectHeaders([r1, r2]);
+    expect(common).toEqual([]);
+    expect(dropped.sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('detectNumericColumns', () => {
+  it('detects mostly-numeric columns and skips string columns', () => {
+    const cols = detectNumericColumns(reportC);
+    expect(cols).toEqual([1]);
+  });
+});
+
+describe('buildLeaderboard', () => {
+  it('builds rows with score column when present', () => {
+    const lb = buildLeaderboard([jobA, jobB, jobC]);
+    expect(lb.metricColumns).toEqual(['score']);
+    expect(lb.rows).toHaveLength(3);
+    expect(lb.rows.find((r) => r.jobId === 'a')!.cells.score.mean).toBeCloseTo(
+      (0.6 + 0.42 + 0.29) / 3,
+      3,
+    );
+  });
+
+  it('marks the per-metric winner with a win', () => {
+    const lb = buildLeaderboard([jobA, jobB, jobC]);
+    const winner = lb.rows.find((r) => r.wins > 0);
+    expect(winner!.jobId).toBe('b');
+    expect(winner!.wins).toBe(1);
+  });
+
+  it('drops columns not present in every report', () => {
+    const lb = buildLeaderboard([jobA, jobC]);
+    expect(lb.droppedColumns).toContain('notes');
+  });
+
+  it('falls back to auto-detected numeric columns when no score column exists', () => {
+    const r1: EvalReport = {
+      header: ['task', 'accuracy', 'f1'],
+      body: [
+        ['a', 0.5, 0.4],
+        ['b', 0.6, 0.55],
+      ],
+    };
+    const r2: EvalReport = {
+      header: ['task', 'accuracy', 'f1'],
+      body: [
+        ['a', 0.55, 0.5],
+        ['b', 0.62, 0.6],
+      ],
+    };
+    const lb = buildLeaderboard([
+      { jobId: 'x', jobTitle: 'X', report: r1 },
+      { jobId: 'y', jobTitle: 'Y', report: r2 },
+    ]);
+    expect(lb.metricColumns).toEqual(['accuracy', 'f1']);
+  });
+
+  it('handles empty input', () => {
+    const lb = buildLeaderboard([]);
+    expect(lb.rows).toEqual([]);
+    expect(lb.metricColumns).toEqual([]);
+  });
+
+  it('respects explicit metricColumns option', () => {
+    const lb = buildLeaderboard([jobA, jobB], { metricColumns: ['score'] });
+    expect(lb.metricColumns).toEqual(['score']);
+  });
+});
+
+describe('buildCategoryBreakdown', () => {
+  it('produces one row per category with per-job means', () => {
+    const rows = buildCategoryBreakdown([jobA, jobB], 'score', 'metric');
+    const mmlu = rows.find((r) => r.category === 'mmlu')!;
+    expect(mmlu.cells.a.mean).toBeCloseTo(0.6, 3);
+    expect(mmlu.cells.b.mean).toBeCloseTo(0.66, 3);
+  });
+});
+
+describe('toMarkdownReport', () => {
+  it('emits a summary table and per-category breakdowns', () => {
+    const lb = buildLeaderboard([jobA, jobB]);
+    const md = toMarkdownReport(
+      lb,
+      lb.categoryColumn
+        ? lb.metricColumns.map((m) => ({
+            metric: m,
+            rows: buildCategoryBreakdown([jobA, jobB], m, lb.categoryColumn!),
+          }))
+        : [],
+      { a: 'sft-llama', b: 'sft-qwen' },
+    );
+    expect(md).toContain('# Evaluation Leaderboard');
+    expect(md).toContain('## Summary');
+    expect(md).toContain('sft-llama');
+    expect(md).toContain('sft-qwen');
+  });
+});
+
+describe('toCsv', () => {
+  it('emits a header row plus one row per model', () => {
+    const lb = buildLeaderboard([jobA, jobB]);
+    const csv = toCsv(lb);
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe('model,score,wins');
+    expect(lines).toHaveLength(3);
+  });
+
+  it('escapes commas and quotes in titles', () => {
+    const jobWeird: JobReport = {
+      jobId: 'w',
+      jobTitle: 'name, with "quotes"',
+      report: reportA,
+    };
+    const lb = buildLeaderboard([jobWeird]);
+    const csv = toCsv(lb);
+    expect(csv).toContain('"name, with ""quotes"""');
+  });
+});

--- a/src/renderer/components/Experiment/Tasks/evalAggregate.ts
+++ b/src/renderer/components/Experiment/Tasks/evalAggregate.ts
@@ -1,0 +1,365 @@
+export interface EvalReport {
+  header: string[];
+  body: unknown[][];
+}
+
+export interface JobReport {
+  jobId: string;
+  jobTitle: string;
+  report: EvalReport;
+}
+
+export interface LeaderboardCell {
+  mean: number;
+  stddev: number;
+  count: number;
+}
+
+export interface LeaderboardRow {
+  jobId: string;
+  jobTitle: string;
+  cells: Record<string, LeaderboardCell>;
+  wins: number;
+}
+
+export interface LeaderboardTable {
+  rows: LeaderboardRow[];
+  metricColumns: string[];
+  categoryColumn: string | null;
+  droppedColumns: string[];
+  incompatibleJobIds: string[];
+}
+
+const NUMERIC_FRACTION_THRESHOLD = 0.5;
+
+function normalize(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function isNumericLike(value: unknown): boolean {
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'string') {
+    if (value.trim() === '') return false;
+    const parsed = parseFloat(value);
+    return !Number.isNaN(parsed) && Number.isFinite(parsed);
+  }
+  return false;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = parseFloat(value);
+    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+export function findScoreColumn(header: string[]): number {
+  return header.findIndex((col) => normalize(col) === 'score');
+}
+
+export function findCategoryColumn(header: string[]): number {
+  const candidates = ['metric', 'task', 'subject', 'category', 'type', 'name'];
+  for (const candidate of candidates) {
+    const idx = header.findIndex((col) => normalize(col) === candidate);
+    if (idx >= 0) return idx;
+  }
+  return 0;
+}
+
+export function detectNumericColumns(report: EvalReport): number[] {
+  const { header, body } = report;
+  if (body.length === 0) return [];
+  const numericCounts = new Array(header.length).fill(0);
+  body.forEach((row) => {
+    header.forEach((_, colIdx) => {
+      if (isNumericLike(row[colIdx])) {
+        numericCounts[colIdx] += 1;
+      }
+    });
+  });
+  return header
+    .map((_, idx) => idx)
+    .filter(
+      (idx) => numericCounts[idx] / body.length >= NUMERIC_FRACTION_THRESHOLD,
+    );
+}
+
+export function intersectHeaders(reports: EvalReport[]): {
+  common: string[];
+  dropped: string[];
+} {
+  if (reports.length === 0) return { common: [], dropped: [] };
+  const firstHeader = reports[0].header;
+  const allHeaders = reports.map((r) => new Set(r.header.map(normalize)));
+  const common: string[] = [];
+  const dropped: string[] = [];
+  firstHeader.forEach((col) => {
+    const key = normalize(col);
+    if (allHeaders.every((s) => s.has(key))) {
+      common.push(col);
+    } else {
+      dropped.push(col);
+    }
+  });
+  reports.slice(1).forEach((r) => {
+    r.header.forEach((col) => {
+      const key = normalize(col);
+      const alreadyDropped = dropped.some((d) => normalize(d) === key);
+      const alreadyCommon = common.some((c) => normalize(c) === key);
+      if (!alreadyCommon && !alreadyDropped) dropped.push(col);
+    });
+  });
+  return { common, dropped };
+}
+
+function colIndexByName(header: string[], name: string): number {
+  const target = normalize(name);
+  return header.findIndex((c) => normalize(c) === target);
+}
+
+function aggregateCell(
+  report: EvalReport,
+  metricColIdx: number,
+  rowFilter?: { col: number; value: string },
+): LeaderboardCell {
+  const values: number[] = [];
+  report.body.forEach((row) => {
+    if (rowFilter) {
+      if (String(row[rowFilter.col] ?? '') !== rowFilter.value) return;
+    }
+    const n = toNumber(row[metricColIdx]);
+    if (n !== null) values.push(n);
+  });
+  if (values.length === 0) {
+    return { mean: NaN, stddev: NaN, count: 0 };
+  }
+  const sum = values.reduce((a, b) => a + b, 0);
+  const mean = sum / values.length;
+  const variance =
+    values.reduce((acc, v) => acc + (v - mean) ** 2, 0) / values.length;
+  return {
+    mean: Number(mean.toFixed(4)),
+    stddev: Number(Math.sqrt(variance).toFixed(4)),
+    count: values.length,
+  };
+}
+
+export interface BuildLeaderboardOptions {
+  /**
+   * If provided, only these metric column names (case-insensitive) are used.
+   * Otherwise, falls back to "score" if present in every report, else to
+   * the intersection of auto-detected numeric columns.
+   */
+  metricColumns?: string[];
+  /**
+   * Column name to treat as the row label inside each report (e.g. "metric",
+   * "task"). Used both for filtering and breakdown reports.
+   */
+  categoryColumn?: string;
+}
+
+export function buildLeaderboard(
+  jobReports: JobReport[],
+  options: BuildLeaderboardOptions = {},
+): LeaderboardTable {
+  const validReports = jobReports.filter((j) => j.report.header.length > 0);
+  if (validReports.length === 0) {
+    return {
+      rows: [],
+      metricColumns: [],
+      categoryColumn: null,
+      droppedColumns: [],
+      incompatibleJobIds: [],
+    };
+  }
+
+  const { common, dropped } = intersectHeaders(
+    validReports.map((j) => j.report),
+  );
+
+  let metricNames: string[];
+  if (options.metricColumns && options.metricColumns.length > 0) {
+    metricNames = options.metricColumns.filter((name) =>
+      common.some((c) => normalize(c) === normalize(name)),
+    );
+  } else {
+    const scoreInCommon = common.find((c) => normalize(c) === 'score');
+    if (scoreInCommon) {
+      metricNames = [scoreInCommon];
+    } else {
+      const perReportNumeric = validReports.map(
+        (j) =>
+          new Set(
+            detectNumericColumns(j.report).map((idx) =>
+              normalize(j.report.header[idx]),
+            ),
+          ),
+      );
+      metricNames = common.filter((c) =>
+        perReportNumeric.every((s) => s.has(normalize(c))),
+      );
+    }
+  }
+
+  const categoryName =
+    options.categoryColumn ??
+    common.find(
+      (c) =>
+        !metricNames.some((m) => normalize(m) === normalize(c)) &&
+        ['metric', 'task', 'subject', 'category', 'type', 'name'].includes(
+          normalize(c),
+        ),
+    ) ??
+    null;
+
+  const rows: LeaderboardRow[] = validReports.map((j) => {
+    const cells: Record<string, LeaderboardCell> = {};
+    metricNames.forEach((metric) => {
+      const colIdx = colIndexByName(j.report.header, metric);
+      if (colIdx < 0) {
+        cells[metric] = { mean: NaN, stddev: NaN, count: 0 };
+      } else {
+        cells[metric] = aggregateCell(j.report, colIdx);
+      }
+    });
+    return {
+      jobId: j.jobId,
+      jobTitle: j.jobTitle,
+      cells,
+      wins: 0,
+    };
+  });
+
+  metricNames.forEach((metric) => {
+    let best = -Infinity;
+    rows.forEach((r) => {
+      const v = r.cells[metric]?.mean;
+      if (Number.isFinite(v) && v > best) best = v;
+    });
+    if (Number.isFinite(best)) {
+      rows.forEach((r) => {
+        if (r.cells[metric]?.mean === best) r.wins += 1;
+      });
+    }
+  });
+
+  return {
+    rows,
+    metricColumns: metricNames,
+    categoryColumn: categoryName,
+    droppedColumns: dropped,
+    incompatibleJobIds: jobReports
+      .filter((j) => j.report.header.length === 0)
+      .map((j) => j.jobId),
+  };
+}
+
+export interface CategoryBreakdownRow {
+  category: string;
+  cells: Record<string, Record<string, number>>;
+}
+
+export function buildCategoryBreakdown(
+  jobReports: JobReport[],
+  metric: string,
+  categoryColumn: string,
+): CategoryBreakdownRow[] {
+  const categories = new Set<string>();
+  jobReports.forEach((j) => {
+    const catIdx = colIndexByName(j.report.header, categoryColumn);
+    if (catIdx < 0) return;
+    j.report.body.forEach((row) => {
+      categories.add(String(row[catIdx] ?? ''));
+    });
+  });
+  const result: CategoryBreakdownRow[] = [];
+  Array.from(categories)
+    .sort()
+    .forEach((cat) => {
+      const cells: Record<string, Record<string, number>> = {};
+      jobReports.forEach((j) => {
+        const catIdx = colIndexByName(j.report.header, categoryColumn);
+        const metricIdx = colIndexByName(j.report.header, metric);
+        if (catIdx < 0 || metricIdx < 0) return;
+        const agg = aggregateCell(j.report, metricIdx, {
+          col: catIdx,
+          value: cat,
+        });
+        cells[j.jobId] = { mean: agg.mean, count: agg.count };
+      });
+      result.push({ category: cat, cells });
+    });
+  return result;
+}
+
+export function toMarkdownReport(
+  table: LeaderboardTable,
+  breakdowns: { metric: string; rows: CategoryBreakdownRow[] }[],
+  jobLookup: Record<string, string>,
+): string {
+  const lines: string[] = [];
+  lines.push('# Evaluation Leaderboard\n');
+  lines.push(`_Generated ${new Date().toISOString()}_\n`);
+  if (table.droppedColumns.length > 0) {
+    lines.push(
+      `> Columns dropped (not present in every job): ${table.droppedColumns.join(', ')}\n`,
+    );
+  }
+
+  lines.push('## Summary\n');
+  const header = ['Model', ...table.metricColumns, 'Wins'];
+  lines.push(`| ${header.join(' | ')} |`);
+  lines.push(`| ${header.map(() => '---').join(' | ')} |`);
+  table.rows.forEach((r) => {
+    const cells = table.metricColumns.map((m) => {
+      const c = r.cells[m];
+      if (!c || !Number.isFinite(c.mean)) return '—';
+      return c.stddev > 0
+        ? `${c.mean.toFixed(3)} ± ${c.stddev.toFixed(3)}`
+        : c.mean.toFixed(3);
+    });
+    lines.push(`| ${[r.jobTitle, ...cells, String(r.wins)].join(' | ')} |`);
+  });
+  lines.push('');
+
+  if (breakdowns.length > 0 && table.categoryColumn) {
+    lines.push(`## Per-${table.categoryColumn} breakdown\n`);
+    breakdowns.forEach(({ metric, rows }) => {
+      lines.push(`### ${metric}\n`);
+      const jobIds = table.rows.map((r) => r.jobId);
+      const titles = jobIds.map((id) => jobLookup[id] ?? id);
+      lines.push(`| ${[table.categoryColumn, ...titles].join(' | ')} |`);
+      lines.push(
+        `| ${[table.categoryColumn, ...titles].map(() => '---').join(' | ')} |`,
+      );
+      rows.forEach((row) => {
+        const cells = jobIds.map((id) => {
+          const cell = row.cells[id];
+          if (!cell || !Number.isFinite(cell.mean)) return '—';
+          return cell.mean.toFixed(3);
+        });
+        lines.push(`| ${[row.category, ...cells].join(' | ')} |`);
+      });
+      lines.push('');
+    });
+  }
+
+  return lines.join('\n');
+}
+
+export function toCsv(table: LeaderboardTable): string {
+  const header = ['model', ...table.metricColumns, 'wins'];
+  const escape = (s: string) =>
+    /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  const lines = [header.map(escape).join(',')];
+  table.rows.forEach((r) => {
+    const cells = table.metricColumns.map((m) => {
+      const c = r.cells[m];
+      return c && Number.isFinite(c.mean) ? String(c.mean) : '';
+    });
+    lines.push([r.jobTitle, ...cells, String(r.wins)].map(escape).join(','));
+  });
+  return lines.join('\n');
+}


### PR DESCRIPTION
🚧
add **Leaderboard** sub-tab under Experiment → Tasks → Evals that aggregates eval results across multiple jobs into a single sortable table.