### PR TITLE
Clean up UI on Team Members list

### DIFF
--- a/src/renderer/components/Team/MembersSection.tsx
+++ b/src/renderer/components/Team/MembersSection.tsx
@@ -50,6 +50,9 @@ export default function MembersSection({
         <tbody>
           {members?.map((m, idx) => {
             const isSelf = !!currentUserId && m.user_id === currentUserId;
+            // Hide the demote button when clicking it would leave the team
+            // with zero owners (the backend rejects this, but hiding the
+            // button avoids a dead-end click + error message).
             const wouldStrandTeam =
               isSelf && m.role === 'owner' && ownerCount <= 1;
             const showRoleButton = iAmOwner && !wouldStrandTeam;

--- a/src/renderer/components/Team/MembersSection.tsx
+++ b/src/renderer/components/Team/MembersSection.tsx
@@ -1,6 +1,8 @@
 import { Box, Button, Stack, Table, Tooltip, Typography } from '@mui/joy';
 import { PlusIcon, User2Icon } from 'lucide-react';
 
+const inviteMemberStartDecorator = <PlusIcon />;
+
 type Member = {
   user_id?: string;
   email?: string;
@@ -96,7 +98,7 @@ export default function MembersSection({
       >
         <span>
           <Button
-            startDecorator={<PlusIcon />}
+            startDecorator={inviteMemberStartDecorator}
             onClick={onInvite}
             variant="soft"
             disabled={!iAmOwner}

--- a/src/renderer/components/Team/MembersSection.tsx
+++ b/src/renderer/components/Team/MembersSection.tsx
@@ -11,6 +11,7 @@ type Props = {
   members: Member[] | undefined;
   roleError?: string;
   iAmOwner: boolean;
+  currentUserId?: string;
   onUpdateRole: (userId: string, currentRole: string) => void;
   onInvite: () => void;
 };
@@ -19,9 +20,11 @@ export default function MembersSection({
   members,
   roleError,
   iAmOwner,
+  currentUserId,
   onUpdateRole,
   onInvite,
 }: Props): JSX.Element {
+  const ownerCount = members?.filter((m) => m.role === 'owner').length ?? 0;
   return (
     <Box sx={{ mt: 3 }}>
       <Typography level="title-lg" mb={1}>
@@ -45,37 +48,43 @@ export default function MembersSection({
           </tr>
         </thead>
         <tbody>
-          {members?.map((m, idx) => (
-            <tr key={m.user_id ?? m.email ?? idx}>
-              <td>
-                <Stack direction="row" alignItems="center" gap={1}>
-                  <User2Icon />
-                  <Box>
-                    <Typography fontWeight="md">{m?.email ?? '—'}</Typography>
-                  </Box>
-                </Stack>
-              </td>
-              <td>{m?.role}</td>
-              <td>
-                {iAmOwner ? (
-                  <Box
-                    sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
-                  >
-                    <Button
-                      variant="outlined"
-                      onClick={() =>
-                        onUpdateRole(m.user_id ?? '', m.role ?? '')
-                      }
+          {members?.map((m, idx) => {
+            const isSelf = !!currentUserId && m.user_id === currentUserId;
+            const wouldStrandTeam =
+              isSelf && m.role === 'owner' && ownerCount <= 1;
+            const showRoleButton = iAmOwner && !wouldStrandTeam;
+            return (
+              <tr key={m.user_id ?? m.email ?? idx}>
+                <td>
+                  <Stack direction="row" alignItems="center" gap={1}>
+                    <User2Icon />
+                    <Box>
+                      <Typography fontWeight="md">{m?.email ?? '—'}</Typography>
+                    </Box>
+                  </Stack>
+                </td>
+                <td>{m?.role}</td>
+                <td>
+                  {showRoleButton ? (
+                    <Box
+                      sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
                     >
-                      {m?.role === 'owner'
-                        ? 'Change role to member'
-                        : 'Change role to owner'}
-                    </Button>
-                  </Box>
-                ) : null}
-              </td>
-            </tr>
-          ))}
+                      <Button
+                        variant="outlined"
+                        onClick={() =>
+                          onUpdateRole(m.user_id ?? '', m.role ?? '')
+                        }
+                      >
+                        {m?.role === 'owner'
+                          ? 'Change role to member'
+                          : 'Change role to owner'}
+                      </Button>
+                    </Box>
+                  ) : null}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </Table>
       <Tooltip

--- a/src/renderer/components/Team/MembersSection.tsx
+++ b/src/renderer/components/Team/MembersSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Stack, Table, Typography } from '@mui/joy';
+import { Box, Button, Stack, Table, Tooltip, Typography } from '@mui/joy';
 import { PlusIcon, User2Icon } from 'lucide-react';
 
 type Member = {
@@ -57,29 +57,42 @@ export default function MembersSection({
               </td>
               <td>{m?.role}</td>
               <td>
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                  <Button
-                    variant="outlined"
-                    onClick={() => onUpdateRole(m.user_id ?? '', m.role ?? '')}
+                {iAmOwner ? (
+                  <Box
+                    sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
                   >
-                    {m?.role === 'owner'
-                      ? 'Change role to member'
-                      : 'Change role to owner'}
-                  </Button>
-                </Box>
+                    <Button
+                      variant="outlined"
+                      onClick={() =>
+                        onUpdateRole(m.user_id ?? '', m.role ?? '')
+                      }
+                    >
+                      {m?.role === 'owner'
+                        ? 'Change role to member'
+                        : 'Change role to owner'}
+                    </Button>
+                  </Box>
+                ) : null}
               </td>
             </tr>
           ))}
         </tbody>
       </Table>
-      <Button
-        startDecorator={<PlusIcon />}
-        onClick={onInvite}
-        variant="soft"
-        disabled={!iAmOwner}
+      <Tooltip
+        title={!iAmOwner ? 'Only owners can invite members' : ''}
+        disableHoverListener={iAmOwner}
       >
-        Invite Member {!iAmOwner ? '(Only owners can invite members)' : ''}
-      </Button>
+        <span>
+          <Button
+            startDecorator={<PlusIcon />}
+            onClick={onInvite}
+            variant="soft"
+            disabled={!iAmOwner}
+          >
+            Invite Member
+          </Button>
+        </span>
+      </Tooltip>
     </Box>
   );
 }

--- a/src/renderer/components/Team/Team.tsx
+++ b/src/renderer/components/Team/Team.tsx
@@ -456,6 +456,15 @@ export default function UserLoginTest(): JSX.Element {
 
     const newRole = currentRole === 'owner' ? 'member' : 'owner';
 
+    // Warn when demoting yourself — you can't undo this without another owner.
+    if (userId === authContext.user?.id && newRole === 'member') {
+      // eslint-disable-next-line no-alert
+      const confirmed = window.confirm(
+        'Are you sure you want to change your own role from owner to member? You will lose the ability to manage this team and you will not be able to undo this change yourself.',
+      );
+      if (!confirmed) return;
+    }
+
     // Clear errors when we start a change
     handleSetRoleError(undefined);
 

--- a/src/renderer/components/Team/Team.tsx
+++ b/src/renderer/components/Team/Team.tsx
@@ -938,6 +938,7 @@ export default function UserLoginTest(): JSX.Element {
           members={members?.members}
           roleError={roleError}
           iAmOwner={iAmOwner}
+          currentUserId={authContext.user?.id}
           onUpdateRole={handleUpdateRole}
           onInvite={() => setOpenInviteModal(true)}
         />


### PR DESCRIPTION
A few changes to improve members list UI:
- warn a team owner if they try to change their role to member (they won't be able to change back)
- hide buttons for changing team member role if user isn't owner
- move detailed parentheses on Invite button to be tooltip
- prevent a team owner from demoting the last owner and stranding the team without an owner