### PR TITLE
Make npm test only care about src and not run all agent worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/.erb/mocks/fileMock.js",
       "\\.(css|less|sass|scss)$": "identity-obj-proxy"
     },
+    "roots": [
+      "<rootDir>/src"
+    ],
     "setupFiles": [
       "./.erb/scripts/check-build-exists.ts",
       "./.erb/scripts/jest.setup.ts"
@@ -84,7 +87,16 @@
       "url": "http://localhost/"
     },
     "testPathIgnorePatterns": [
-      ".erb/dll"
+      "/node_modules/",
+      "/\\.claude/",
+      "/\\.erb/dll/",
+      "/\\.git/"
+    ],
+    "watchPathIgnorePatterns": [
+      "/node_modules/",
+      "/\\.claude/",
+      "/\\.erb/dll/",
+      "/\\.git/"
     ],
     "transform": {
       "\\.(ts|tsx|js|jsx)$": "ts-jest"


### PR DESCRIPTION
This is slightly belt-and-suspenders...sets test roots to only include `src` and also includes a list of directories to not explore in case the first part gets changed later.

Without this, running npm test on your machine with lots of claude worktrees could blow up your laptop.

Note: we currently don't use `npm test` anywhere even though it is referenced in our agent docs. Working on updating that in #2171. 
