### PR TITLE
Fix missed clicks on new provider select box

### DIFF
--- a/src/renderer/components/Team/providerForms/ProviderTypePicker.tsx
+++ b/src/renderer/components/Team/providerForms/ProviderTypePicker.tsx
@@ -28,6 +28,7 @@ export default function ProviderTypePicker({
         value={selectedType}
         placeholder="Select provider type"
         sx={{ mt: 1 }}
+        slotProps={{ listbox: { sx: { maxHeight: 'none' } } }}
         onChange={(event, value) => {
           if (!value) return;
           setSelectedType(value);


### PR DESCRIPTION
There was a bug on the select box when you are creating a new provider.  Basically if you click on the select to edit it, and then scroll down...your click will do nothing but reset the box.  

The reason why is a bit complicated but it seems to stem from the fact that the first provider is selected and then after you scroll the selected provider disappears from the MUI element and somehow this causes it to not register the click.

This fix is a workaround that avoids this by just growing the box so it doesn't scroll.  Eventually we should replace the select box with cards or something more dynamic (assuming we are going to keep adding providers).