### PR TITLE
Fixes to make dependabot less noisy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,12 @@ updates:
       # single toolchain-upgrade PR when it's worth a focused day.
       - dependency-name: "webpack-cli"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "webpack-dev-server"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "webpack-merge"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "webpack-bundle-analyzer"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "css-loader"
         update-types: ["version-update:semver-major"]
       - dependency-name: "sass-loader"
@@ -84,6 +90,29 @@ updates:
       - dependency-name: "style-loader"
         update-types: ["version-update:semver-major"]
       - dependency-name: "postcss-loader"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "esbuild-loader"
+        update-types: ["version-update:semver-major"]
+      # file-loader and url-loader are abandoned upstream (replaced by webpack 5's
+      # built-in asset modules). No future major will be worth taking — only here
+      # for legacy compatibility.
+      - dependency-name: "file-loader"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "url-loader"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mini-css-extract-plugin"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "css-minimizer-webpack-plugin"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "html-webpack-plugin"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tsconfig-paths-webpack-plugin"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@svgr/webpack"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@pmmmwh/react-refresh-webpack-plugin"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@teamsupercell/typings-for-css-modules-loader"
         update-types: ["version-update:semver-major"]
 
   # Docs site (Docusaurus, managed with yarn classic — dependabot's npm ecosystem auto-detects yarn.lock)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,22 @@ updates:
       # package). Lift this in lockstep when Node itself moves.
       - dependency-name: "@types/node"
         versions: [">=23"]
+      # Webpack loader / CLI family. These churn constantly and each major typically
+      # requires coordinated changes across .erb/configs/* (webpack 5 config shape,
+      # asset modules, postcss override compatibility — see the `overrides` note in
+      # package.json). We're not chasing the bleeding edge on the build toolchain;
+      # security fixes still land via minor/patch. Bump these deliberately as a
+      # single toolchain-upgrade PR when it's worth a focused day.
+      - dependency-name: "webpack-cli"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "css-loader"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "sass-loader"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "style-loader"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "postcss-loader"
+        update-types: ["version-update:semver-major"]
 
   # Docs site (Docusaurus, managed with yarn classic — dependabot's npm ecosystem auto-detects yarn.lock)
   # Build runs on Node 22 via transformerlab-docs/netlify.toml. Major bumps are ignored across

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,13 @@ updates:
       # See PR #2130.
       - dependency-name: "jest-environment-jsdom"
         versions: [">=30"]
+      # @types/node majors track Node runtime majors. We're pinned to Node 22 (see
+      # CLAUDE.md; conda env, scripts/dev.py, CI), and the renderer doesn't import
+      # Node builtins directly — only build tooling under .erb/ and scripts/ does.
+      # Holding at 22.x avoids a recurring PR with zero security exposure (types-only
+      # package). Lift this in lockstep when Node itself moves.
+      - dependency-name: "@types/node"
+        versions: [">=23"]
 
   # Docs site (Docusaurus, managed with yarn classic — dependabot's npm ecosystem auto-detects yarn.lock)
   # Build runs on Node 22 via transformerlab-docs/netlify.toml. Major bumps are ignored across


### PR DESCRIPTION
A bunch of updates to make dependabot less noisy:
- Peg node runtime at 22. We aren't upgrading that casually. No security exposure.
- Change some noisy updates to monthly instead of weekly
- Ignore majors on webpack/loader libraries that we don't really care about upgrading