### PR TITLE
Fix playwright E2E public share check test

### DIFF
--- a/test/playwright/public-share.spec.ts
+++ b/test/playwright/public-share.spec.ts
@@ -15,7 +15,10 @@ test('public notes share link works for an unauthenticated user', async ({
   await page.getByRole('button', { name: /public share link/i }).click();
 
   const toggle = page.getByRole('switch').first();
-  await toggle.check();
+  if (!(await toggle.isChecked())) {
+    await toggle.click();
+    await expect(toggle).toBeChecked({ timeout: 10_000 });
+  }
 
   const urlInput = page.locator('input[readonly]').first();
   await expect(urlInput).toBeVisible({ timeout: 10_000 });
@@ -31,7 +34,8 @@ test('public notes share link works for an unauthenticated user', async ({
     timeout: 10_000,
   });
 
-  await toggle.uncheck();
+  await toggle.click();
+  await expect(toggle).not.toBeChecked({ timeout: 10_000 });
 
   await anonPage.reload();
   await expect(anonPage.getByText(/no longer active/i)).toBeVisible({


### PR DESCRIPTION
Fix for E2E tests that have been failing since 2044 got merged:

```
18 |   await toggle.check();

  1 failed
    [e2e] › test/playwright/public-share.spec.ts:6:5 › public notes share link works for an unauthenticated user 
  27 passed (3.0m)
Notice:   1 failed
    [e2e] › test/playwright/public-share.spec.ts:6:5 › public notes share link works for an unauthenticated user 
  27 passed (3.0m)
  ```