### PR TITLE
Stop dependabot from trying to update boto3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -119,6 +119,13 @@ updates:
       # fails immediately on import. Revisit after refactoring the import path. See PR #2083.
       - dependency-name: "azure-mgmt-resource"
         versions: [">=25"]
+      # boto3 1.41+ requires botocore >=1.41, which in turn requires newer aiobotocore /
+      # s3fs / fsspec. But `datasets` is pinned to 3.x (above), which caps
+      # fsspec at <=2025.3.0 — and the s3fs releases compatible with that fsspec cap
+      # only support botocore <1.41. Result: boto3 >=1.41 is uninstallable until the
+      # datasets pin is lifted. Hold boto3 at 1.40.x. See PR #2159.
+      - dependency-name: "boto3"
+        versions: [">=1.41"]
 
   # CLI (Typer, managed with uv)
   - package-ecosystem: "uv"


### PR DESCRIPTION
As mentioned in the comments:
boto3 1.41+ requires botocore >=1.41, which in turn requires newer aiobotocore s3fs / fsspec. 
But `datasets` is pinned to 3.x (above), which caps fsspec at <=2025.3.0 — and the s3fs releases 
compatible with that fsspec cap only support botocore <1.41.
Result: boto3 >=1.41 is uninstallable until the datasets pin is lifted. 
Hold boto3 at 1.40.x. See PR #2159.