### PR TITLE
Cleanup Experiment List UI

### DIFF
--- a/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
+++ b/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
@@ -147,30 +147,34 @@ export default function ExperimentsManagerModal({
           }}
         >
           <ModalClose />
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: 2,
-              minHeight: 32,
-              mb: 2,
-              // Reserve space so + New Experiment doesn't overlap ModalClose X.
-              pr: 4,
-            }}
-          >
-            <Typography level="h3" component="h2">
-              Experiments
-            </Typography>
-            <Button
-              size="sm"
-              onClick={() => {
-                onClose();
-                onNewExperiment();
+          <Box sx={{ mb: 2 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 2,
+                minHeight: 32,
+                // Reserve space so + New Experiment doesn't overlap ModalClose X.
+                pr: 4,
               }}
             >
-              + New Experiment
-            </Button>
+              <Typography level="h3" component="h2">
+                Experiments
+              </Typography>
+              <Button
+                size="sm"
+                onClick={() => {
+                  onClose();
+                  onNewExperiment();
+                }}
+              >
+                + New Experiment
+              </Button>
+            </Box>
+            <Typography level="body-xs" color="neutral" sx={{ mt: 0.5 }}>
+              Click an experiment name to open it.
+            </Typography>
           </Box>
           <Input
             placeholder="Search experiments…"

--- a/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
+++ b/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
@@ -147,31 +147,31 @@ export default function ExperimentsManagerModal({
           }}
         >
           <ModalClose />
-          <Stack spacing={2} sx={{ mb: 2 }}>
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                minHeight: 32,
-                pr: 0.5,
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 2,
+              minHeight: 32,
+              mb: 2,
+              // Reserve space so + New Experiment doesn't overlap ModalClose X.
+              pr: 4,
+            }}
+          >
+            <Typography level="h3" component="h2">
+              Experiments
+            </Typography>
+            <Button
+              size="sm"
+              onClick={() => {
+                onClose();
+                onNewExperiment();
               }}
             >
-              <Typography level="h3" component="h2">
-                Experiments
-              </Typography>
-            </Box>
-            <Box>
-              <Button
-                size="sm"
-                onClick={() => {
-                  onClose();
-                  onNewExperiment();
-                }}
-              >
-                + New Experiment
-              </Button>
-            </Box>
-          </Stack>
+              + New Experiment
+            </Button>
+          </Box>
           <Input
             placeholder="Search experiments…"
             value={search}

--- a/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
+++ b/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
@@ -203,7 +203,7 @@ export default function ExperimentsManagerModal({
                     <th style={{ width: 160 }}>Owner</th>
                     <th style={{ width: 120 }}>Last Opened</th>
                     <th style={{ width: 100 }}>Sharing</th>
-                    <th style={{ width: 160 }}>Actions</th>
+                    <th style={{ width: 160, textAlign: 'right' }}>Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -284,6 +284,7 @@ export default function ExperimentsManagerModal({
                               display: 'flex',
                               gap: 0.5,
                               alignItems: 'center',
+                              justifyContent: 'flex-end',
                             }}
                           >
                             <Button

--- a/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
+++ b/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
@@ -209,7 +209,7 @@ export default function ExperimentsManagerModal({
                     <th style={{ width: 100 }}>Sharing</th>
                     <th
                       style={{
-                        width: 160,
+                        width: 120,
                         textAlign: 'right',
                         paddingRight: 14,
                       }}
@@ -299,13 +299,6 @@ export default function ExperimentsManagerModal({
                               justifyContent: 'flex-end',
                             }}
                           >
-                            <Button
-                              size="sm"
-                              variant="plain"
-                              onClick={() => handleOpen(exp)}
-                            >
-                              Open
-                            </Button>
                             <TagEditor
                               experimentId={exp.id}
                               experimentName={exp.name}

--- a/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
+++ b/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
@@ -203,7 +203,15 @@ export default function ExperimentsManagerModal({
                     <th style={{ width: 160 }}>Owner</th>
                     <th style={{ width: 120 }}>Last Opened</th>
                     <th style={{ width: 100 }}>Sharing</th>
-                    <th style={{ width: 160, textAlign: 'right' }}>Actions</th>
+                    <th
+                      style={{
+                        width: 160,
+                        textAlign: 'right',
+                        paddingRight: 14,
+                      }}
+                    >
+                      Actions
+                    </th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
+++ b/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/joy';
-import { ShareIcon, Trash2Icon } from 'lucide-react';
+import { Trash2Icon, UserRoundPlusIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import {
   useSWRWithAuth as useSWR,
@@ -311,7 +311,7 @@ export default function ExperimentsManagerModal({
                                     variant="plain"
                                     onClick={() => setShareTarget(exp)}
                                   >
-                                    <ShareIcon size={14} />
+                                    <UserRoundPlusIcon size={14} />
                                   </IconButton>
                                 </Tooltip>
                                 <Tooltip title="Delete">

--- a/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
+++ b/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
@@ -279,7 +279,20 @@ export default function ExperimentsManagerModal({
                           )}
                         </td>
                         <td>
-                          <Box sx={{ display: 'flex', gap: 0.5 }}>
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              gap: 0.5,
+                              alignItems: 'center',
+                            }}
+                          >
+                            <Button
+                              size="sm"
+                              variant="plain"
+                              onClick={() => handleOpen(exp)}
+                            >
+                              Open
+                            </Button>
                             <TagEditor
                               experimentId={exp.id}
                               experimentName={exp.name}
@@ -290,13 +303,6 @@ export default function ExperimentsManagerModal({
                               }
                               onChanged={() => mutate()}
                             />
-                            <Button
-                              size="sm"
-                              variant="plain"
-                              onClick={() => handleOpen(exp)}
-                            >
-                              Open
-                            </Button>
                             {canManage(exp) && (
                               <>
                                 <Tooltip title="Share">

--- a/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
+++ b/src/renderer/components/Experiment/ExperimentsManagerModal.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   Chip,
   CircularProgress,
-  Divider,
   IconButton,
   Input,
   Modal,
@@ -182,7 +181,6 @@ export default function ExperimentsManagerModal({
             onChange={(e) => setSearch(e.target.value)}
             sx={{ mb: 2 }}
           />
-          <Divider />
 
           {isLoading ? (
             <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>

--- a/src/renderer/components/Experiment/SelectExperimentMenu.tsx
+++ b/src/renderer/components/Experiment/SelectExperimentMenu.tsx
@@ -254,6 +254,7 @@ export default function SelectExperimentMenu({ models }) {
                 marginBottom: '4px',
                 minHeight: '22px',
                 height: '22px',
+                width: '100%',
                 overflow: 'hidden',
                 justifyContent: 'flex-start',
               }}

--- a/src/renderer/components/Experiment/SelectExperimentMenu.tsx
+++ b/src/renderer/components/Experiment/SelectExperimentMenu.tsx
@@ -256,31 +256,29 @@ export default function SelectExperimentMenu({ models }) {
                 height: '22px',
                 overflow: 'hidden',
                 justifyContent: 'flex-start',
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
               }}
             >
-              {experimentInfo?.name || 'Select'}
               <span
                 style={{
-                  flexGrow: 0,
-                  justifyContent: 'right',
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                }}
+                title={experimentInfo?.name || undefined}
+              >
+                {experimentInfo?.name || 'Select'}
+              </span>
+              <span
+                style={{
+                  flexShrink: 0,
                   display: 'inline-flex',
                   color: 'var(--joy-palette-neutral-plainColor)',
                   marginLeft: '8px',
                 }}
               >
                 <ChevronDownIcon size="18px" />
-              </span>
-              <span
-                style={{
-                  flexGrow: 1,
-                  justifyContent: 'right',
-                  display: 'inline-flex',
-                  color: 'var(--joy-palette-neutral-plainColor)',
-                }}
-              >
-                &nbsp;
               </span>
             </MenuButton>
           )}

--- a/src/renderer/components/Experiment/SelectExperimentMenu.tsx
+++ b/src/renderer/components/Experiment/SelectExperimentMenu.tsx
@@ -348,7 +348,7 @@ export default function SelectExperimentMenu({ models }) {
               <ListItemDecorator>
                 <LayoutGridIcon strokeWidth={1} />
               </ListItemDecorator>
-              See all experiments
+              Manage experiments
             </MenuItem>
             <Divider />
             <MenuItem onClick={() => setModalOpen(true)} disabled={isLoading}>

--- a/src/renderer/components/Experiment/SelectExperimentMenu.tsx
+++ b/src/renderer/components/Experiment/SelectExperimentMenu.tsx
@@ -6,7 +6,6 @@ import {
   ChevronDownIcon,
   LayoutGridIcon,
   PlusCircleIcon,
-  SettingsIcon,
   StopCircleIcon,
 } from 'lucide-react';
 import {
@@ -41,66 +40,6 @@ import ExperimentsManagerModal from './ExperimentsManagerModal';
 interface ExperimentMenuItem {
   id: string;
   name: string;
-}
-
-function ExperimentSettingsMenu({
-  experimentInfo,
-  setExperimentId,
-  data,
-  mutate,
-}) {
-  return (
-    <Dropdown>
-      <MenuButton
-        variant="plain"
-        size="sm"
-        sx={{
-          background: 'transparent !important,',
-          padding: 0,
-          paddingInline: 0,
-          minHeight: '18px',
-          height: '18px',
-        }}
-      >
-        <SettingsIcon size="18px" color="var(--joy-palette-text-tertiary)" />
-      </MenuButton>
-      <Menu variant="soft" className="select-experiment-menu">
-        <MenuItem
-          variant="soft"
-          color="danger"
-          onClick={async () => {
-            if (
-              confirm(
-                'Are you sure you want to delete this project? If you click on "OK" There is no way to recover it.',
-              )
-            ) {
-              await chatAPI.authenticatedFetch(
-                chatAPI.Endpoints.Experiment.Delete(experimentInfo?.id),
-                {},
-              );
-
-              // Find the next available experiment (first one in the list that's not the deleted one)
-              const remainingExperiments =
-                data?.filter((exp) => exp.id !== experimentInfo?.id) || [];
-
-              if (remainingExperiments.length > 0) {
-                // Set to the first experiment in the remaining list
-                setExperimentId(remainingExperiments[0].id);
-              } else {
-                // Only set to null if no experiments remain
-                setExperimentId(null);
-              }
-
-              // Refresh the experiments list
-              mutate();
-            }
-          }}
-        >
-          Delete {experimentInfo?.name}
-        </MenuItem>
-      </Menu>
-    </Dropdown>
-  );
 }
 
 export default function SelectExperimentMenu({ models }) {
@@ -303,62 +242,47 @@ export default function SelectExperimentMenu({ models }) {
               </div>
             </Tooltip>
           ) : (
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                alignItems: 'center',
+            <MenuButton
+              variant="plain"
+              size="sm"
+              sx={{
+                fontSize: '20px',
+                backgroundColor: 'transparent !important',
+                color: 'var(--joy-palette-neutral-plainColor)',
+                paddingLeft: 1,
+                marginRight: 0.5,
                 marginBottom: '4px',
+                minHeight: '22px',
+                height: '22px',
+                overflow: 'hidden',
+                justifyContent: 'flex-start',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
               }}
             >
-              <MenuButton
-                variant="plain"
-                size="sm"
-                sx={{
-                  fontSize: '20px',
-                  backgroundColor: 'transparent !important',
+              {experimentInfo?.name || 'Select'}
+              <span
+                style={{
+                  flexGrow: 0,
+                  justifyContent: 'right',
+                  display: 'inline-flex',
                   color: 'var(--joy-palette-neutral-plainColor)',
-                  paddingLeft: 1,
-                  marginRight: 0.5,
-                  minHeight: '22px',
-                  height: '22px',
-                  overflow: 'hidden',
-                  justifyContent: 'flex-start',
-                  whiteSpace: 'nowrap',
-                  textOverflow: 'ellipsis',
+                  marginLeft: '8px',
                 }}
               >
-                {experimentInfo?.name || 'Select'}
-                <span
-                  style={{
-                    flexGrow: 0,
-                    justifyContent: 'right',
-                    display: 'inline-flex',
-                    color: 'var(--joy-palette-neutral-plainColor)',
-                    marginLeft: '8px',
-                  }}
-                >
-                  <ChevronDownIcon size="18px" />
-                </span>
-                <span
-                  style={{
-                    flexGrow: 1,
-                    justifyContent: 'right',
-                    display: 'inline-flex',
-                    color: 'var(--joy-palette-neutral-plainColor)',
-                  }}
-                >
-                  &nbsp;
-                </span>
-              </MenuButton>
-              <ExperimentSettingsMenu
-                experimentInfo={experimentInfo}
-                setExperimentId={setExperimentId}
-                data={data}
-                mutate={mutate}
-              />
-            </div>
+                <ChevronDownIcon size="18px" />
+              </span>
+              <span
+                style={{
+                  flexGrow: 1,
+                  justifyContent: 'right',
+                  display: 'inline-flex',
+                  color: 'var(--joy-palette-neutral-plainColor)',
+                }}
+              >
+                &nbsp;
+              </span>
+            </MenuButton>
           )}
           <Menu
             className="select-experiment-menu"

--- a/src/renderer/components/Experiment/TagEditorModal.tsx
+++ b/src/renderer/components/Experiment/TagEditorModal.tsx
@@ -11,7 +11,7 @@ import {
   Stack,
   Typography,
 } from '@mui/joy';
-import { PencilIcon } from 'lucide-react';
+import { TagIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import * as chatAPI from 'renderer/lib/transformerlab-api-sdk';
 import { fetcher } from 'renderer/lib/transformerlab-api-sdk';
@@ -106,7 +106,7 @@ export default function TagEditor({
         title="Edit tags"
         onClick={() => setOpen(true)}
       >
-        <PencilIcon size={14} />
+        <TagIcon size={14} />
       </IconButton>
       <Modal open={open} onClose={() => setOpen(false)}>
         <ModalDialog sx={{ minWidth: 360 }}>

--- a/src/renderer/components/Experiment/TagEditorModal.tsx
+++ b/src/renderer/components/Experiment/TagEditorModal.tsx
@@ -9,6 +9,7 @@ import {
   ModalClose,
   ModalDialog,
   Stack,
+  Tooltip,
   Typography,
 } from '@mui/joy';
 import { TagIcon } from 'lucide-react';
@@ -100,14 +101,11 @@ export default function TagEditor({
 
   return (
     <>
-      <IconButton
-        size="sm"
-        variant="plain"
-        title="Edit tags"
-        onClick={() => setOpen(true)}
-      >
-        <TagIcon size={14} />
-      </IconButton>
+      <Tooltip title="Edit tags">
+        <IconButton size="sm" variant="plain" onClick={() => setOpen(true)}>
+          <TagIcon size={14} />
+        </IconButton>
+      </Tooltip>
       <Modal open={open} onClose={() => setOpen(false)}>
         <ModalDialog sx={{ minWidth: 360 }}>
           <ModalClose />


### PR DESCRIPTION
Numerous fixes:
- removed gear icon which only showed a submenu with option to delete experiment
- changed "See All Experiments" to "Manage Experiments"
- improved how long-named experiments appear
- grouped icons (previously separated by "Open") in experiment action on management modal
- actually just removed "Open" altogether. Click an experiment to open it.
- condensed header on experiments modal
- Changed Pencil icon to TagIcon as that's all that button does (Pencil implies edit experiment IMO)
- Changed share icon to UserRoundPlusIcon so it doesn't look like Upload

Fixes #2195 