### PR TITLE
Fix docs dependabot to make more manageable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,9 @@ updates:
           - "patch"
 
   # Docs site (Docusaurus, managed with yarn classic — dependabot's npm ecosystem auto-detects yarn.lock)
-  # Build is pinned to Node 18 via transformerlab-docs/netlify.toml. Packages that drop Node 18
-  # support are explicitly ignored below; revisit those ignores when the build moves to Node 20+.
+  # Build is pinned to Node 18 via transformerlab-docs/netlify.toml. Major bumps are ignored across
+  # the board (manual coordination needed); packages that drop Node 18 support in a minor or patch
+  # bump are listed individually under `ignore` below. Revisit when the build moves to Node 20+.
   - package-ecosystem: "npm"
     directory: "/transformerlab-docs"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,9 @@ updates:
       # mermaid >= 11.12 requires Node 20+; we're pinned to Node 18 in Netlify.
       - dependency-name: "mermaid"
         versions: [">=11.12"]
+      # Major bumps on docs deps need manual coordination; minor/patch is enough for security.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # API (FastAPI, managed with uv)
   - package-ecosystem: "uv"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,17 +14,37 @@ updates:
           - "patch"
 
   # Docs site (Docusaurus, managed with yarn classic — dependabot's npm ecosystem auto-detects yarn.lock)
+  # Build is pinned to Node 18 via transformerlab-docs/netlify.toml. Packages that drop Node 18
+  # support are explicitly ignored below; revisit those ignores when the build moves to Node 20+.
   - package-ecosystem: "npm"
     directory: "/transformerlab-docs"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "docs-deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docs"
     groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+          - "@mdx-js/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # mermaid >= 11.12 requires Node 20+; we're pinned to Node 18 in Netlify.
+      - dependency-name: "mermaid"
+        versions: [">=11.12"]
 
   # API (FastAPI, managed with uv)
   - package-ecosystem: "uv"


### PR DESCRIPTION
* Ignore major bumps for the docs site — they almost always break Docusaurus plugin compat. Patch+minor is enough for security
* Group all Docusaurus packages into one PR — they must move in lockstep, and grouping them avoids merge churn
* Group all React packages together (react + react-dom)
* Better commit-message prefix (docs-deps:) so they're easy to filter