### PR TITLE
Add lab team setup and move secret under lab team

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.55"
+version = "0.0.56"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/provider.py
+++ b/cli/src/transformerlab_cli/commands/provider.py
@@ -100,6 +100,27 @@ def _extract_error_detail(response) -> str:
         return response.text
 
 
+def _resolve_provider_id(identifier: str) -> str | None:
+    """Resolve a provider identifier (id or name) to a provider id.
+
+    Provider names are unique within a team (enforced by the API), and the CLI
+    is always team-scoped, so a name resolves to at most one provider. Returns
+    the provider id, or None if no provider matches the identifier.
+    """
+    response = api.get("/compute_provider/providers/?include_disabled=true")
+    if response.status_code != 200:
+        return None
+
+    providers = response.json()
+    for provider in providers:
+        if provider.get("id") == identifier:
+            return identifier
+    for provider in providers:
+        if provider.get("name") == identifier:
+            return provider.get("id")
+    return None
+
+
 def _extract_provider_check_reason(result: dict) -> str:
     """Extract a human-readable provider check failure reason."""
     reason = result.get("reason")
@@ -537,14 +558,21 @@ def command_provider_update(
 
 @app.command("delete")
 def command_provider_delete(
-    provider_id: str = typer.Argument(..., help="Provider ID to delete"),
+    identifier: str = typer.Argument(..., help="Provider ID or name to delete"),
     no_interactive: bool = typer.Option(False, "--no-interactive", help="Skip confirmation prompt"),
 ):
-    """Delete a compute provider."""
+    """Delete a compute provider by ID or name."""
     check_configs(output_format=cli_state.output_format)
 
+    # Resolve the identifier (id or name) up front so we only prompt for
+    # confirmation when the provider actually exists.
+    provider_id = _resolve_provider_id(identifier)
+    if provider_id is None:
+        console.print(f"[error]Error:[/error] Provider {identifier} not found.")
+        raise typer.Exit(1)
+
     if not no_interactive:
-        typer.confirm(f"Delete provider {provider_id}?", abort=True)
+        typer.confirm(f"Delete provider {identifier}?", abort=True)
 
     with console.status(f"[bold success]Deleting provider {provider_id}...[/bold success]", spinner="dots"):
         response = api.delete(f"/compute_provider/providers/{provider_id}")

--- a/cli/src/transformerlab_cli/commands/provider.py
+++ b/cli/src/transformerlab_cli/commands/provider.py
@@ -189,7 +189,8 @@ def _upload_aws_credentials(provider_id: str, access_key_id: str, secret_access_
             json_data={"access_key_id": access_key_id, "secret_access_key": secret_access_key},
         )
     if response.status_code == 200:
-        console.print("[success]✓[/success] AWS credentials saved to API host.")
+        if cli_state.output_format != "json":
+            console.print("[success]✓[/success] AWS credentials saved to API host.")
     else:
         console.print(f"[error]Error:[/error] Failed to upload AWS credentials. {_extract_error_detail(response)}")
         raise typer.Exit(1)
@@ -205,7 +206,8 @@ def _upload_gcp_service_account(provider_id: str, service_account_json: str) -> 
             json_data={"service_account_json": service_account_json},
         )
     if response.status_code == 200:
-        console.print("[success]✓[/success] GCP service account saved.")
+        if cli_state.output_format != "json":
+            console.print("[success]✓[/success] GCP service account saved.")
     else:
         console.print(f"[error]Error:[/error] Failed to upload GCP service account. {_extract_error_detail(response)}")
         raise typer.Exit(1)
@@ -308,7 +310,8 @@ def create_provider_interactively(
 
     result = response.json()
     provider_id = result.get("id", "unknown")
-    console.print(f"[success]✓[/success] Provider created with ID: [bold]{provider_id}[/bold]")
+    if cli_state.output_format != "json":
+        console.print(f"[success]✓[/success] Provider created with ID: [bold]{provider_id}[/bold]")
 
     if provider_type == "aws" and aws_access_key_id and aws_secret_access_key:
         _upload_aws_credentials(provider_id, aws_access_key_id, aws_secret_access_key)
@@ -388,7 +391,8 @@ def command_provider_add(
     if check_response.status_code == 200:
         check_result = check_response.json()
         if check_result.get("status"):
-            console.print("[success]✓[/success] Provider health check passed.")
+            if cli_state.output_format != "json":
+                console.print("[success]✓[/success] Provider health check passed.")
         else:
             reason = _extract_provider_check_reason(check_result)
             console.print(f"[error]Error:[/error] Provider health check failed. {reason}")

--- a/cli/src/transformerlab_cli/commands/provider.py
+++ b/cli/src/transformerlab_cli/commands/provider.py
@@ -211,6 +211,113 @@ def _upload_gcp_service_account(provider_id: str, service_account_json: str) -> 
         raise typer.Exit(1)
 
 
+def create_provider_interactively(
+    name: str | None,
+    provider_type: str | None,
+    config: str | None,
+    interactive: bool,
+    credentials_file: str | None,
+) -> str:
+    """Resolve provider inputs, create the provider, upload any credentials, and return its id.
+
+    Does NOT run the health check — callers run it when appropriate. Raises typer.Exit on any
+    validation or API failure, printing an error first (matching the CLI's existing behavior).
+    """
+    if not interactive:
+        if not name or not provider_type or config is None:
+            console.print("[error]Error:[/error] --name, --type, and --config are required with --no-interactive")
+            raise typer.Exit(1)
+        if provider_type not in PROVIDER_TYPES:
+            console.print(
+                f"[error]Error:[/error] Invalid type '{provider_type}'. Must be one of: {', '.join(PROVIDER_TYPES)}"
+            )
+            raise typer.Exit(1)
+        try:
+            config_dict = json.loads(config)
+        except json.JSONDecodeError as e:
+            console.print(f"[error]Error:[/error] Invalid JSON in --config: {e}")
+            raise typer.Exit(1)
+    else:
+        if not name:
+            name = typer.prompt("Provider name")
+        if not provider_type:
+            provider_type = _prompt_provider_type()
+        elif provider_type not in PROVIDER_TYPES:
+            console.print(
+                f"[error]Error:[/error] Invalid type '{provider_type}'. Must be one of: {', '.join(PROVIDER_TYPES)}"
+            )
+            raise typer.Exit(1)
+        if config is not None:
+            try:
+                config_dict = json.loads(config)
+            except json.JSONDecodeError as e:
+                console.print(f"[error]Error:[/error] Invalid JSON in --config: {e}")
+                raise typer.Exit(1)
+        else:
+            config_dict = _prompt_config_fields(provider_type)
+
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+    gcp_service_account_json: str | None = None
+    if credentials_file:
+        if provider_type == "gcp":
+            gcp_service_account_json = _read_service_account_file(credentials_file)
+        else:
+            creds = _read_credentials_file(credentials_file)
+            if provider_type == "aws":
+                aws_access_key_id = str(creds.pop("aws_access_key_id", "") or "")
+                aws_secret_access_key = str(creds.pop("aws_secret_access_key", "") or "")
+            config_dict.update(creds)
+
+    if provider_type == "aws":
+        if bool(aws_access_key_id) != bool(aws_secret_access_key):
+            console.print(
+                "[error]Error:[/error] --credentials-file for --type aws must contain both "
+                "'aws_access_key_id' and 'aws_secret_access_key' (or neither)."
+            )
+            raise typer.Exit(1)
+        if interactive and not aws_access_key_id and not aws_secret_access_key:
+            aws_access_key_id, aws_secret_access_key = _prompt_aws_credentials()
+        if not interactive and not aws_access_key_id and not aws_secret_access_key:
+            console.print(
+                "[error]Error:[/error] AWS providers require credentials. "
+                "Pass --credentials-file PATH pointing at a JSON file containing "
+                "'aws_access_key_id' and 'aws_secret_access_key' (or run interactively)."
+            )
+            raise typer.Exit(1)
+
+    if provider_type == "gcp":
+        if not gcp_service_account_json and interactive:
+            gcp_service_account_json = _prompt_gcp_service_account_json()
+        if not gcp_service_account_json:
+            console.print(
+                "[error]Error:[/error] GCP providers require a service account JSON key. "
+                "Pass --credentials-file PATH pointing at your service account JSON "
+                "(or run interactively)."
+            )
+            raise typer.Exit(1)
+
+    payload = {"name": name, "type": provider_type, "config": config_dict}
+
+    with console.status("[bold success]Creating provider...[/bold success]", spinner="dots"):
+        response = api.post_json("/compute_provider/providers/", json_data=payload)
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to create provider. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    result = response.json()
+    provider_id = result.get("id", "unknown")
+    console.print(f"[success]✓[/success] Provider created with ID: [bold]{provider_id}[/bold]")
+
+    if provider_type == "aws" and aws_access_key_id and aws_secret_access_key:
+        _upload_aws_credentials(provider_id, aws_access_key_id, aws_secret_access_key)
+    if provider_type == "gcp" and gcp_service_account_json:
+        _upload_gcp_service_account(provider_id, gcp_service_account_json)
+
+    return provider_id
+
+
 ## COMMANDS ##
 
 
@@ -267,106 +374,13 @@ def command_provider_add(
     """Add a new compute provider."""
     check_configs(output_format=cli_state.output_format)
 
-    if not interactive:
-        if not name or not provider_type or config is None:
-            console.print("[error]Error:[/error] --name, --type, and --config are required with --no-interactive")
-            raise typer.Exit(1)
-        if provider_type not in PROVIDER_TYPES:
-            console.print(
-                f"[error]Error:[/error] Invalid type '{provider_type}'. Must be one of: {', '.join(PROVIDER_TYPES)}"
-            )
-            raise typer.Exit(1)
-        try:
-            config_dict = json.loads(config)
-        except json.JSONDecodeError as e:
-            console.print(f"[error]Error:[/error] Invalid JSON in --config: {e}")
-            raise typer.Exit(1)
-    else:
-        if not name:
-            name = typer.prompt("Provider name")
-        if not provider_type:
-            provider_type = _prompt_provider_type()
-        elif provider_type not in PROVIDER_TYPES:
-            console.print(
-                f"[error]Error:[/error] Invalid type '{provider_type}'. Must be one of: {', '.join(PROVIDER_TYPES)}"
-            )
-            raise typer.Exit(1)
-        if config is not None:
-            try:
-                config_dict = json.loads(config)
-            except json.JSONDecodeError as e:
-                console.print(f"[error]Error:[/error] Invalid JSON in --config: {e}")
-                raise typer.Exit(1)
-        else:
-            config_dict = _prompt_config_fields(provider_type)
-
-    # --credentials-file: shape depends on provider type.
-    #   aws: JSON object with aws_access_key_id / aws_secret_access_key (uploaded via /aws/credentials).
-    #        Any remaining keys merge into config.
-    #   gcp: the raw service account JSON key file (uploaded via /gcp/credentials).
-    #   other: a flat JSON object merged on top of --config (file values win).
-    aws_access_key_id: str = ""
-    aws_secret_access_key: str = ""
-    gcp_service_account_json: str | None = None
-    if credentials_file:
-        if provider_type == "gcp":
-            gcp_service_account_json = _read_service_account_file(credentials_file)
-        else:
-            creds = _read_credentials_file(credentials_file)
-            if provider_type == "aws":
-                aws_access_key_id = str(creds.pop("aws_access_key_id", "") or "")
-                aws_secret_access_key = str(creds.pop("aws_secret_access_key", "") or "")
-            config_dict.update(creds)
-
-    # AWS access key pair: must be both-or-neither.
-    if provider_type == "aws":
-        if bool(aws_access_key_id) != bool(aws_secret_access_key):
-            console.print(
-                "[error]Error:[/error] --credentials-file for --type aws must contain both "
-                "'aws_access_key_id' and 'aws_secret_access_key' (or neither)."
-            )
-            raise typer.Exit(1)
-        if interactive and not aws_access_key_id and not aws_secret_access_key:
-            aws_access_key_id, aws_secret_access_key = _prompt_aws_credentials()
-        if not interactive and not aws_access_key_id and not aws_secret_access_key:
-            console.print(
-                "[error]Error:[/error] AWS providers require credentials. "
-                "Pass --credentials-file PATH pointing at a JSON file containing "
-                "'aws_access_key_id' and 'aws_secret_access_key' (or run interactively)."
-            )
-            raise typer.Exit(1)
-
-    # GCP service account JSON: required at create time (provider will be unhealthy without it).
-    if provider_type == "gcp":
-        if not gcp_service_account_json and interactive:
-            gcp_service_account_json = _prompt_gcp_service_account_json()
-        if not gcp_service_account_json:
-            console.print(
-                "[error]Error:[/error] GCP providers require a service account JSON key. "
-                "Pass --credentials-file PATH pointing at your service account JSON "
-                "(or run interactively)."
-            )
-            raise typer.Exit(1)
-
-    payload = {"name": name, "type": provider_type, "config": config_dict}
-
-    with console.status("[bold success]Creating provider...[/bold success]", spinner="dots"):
-        response = api.post_json("/compute_provider/providers/", json_data=payload)
-
-    if response.status_code != 200:
-        console.print(f"[error]Error:[/error] Failed to create provider. {_extract_error_detail(response)}")
-        raise typer.Exit(1)
-
-    result = response.json()
-    provider_id = result.get("id", "unknown")
-    console.print(f"[success]✓[/success] Provider created with ID: [bold]{provider_id}[/bold]")
-
-    # Submit AWS credentials and GCP service account JSON via their dedicated endpoints,
-    # before the health check (the check will fail without credentials).
-    if provider_type == "aws" and aws_access_key_id and aws_secret_access_key:
-        _upload_aws_credentials(provider_id, aws_access_key_id, aws_secret_access_key)
-    if provider_type == "gcp" and gcp_service_account_json:
-        _upload_gcp_service_account(provider_id, gcp_service_account_json)
+    provider_id = create_provider_interactively(
+        name=name,
+        provider_type=provider_type,
+        config=config,
+        interactive=interactive,
+        credentials_file=credentials_file,
+    )
 
     with console.status(f"[bold success]Checking provider {provider_id}...[/bold success]", spinner="dots"):
         check_response = api.get(f"/compute_provider/providers/{provider_id}/check", timeout=60.0)

--- a/cli/src/transformerlab_cli/commands/secret.py
+++ b/cli/src/transformerlab_cli/commands/secret.py
@@ -173,9 +173,10 @@ def command_secret_delete(
 ):
     """Delete a secret."""
     check_configs(output_format=cli_state.output_format)
+    skip_confirm = no_interactive or cli_state.no_interactive
 
     if name in SPECIAL_SECRET_KEYS:
-        if not no_interactive:
+        if not skip_confirm:
             typer.confirm(f"Delete special secret {name}?", abort=True)
         path = _get_special_secrets_path(user)
         payload = {"secret_type": name, "value": ""}
@@ -194,7 +195,7 @@ def command_secret_delete(
             console.print(f"[error]Error:[/error] Secret [bold]{name}[/bold] not found.")
             raise typer.Exit(1)
 
-        if not no_interactive:
+        if not skip_confirm:
             typer.confirm(f"Delete secret {name}?", abort=True)
 
         del secrets[name]

--- a/cli/src/transformerlab_cli/commands/secret.py
+++ b/cli/src/transformerlab_cli/commands/secret.py
@@ -39,6 +39,32 @@ def _get_special_secrets_path(user: bool) -> str:
     return f"/teams/{team_id}/special_secrets"
 
 
+def _prompt_special_secret_key() -> str:
+    """Show a menu of platform secret keys by friendly description and return the chosen raw key.
+
+    The last option is a custom key, which prompts for an arbitrary key name.
+    """
+    items = list(SPECIAL_SECRET_KEYS.items())  # [(raw_key, description), ...]
+    console.print("\n[bold label]Select a secret to set:[/bold label]")
+    for i, (raw_key, description) in enumerate(items, 1):
+        console.print(f"  [bold]{i}[/bold]. {description} [muted]({raw_key})[/muted]")
+    custom_idx = len(items) + 1
+    console.print(f"  [bold]{custom_idx}[/bold]. Custom key…")
+
+    while True:
+        choice = typer.prompt("\nSelect a key", default="1")
+        try:
+            idx = int(choice)
+        except ValueError:
+            console.print("[error]Please enter a valid number[/error]")
+            continue
+        if 1 <= idx <= len(items):
+            return items[idx - 1][0]
+        if idx == custom_idx:
+            return typer.prompt("Custom key name").strip()
+        console.print(f"[error]Please enter a number between 1 and {custom_idx}[/error]")
+
+
 @app.command("list")
 def command_secret_list(
     user: bool = typer.Option(False, "--user", help="List user-level secrets instead of team secrets"),
@@ -85,14 +111,25 @@ def command_secret_keys():
 
 @app.command("set")
 def command_secret_set(
-    name: str = typer.Argument(..., help="Secret name"),
+    name: str = typer.Argument(None, help="Secret name (omit to choose from a menu interactively)"),
     value: str = typer.Argument(None, help="Secret value (omit to be prompted with hidden input)"),
     user: bool = typer.Option(False, "--user", help="Set as a user-level secret instead of team secret"),
 ):
     """Set a secret. Overwrites if the name already exists."""
+    if name is None:
+        if cli_state.no_interactive:
+            console.print("[error]Error:[/error] A secret name is required with --no-interactive/--format json")
+            raise typer.Exit(1)
+
     check_configs(output_format=cli_state.output_format)
 
+    if name is None:
+        name = _prompt_special_secret_key()
+
     if value is None:
+        if cli_state.no_interactive:
+            console.print("[error]Error:[/error] A secret value is required with --no-interactive/--format json")
+            raise typer.Exit(1)
         value = typer.prompt("Value", hide_input=True)
 
     if name in SPECIAL_SECRET_KEYS:

--- a/cli/src/transformerlab_cli/commands/secret.py
+++ b/cli/src/transformerlab_cli/commands/secret.py
@@ -61,7 +61,11 @@ def _prompt_special_secret_key() -> str:
         if 1 <= idx <= len(items):
             return items[idx - 1][0]
         if idx == custom_idx:
-            return typer.prompt("Custom key name").strip()
+            while True:
+                custom = typer.prompt("Custom key name").strip()
+                if custom:
+                    return custom
+                console.print("[error]A key name is required[/error]")
         console.print(f"[error]Please enter a number between 1 and {custom_idx}[/error]")
 
 

--- a/cli/src/transformerlab_cli/commands/team.py
+++ b/cli/src/transformerlab_cli/commands/team.py
@@ -1,7 +1,140 @@
+import json
+
 import typer
 
-from transformerlab_cli.commands.secret import app as secret_app
+import transformerlab_cli.util.api as api
+from transformerlab_cli.commands.provider import (
+    _extract_error_detail,
+    _extract_provider_check_reason,
+    create_provider_interactively,
+)
+from transformerlab_cli.commands.secret import (
+    SPECIAL_SECRET_KEYS,
+    _get_secrets_path,
+    _get_special_secrets_path,
+    _prompt_special_secret_key,
+    app as secret_app,
+)
+from transformerlab_cli.state import cli_state
+from transformerlab_cli.util.config import check_configs
+from transformerlab_cli.util.ui import console
 
 app = typer.Typer()
 
+
+def _save_secret(name: str, value: str) -> None:
+    """Save one secret (team-level), routing special keys to the special_secrets endpoint."""
+    if name in SPECIAL_SECRET_KEYS:
+        api.put_json(_get_special_secrets_path(False), json_data={"secret_type": name, "value": value})
+    else:
+        path = _get_secrets_path(False)
+        get_response = api.get(f"{path}?include_values=true")
+        secrets = get_response.json().get("secrets", {}) if get_response.status_code == 200 else {}
+        secrets[name] = value
+        api.put_json(path, json_data={"secrets": secrets})
+
+
+def _run_check(provider_id: str) -> dict:
+    """Run the provider health check and return {"ok": bool, "reason": str | None}."""
+    response = api.get(f"/compute_provider/providers/{provider_id}/check", timeout=60.0)
+    if response.status_code == 200 and response.json().get("status") is True:
+        return {"ok": True, "reason": None}
+    if response.status_code == 200:
+        return {"ok": False, "reason": _extract_provider_check_reason(response.json())}
+    return {"ok": False, "reason": _extract_error_detail(response)}
+
+
+setup_app = typer.Typer(invoke_without_command=True)
+
+
+@setup_app.callback()
+def command_team_setup(
+    ctx: typer.Context,
+    name: str = typer.Option(None, "--name", help="Provider name"),
+    provider_type: str = typer.Option(None, "--type", help="Provider type"),
+    config: str = typer.Option(None, "--config", help="Provider config as JSON string"),
+    credentials_file: str = typer.Option(None, "--credentials-file", help="Path to provider credentials JSON file"),
+    set_default: bool = typer.Option(
+        None, "--set-default/--no-set-default", help="Mark the new provider as the team default"
+    ),
+    secret: list[str] = typer.Option(
+        None, "--secret", help="Secret as KEY=VALUE (repeatable). Used in non-interactive mode."
+    ),
+    check: bool = typer.Option(None, "--check/--no-check", help="Run the provider health check at the end"),
+):
+    """Onboarding wizard: add a provider, set defaults and secrets, and verify connectivity.
+
+    Run with no flags for the interactive wizard. In non-interactive mode (--no-interactive or
+    --format json) all input comes from flags.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    check_configs(output_format=cli_state.output_format)
+    interactive = not cli_state.no_interactive
+
+    # Step 1: create the provider.
+    provider_id = create_provider_interactively(
+        name=name,
+        provider_type=provider_type,
+        config=config,
+        interactive=interactive,
+        credentials_file=credentials_file,
+    )
+
+    # Step 2: set as team default.
+    if set_default is None:
+        default_set = typer.confirm("Set this provider as the team default?", default=True) if interactive else False
+    else:
+        default_set = set_default
+    if default_set:
+        api.patch(f"/compute_provider/providers/{provider_id}", json_data={"is_default": True})
+
+    # Step 3: set platform secrets.
+    secrets_set: list[str] = []
+    if interactive:
+        while typer.confirm("Set a platform secret now?", default=False):
+            key = _prompt_special_secret_key()
+            value = typer.prompt("Value", hide_input=True)
+            _save_secret(key, value)
+            secrets_set.append(key)
+    else:
+        for item in secret or []:
+            if "=" not in item:
+                console.print(f"[error]Error:[/error] --secret must be KEY=VALUE, got '{item}'")
+                raise typer.Exit(1)
+            key, value = item.split("=", 1)
+            _save_secret(key, value)
+            secrets_set.append(key)
+
+    # Step 4: run the health check.
+    if check is None:
+        run = typer.confirm("Run a provider health check now?", default=True) if interactive else False
+    else:
+        run = check
+    check_result = _run_check(provider_id) if run else None
+
+    summary = {
+        "provider_id": provider_id,
+        "default_set": default_set,
+        "secrets_set": secrets_set,
+        "check": check_result,
+    }
+
+    if cli_state.output_format == "json":
+        print(json.dumps(summary))
+        return
+
+    console.print("\n[bold success]Team setup complete.[/bold success]")
+    console.print(f"  Provider: [bold]{provider_id}[/bold]")
+    console.print(f"  Default:  {'yes' if default_set else 'no'}")
+    console.print(f"  Secrets:  {', '.join(secrets_set) if secrets_set else 'none'}")
+    if check_result is not None:
+        status = (
+            "[success]passed[/success]" if check_result["ok"] else f"[error]failed[/error] ({check_result['reason']})"
+        )
+        console.print(f"  Check:    {status}")
+
+
+app.add_typer(setup_app, name="setup", help="Onboarding wizard for a new team")
 app.add_typer(secret_app, name="secret", help="Secret management commands", no_args_is_help=True)

--- a/cli/src/transformerlab_cli/commands/team.py
+++ b/cli/src/transformerlab_cli/commands/team.py
@@ -1,0 +1,7 @@
+import typer
+
+from transformerlab_cli.commands.secret import app as secret_app
+
+app = typer.Typer()
+
+app.add_typer(secret_app, name="secret", help="Secret management commands", no_args_is_help=True)

--- a/cli/src/transformerlab_cli/commands/team.py
+++ b/cli/src/transformerlab_cli/commands/team.py
@@ -25,13 +25,21 @@ app = typer.Typer()
 def _save_secret(name: str, value: str) -> None:
     """Save one secret (team-level), routing special keys to the special_secrets endpoint."""
     if name in SPECIAL_SECRET_KEYS:
-        api.put_json(_get_special_secrets_path(False), json_data={"secret_type": name, "value": value})
+        response = api.put_json(_get_special_secrets_path(False), json_data={"secret_type": name, "value": value})
     else:
         path = _get_secrets_path(False)
         get_response = api.get(f"{path}?include_values=true")
-        secrets = get_response.json().get("secrets", {}) if get_response.status_code == 200 else {}
+        if get_response.status_code != 200:
+            console.print(
+                f"[error]Error:[/error] Failed to fetch current secrets. {_extract_error_detail(get_response)}"
+            )
+            raise typer.Exit(1)
+        secrets = get_response.json().get("secrets", {})
         secrets[name] = value
-        api.put_json(path, json_data={"secrets": secrets})
+        response = api.put_json(path, json_data={"secrets": secrets})
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to save secret {name}. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
 
 
 def _run_check(provider_id: str) -> dict:
@@ -88,7 +96,10 @@ def command_team_setup(
     else:
         default_set = set_default
     if default_set:
-        api.patch(f"/compute_provider/providers/{provider_id}", json_data={"is_default": True})
+        response = api.patch(f"/compute_provider/providers/{provider_id}", json_data={"is_default": True})
+        if response.status_code != 200:
+            console.print(f"[error]Error:[/error] Failed to set provider as default. {_extract_error_detail(response)}")
+            raise typer.Exit(1)
 
     # Step 3: set platform secrets.
     secrets_set: list[str] = []

--- a/cli/src/transformerlab_cli/commands/team.py
+++ b/cli/src/transformerlab_cli/commands/team.py
@@ -104,7 +104,10 @@ def command_team_setup(
     # Step 3: set platform secrets.
     secrets_set: list[str] = []
     if interactive:
-        while typer.confirm("Set a platform secret now?", default=False):
+        while typer.confirm(
+            "Set another platform secret?" if secrets_set else "Set a platform secret now?",
+            default=False,
+        ):
             key = _prompt_special_secret_key()
             value = typer.prompt("Value", hide_input=True)
             _save_secret(key, value)

--- a/cli/src/transformerlab_cli/main.py
+++ b/cli/src/transformerlab_cli/main.py
@@ -20,7 +20,7 @@ from transformerlab_cli.commands.experiment import app as experiment_app
 from transformerlab_cli.commands.notes import app as notes_app
 from transformerlab_cli.commands.dataset import app as dataset_app
 from transformerlab_cli.commands.model import app as model_app
-from transformerlab_cli.commands.secret import app as secret_app
+from transformerlab_cli.commands.team import app as team_app
 from transformerlab_cli.commands.install_agent_skill import app as install_agent_skill_app
 
 
@@ -53,17 +53,24 @@ app.add_typer(server_app, name="server", help="Server installation and configura
 app.add_typer(dataset_app, name="dataset", help="Dataset management commands", no_args_is_help=True)
 app.add_typer(model_app, name="model", help="Model management commands", no_args_is_help=True)
 app.add_typer(experiment_app, name="experiment", help="Experiment management commands", no_args_is_help=True)
-app.add_typer(secret_app, name="secret", help="Secret management commands", no_args_is_help=True)
+app.add_typer(team_app, name="team", help="Team configuration commands", no_args_is_help=True)
 app.add_typer(install_agent_skill_app)
 
 
 # Apply common setup to all commands
 @app.callback()
 def common_setup(
-    ctx: typer.Context, format: str = typer.Option("pretty", "--format", help="Output format: pretty or json")
+    ctx: typer.Context,
+    format: str = typer.Option("pretty", "--format", help="Output format: pretty or json"),
+    no_interactive: bool = typer.Option(
+        False,
+        "--no-interactive",
+        help="Never prompt; take all input from arguments/flags. Implied by --format json.",
+    ),
 ):
     """Common setup code to run before any command."""
     cli_state.output_format = format
+    cli_state.no_interactive = no_interactive or (format == "json")
     if not ctx.invoked_subcommand:
         show_header(console)  # Display the logo when no command is provided
     elif ctx.invoked_subcommand != "version" and format != "json":

--- a/cli/src/transformerlab_cli/state.py
+++ b/cli/src/transformerlab_cli/state.py
@@ -13,6 +13,8 @@ class CLIState:
     def __init__(self):
         if not hasattr(self, "output_format"):
             self.output_format = "pretty"  # Default output format
+        if not hasattr(self, "no_interactive"):
+            self.no_interactive = False  # When True, never prompt; take input from args/flags
 
 
 # Module-level singleton instance

--- a/cli/tests/commands/test_provider.py
+++ b/cli/tests/commands/test_provider.py
@@ -157,13 +157,37 @@ def test_provider_add_fails_when_provider_check_unhealthy(_mock_check, _mock_pos
     assert "Bad API key" in result.output
 
 
+@patch("transformerlab_cli.commands.provider.api.get", return_value=_mock_response(200, SAMPLE_PROVIDERS))
 @patch("transformerlab_cli.commands.provider.api.delete", return_value=_mock_response(200))
 @patch("transformerlab_cli.commands.provider.check_configs")
-def test_provider_delete(_mock_check, _mock_api):
-    """Test deleting a provider."""
+def test_provider_delete(_mock_check, mock_delete, _mock_get):
+    """Test deleting a provider by id."""
     result = runner.invoke(app, ["provider", "delete", "p1", "--no-interactive"])
     assert result.exit_code == 0
     assert "deleted" in result.output
+    mock_delete.assert_called_once_with("/compute_provider/providers/p1")
+
+
+@patch("transformerlab_cli.commands.provider.api.get", return_value=_mock_response(200, SAMPLE_PROVIDERS))
+@patch("transformerlab_cli.commands.provider.api.delete", return_value=_mock_response(200))
+@patch("transformerlab_cli.commands.provider.check_configs")
+def test_provider_delete_by_name(_mock_check, mock_delete, _mock_get):
+    """Test deleting a provider by name resolves to its id."""
+    result = runner.invoke(app, ["provider", "delete", "slurm-1", "--no-interactive"])
+    assert result.exit_code == 0
+    assert "deleted" in result.output
+    mock_delete.assert_called_once_with("/compute_provider/providers/p2")
+
+
+@patch("transformerlab_cli.commands.provider.api.get", return_value=_mock_response(200, SAMPLE_PROVIDERS))
+@patch("transformerlab_cli.commands.provider.api.delete", return_value=_mock_response(200))
+@patch("transformerlab_cli.commands.provider.check_configs")
+def test_provider_delete_not_found(_mock_check, mock_delete, _mock_get):
+    """Test deleting a nonexistent provider errors before confirming or calling delete."""
+    result = runner.invoke(app, ["provider", "delete", "nope"])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+    mock_delete.assert_not_called()
 
 
 @patch("transformerlab_cli.commands.provider.api.patch", return_value=_mock_response(200))

--- a/cli/tests/commands/test_secret.py
+++ b/cli/tests/commands/test_secret.py
@@ -37,14 +37,14 @@ def _mock_response(status_code: int = 200, json_data=None):
 
 def test_secret_help():
     """Test the secret command help."""
-    result = runner.invoke(app, ["secret", "--help"])
+    result = runner.invoke(app, ["team", "secret", "--help"])
     assert result.exit_code == 0
     assert "Secret management commands" in result.output
 
 
 def test_secret_keys():
     """Test listing platform-recognized keys."""
-    result = runner.invoke(app, ["secret", "keys"])
+    result = runner.invoke(app, ["team", "secret", "keys"])
     assert result.exit_code == 0
     assert "_HF_TOKEN" in result.output
     assert "_GITHUB_PAT_TOKEN" in result.output
@@ -54,7 +54,7 @@ def test_secret_keys():
 
 def test_secret_keys_json():
     """Test listing platform keys in JSON format."""
-    result = runner.invoke(app, ["--format", "json", "secret", "keys"])
+    result = runner.invoke(app, ["--format", "json", "team", "secret", "keys"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert len(data) == 4
@@ -67,7 +67,7 @@ def test_secret_keys_json():
 @patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
 def test_secret_list(_mock_config, _mock_check, _mock_api):
     """Test listing secrets."""
-    result = runner.invoke(app, ["secret", "list"])
+    result = runner.invoke(app, ["team", "secret", "list"])
     assert result.exit_code == 0
     assert "API_KEY" in result.output
     assert "DB_PASSWORD" in result.output
@@ -78,7 +78,7 @@ def test_secret_list(_mock_config, _mock_check, _mock_api):
 @patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
 def test_secret_list_show_values(_mock_config, _mock_check, _mock_api):
     """Test listing secrets with values visible."""
-    result = runner.invoke(app, ["secret", "list", "--show-values"])
+    result = runner.invoke(app, ["team", "secret", "list", "--show-values"])
     assert result.exit_code == 0
     assert "sk-123" in result.output
     assert "hunter2" in result.output
@@ -89,7 +89,7 @@ def test_secret_list_show_values(_mock_config, _mock_check, _mock_api):
 @patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
 def test_secret_list_empty(_mock_config, _mock_check, _mock_api):
     """Test listing secrets when none exist."""
-    result = runner.invoke(app, ["secret", "list"])
+    result = runner.invoke(app, ["team", "secret", "list"])
     assert result.exit_code == 2
     assert "No secrets found" in result.output
 
@@ -99,7 +99,7 @@ def test_secret_list_empty(_mock_config, _mock_check, _mock_api):
 @patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
 def test_secret_list_json(_mock_config, _mock_check, _mock_api):
     """Test listing secrets in JSON format."""
-    result = runner.invoke(app, ["--format", "json", "secret", "list"])
+    result = runner.invoke(app, ["--format", "json", "team", "secret", "list"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert isinstance(data, list)
@@ -113,7 +113,7 @@ def test_secret_list_json(_mock_config, _mock_check, _mock_api):
 def test_secret_set_prompts_for_value(_mock_config, _mock_check, mock_get, mock_put):
     """Test that omitting value prompts with hidden input."""
     mock_put.return_value = _mock_response(200, {"status": "success"})
-    result = runner.invoke(app, ["secret", "set", "MY_KEY"], input="secret-from-prompt\n")
+    result = runner.invoke(app, ["team", "secret", "set", "MY_KEY"], input="secret-from-prompt\n")
     assert result.exit_code == 0
     assert "saved" in result.output
 
@@ -129,7 +129,7 @@ def test_secret_set_prompts_for_value(_mock_config, _mock_check, mock_get, mock_
 def test_secret_set(_mock_config, _mock_check, mock_get, mock_put):
     """Test setting a secret."""
     mock_put.return_value = _mock_response(200, {"status": "success", "message": "Team secrets saved successfully"})
-    result = runner.invoke(app, ["secret", "set", "NEW_KEY", "new-value"])
+    result = runner.invoke(app, ["team", "secret", "set", "NEW_KEY", "new-value"])
     assert result.exit_code == 0
     assert "NEW_KEY" in result.output
     assert "saved" in result.output
@@ -146,7 +146,7 @@ def test_secret_set(_mock_config, _mock_check, mock_get, mock_put):
 def test_secret_set_special(_mock_config, _mock_check, mock_put):
     """Test setting a special secret routes to special_secrets endpoint."""
     mock_put.return_value = _mock_response(200, {"status": "success", "secret_type": "_HF_TOKEN"})
-    result = runner.invoke(app, ["secret", "set", "_HF_TOKEN", "hf_abc123"])
+    result = runner.invoke(app, ["team", "secret", "set", "_HF_TOKEN", "hf_abc123"])
     assert result.exit_code == 0
     assert "_HF_TOKEN" in result.output
 
@@ -163,7 +163,7 @@ def test_secret_set_special(_mock_config, _mock_check, mock_put):
 def test_secret_delete(_mock_config, _mock_check, mock_get, mock_put):
     """Test deleting a secret."""
     mock_put.return_value = _mock_response(200, {"status": "success"})
-    result = runner.invoke(app, ["secret", "delete", "API_KEY", "--no-interactive"])
+    result = runner.invoke(app, ["team", "secret", "delete", "API_KEY", "--no-interactive"])
     assert result.exit_code == 0
     assert "deleted" in result.output
 
@@ -178,7 +178,7 @@ def test_secret_delete(_mock_config, _mock_check, mock_get, mock_put):
 @patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
 def test_secret_delete_not_found(_mock_config, _mock_check, _mock_get):
     """Test deleting a secret that doesn't exist."""
-    result = runner.invoke(app, ["secret", "delete", "NONEXISTENT", "--no-interactive"])
+    result = runner.invoke(app, ["team", "secret", "delete", "NONEXISTENT", "--no-interactive"])
     assert result.exit_code == 1
     assert "not found" in result.output
 
@@ -189,7 +189,7 @@ def test_secret_delete_not_found(_mock_config, _mock_check, _mock_get):
 def test_secret_delete_special(_mock_config, _mock_check, mock_put):
     """Test deleting a special secret sends empty value."""
     mock_put.return_value = _mock_response(200, {"status": "success"})
-    result = runner.invoke(app, ["secret", "delete", "_HF_TOKEN", "--no-interactive"])
+    result = runner.invoke(app, ["team", "secret", "delete", "_HF_TOKEN", "--no-interactive"])
     assert result.exit_code == 0
 
     put_call = mock_put.call_args
@@ -201,7 +201,7 @@ def test_secret_delete_special(_mock_config, _mock_check, mock_put):
 @patch("transformerlab_cli.commands.secret.check_configs")
 def test_secret_list_user(_mock_check, mock_get):
     """Test listing user-level secrets."""
-    result = runner.invoke(app, ["secret", "list", "--user"])
+    result = runner.invoke(app, ["team", "secret", "list", "--user"])
     assert result.exit_code == 0
     mock_get.assert_called_once()
     assert "/users/me/secrets" in mock_get.call_args.args[0]
@@ -213,7 +213,7 @@ def test_secret_list_user(_mock_check, mock_get):
 def test_secret_set_user(_mock_check, mock_get, mock_put):
     """Test setting a user-level secret."""
     mock_put.return_value = _mock_response(200, {"status": "success"})
-    result = runner.invoke(app, ["secret", "set", "MY_KEY", "my-val", "--user"])
+    result = runner.invoke(app, ["team", "secret", "set", "MY_KEY", "my-val", "--user"])
     assert result.exit_code == 0
     assert "/users/me/secrets" in mock_get.call_args.args[0]
     assert "/users/me/secrets" in mock_put.call_args.args[0]
@@ -224,6 +224,6 @@ def test_secret_set_user(_mock_check, mock_get, mock_put):
 @patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
 def test_secret_list_error(_mock_config, _mock_check, _mock_get):
     """Test error handling when API returns failure."""
-    result = runner.invoke(app, ["secret", "list"])
+    result = runner.invoke(app, ["team", "secret", "list"])
     assert result.exit_code == 1
     assert "Error" in result.output

--- a/cli/tests/commands/test_secret.py
+++ b/cli/tests/commands/test_secret.py
@@ -3,10 +3,22 @@
 import json
 from unittest.mock import patch, MagicMock
 
+import pytest
 from typer.testing import CliRunner
 from transformerlab_cli.main import app
+from transformerlab_cli.state import cli_state
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_state():
+    cli_state.output_format = "pretty"
+    cli_state.no_interactive = False
+    yield
+    cli_state.output_format = "pretty"
+    cli_state.no_interactive = False
+
 
 SAMPLE_SECRETS_RESPONSE = {
     "status": "success",
@@ -227,3 +239,39 @@ def test_secret_list_error(_mock_config, _mock_check, _mock_get):
     result = runner.invoke(app, ["team", "secret", "list"])
     assert result.exit_code == 1
     assert "Error" in result.output
+
+
+@patch("transformerlab_cli.commands.secret.api.put_json")
+@patch("transformerlab_cli.commands.secret.check_configs")
+@patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
+def test_secret_set_picker_special_key(_mock_config, _mock_check, mock_put):
+    """Bare `team secret set` shows a picker; choosing item 2 maps to _HF_TOKEN."""
+    mock_put.return_value = _mock_response(200, {"status": "success", "secret_type": "_HF_TOKEN"})
+    # SPECIAL_SECRET_KEYS order: _GITHUB_PAT_TOKEN(1), _HF_TOKEN(2), _WANDB_API_KEY(3), _NGROK_AUTH_TOKEN(4)
+    result = runner.invoke(app, ["team", "secret", "set"], input="2\nhf_abc123\n")
+    assert result.exit_code == 0
+    put_call = mock_put.call_args
+    assert "special_secrets" in put_call.args[0]
+    assert put_call.kwargs["json_data"]["secret_type"] == "_HF_TOKEN"
+    assert put_call.kwargs["json_data"]["value"] == "hf_abc123"
+
+
+@patch("transformerlab_cli.commands.secret.api.put_json")
+@patch("transformerlab_cli.commands.secret.api.get", return_value=_mock_response(200, SAMPLE_EMPTY_SECRETS))
+@patch("transformerlab_cli.commands.secret.check_configs")
+@patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
+def test_secret_set_picker_custom_key(_mock_config, _mock_check, mock_get, mock_put):
+    """Picking the custom option prompts for an arbitrary key and value."""
+    mock_put.return_value = _mock_response(200, {"status": "success"})
+    # Custom is the last menu item (index 5). Then key name, then value.
+    result = runner.invoke(app, ["team", "secret", "set"], input="5\nMY_CUSTOM\ncustomval\n")
+    assert result.exit_code == 0
+    put_call = mock_put.call_args
+    assert put_call.kwargs["json_data"]["secrets"]["MY_CUSTOM"] == "customval"
+
+
+def test_secret_set_no_key_non_interactive_errors():
+    """In non-interactive mode, a missing key is an error (no prompt)."""
+    result = runner.invoke(app, ["--no-interactive", "team", "secret", "set"])
+    assert result.exit_code == 1
+    assert "required" in result.output.lower()

--- a/cli/tests/commands/test_secret.py
+++ b/cli/tests/commands/test_secret.py
@@ -245,10 +245,12 @@ def test_secret_list_error(_mock_config, _mock_check, _mock_get):
 @patch("transformerlab_cli.commands.secret.check_configs")
 @patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
 def test_secret_set_picker_special_key(_mock_config, _mock_check, mock_put):
-    """Bare `team secret set` shows a picker; choosing item 2 maps to _HF_TOKEN."""
+    """Bare `team secret set` shows a picker; choosing _HF_TOKEN maps to the special_secrets endpoint."""
     mock_put.return_value = _mock_response(200, {"status": "success", "secret_type": "_HF_TOKEN"})
-    # SPECIAL_SECRET_KEYS order: _GITHUB_PAT_TOKEN(1), _HF_TOKEN(2), _WANDB_API_KEY(3), _NGROK_AUTH_TOKEN(4)
-    result = runner.invoke(app, ["team", "secret", "set"], input="2\nhf_abc123\n")
+    from transformerlab_cli.commands.secret import SPECIAL_SECRET_KEYS
+
+    hf_index = list(SPECIAL_SECRET_KEYS.keys()).index("_HF_TOKEN") + 1
+    result = runner.invoke(app, ["team", "secret", "set"], input=f"{hf_index}\nhf_abc123\n")
     assert result.exit_code == 0
     put_call = mock_put.call_args
     assert "special_secrets" in put_call.args[0]

--- a/cli/tests/commands/test_secret.py
+++ b/cli/tests/commands/test_secret.py
@@ -277,3 +277,18 @@ def test_secret_set_no_key_non_interactive_errors():
     result = runner.invoke(app, ["--no-interactive", "team", "secret", "set"])
     assert result.exit_code == 1
     assert "required" in result.output.lower()
+
+
+@patch("transformerlab_cli.commands.secret.api.put_json")
+@patch(
+    "transformerlab_cli.commands.secret.api.get",
+    return_value=_mock_response(200, json.loads(json.dumps(SAMPLE_SECRETS_WITH_VALUES))),
+)
+@patch("transformerlab_cli.commands.secret.check_configs")
+@patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
+def test_secret_delete_global_no_interactive_skips_confirm(_mock_config, _mock_check, mock_get, mock_put):
+    """The global --no-interactive flag skips the delete confirmation prompt."""
+    mock_put.return_value = _mock_response(200, {"status": "success"})
+    result = runner.invoke(app, ["--no-interactive", "team", "secret", "delete", "API_KEY"])
+    assert result.exit_code == 0
+    assert "deleted" in result.output

--- a/cli/tests/commands/test_team.py
+++ b/cli/tests/commands/test_team.py
@@ -135,12 +135,15 @@ def test_wizard_no_check_no_default(_mock_check, _mock_create, mock_api):
     mock_api.get.assert_not_called()
 
 
-def test_setup_help():
-    # Widen the terminal so rich does not wrap/truncate the option names.
-    result = runner.invoke(app, ["team", "setup", "--help"], env={"COLUMNS": "200"})
-    assert result.exit_code == 0
-    assert "--set-default" in result.output
-    assert "--secret" in result.output
+def test_setup_exposes_flags():
+    """The wizard exposes the documented flags (checked via click params, not fragile help text)."""
+    import typer.main
+
+    cmd = typer.main.get_command(app)
+    setup = cmd.get_command(None, "team").get_command(None, "setup")
+    opts = {opt for param in setup.params for opt in param.opts}
+    assert "--set-default" in opts
+    assert "--secret" in opts
 
 
 @patch("transformerlab_cli.commands.team.api")

--- a/cli/tests/commands/test_team.py
+++ b/cli/tests/commands/test_team.py
@@ -1,0 +1,67 @@
+"""Tests for the lab team namespace, setup wizard, and global non-interactive flag."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from transformerlab_cli.main import app
+from transformerlab_cli.state import cli_state
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_state():
+    cli_state.output_format = "pretty"
+    cli_state.no_interactive = False
+    yield
+    cli_state.output_format = "pretty"
+    cli_state.no_interactive = False
+
+
+def _mock_response(status_code: int = 200, json_data=None):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data if json_data is not None else {}
+    mock.text = ""
+    return mock
+
+
+def test_no_interactive_flag_sets_state():
+    """The global --no-interactive flag sets cli_state.no_interactive."""
+    runner.invoke(app, ["--no-interactive", "version"])
+    assert cli_state.no_interactive is True
+
+
+def test_json_format_implies_no_interactive():
+    """--format json implies non-interactive mode."""
+    runner.invoke(app, ["--format", "json", "version"])
+    assert cli_state.no_interactive is True
+
+
+def test_default_is_interactive():
+    """Without flags, no_interactive defaults to False."""
+    runner.invoke(app, ["version"])
+    assert cli_state.no_interactive is False
+
+
+def test_team_help_lists_subcommands():
+    result = runner.invoke(app, ["team", "--help"])
+    assert result.exit_code == 0
+    # TODO(Task 5): assert "setup" in result.output
+    assert "secret" in result.output
+
+
+def test_team_secret_keys_works():
+    """`lab team secret keys` resolves to the moved secret command."""
+    result = runner.invoke(app, ["team", "secret", "keys"])
+    assert result.exit_code == 0
+    assert "_HF_TOKEN" in result.output
+
+
+def test_top_level_secret_removed():
+    """`lab secret` is no longer registered."""
+    result = runner.invoke(app, ["secret", "keys"])
+    assert result.exit_code != 0
+    assert "No such command" in result.output or "Usage" in result.output

--- a/cli/tests/commands/test_team.py
+++ b/cli/tests/commands/test_team.py
@@ -1,6 +1,7 @@
 """Tests for the lab team namespace, setup wizard, and global non-interactive flag."""
 
-from unittest.mock import MagicMock
+import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -49,7 +50,7 @@ def test_default_is_interactive():
 def test_team_help_lists_subcommands():
     result = runner.invoke(app, ["team", "--help"])
     assert result.exit_code == 0
-    # TODO(Task 5): assert "setup" in result.output
+    assert "setup" in result.output
     assert "secret" in result.output
 
 
@@ -65,3 +66,77 @@ def test_top_level_secret_removed():
     result = runner.invoke(app, ["secret", "keys"])
     assert result.exit_code != 0
     assert "No such command" in result.output or "Usage" in result.output
+
+
+@patch("transformerlab_cli.commands.team.api")
+@patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-1")
+@patch("transformerlab_cli.commands.team.check_configs")
+def test_wizard_non_interactive_json(_mock_check, mock_create, mock_api):
+    """Non-interactive JSON wizard creates a provider, sets default, sets secrets, checks."""
+    mock_api.patch.return_value = _mock_response(200, {"status": "success"})
+    mock_api.put_json.return_value = _mock_response(200, {"status": "success"})
+    mock_api.get.return_value = _mock_response(200, {"status": True})
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "team",
+            "setup",
+            "--name",
+            "p",
+            "--type",
+            "local",
+            "--config",
+            "{}",
+            "--set-default",
+            "--secret",
+            "_HF_TOKEN=hf_abc",
+            "--check",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["provider_id"] == "prov-1"
+    assert data["default_set"] is True
+    assert data["secrets_set"] == ["_HF_TOKEN"]
+    assert data["check"]["ok"] is True
+    assert any(c.kwargs["json_data"].get("is_default") is True for c in mock_api.patch.call_args_list)
+    assert any("special_secrets" in c.args[0] for c in mock_api.put_json.call_args_list)
+
+
+@patch("transformerlab_cli.commands.team.api")
+@patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-2")
+@patch("transformerlab_cli.commands.team.check_configs")
+def test_wizard_no_check_no_default(_mock_check, mock_create, mock_api):
+    """--no-check and --no-set-default skip those steps."""
+    mock_api.put_json.return_value = _mock_response(200, {"status": "success"})
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "team",
+            "setup",
+            "--name",
+            "p",
+            "--type",
+            "local",
+            "--config",
+            "{}",
+            "--no-set-default",
+            "--no-check",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["default_set"] is False
+    assert data["check"] is None
+    mock_api.get.assert_not_called()
+
+
+def test_setup_help():
+    result = runner.invoke(app, ["team", "setup", "--help"])
+    assert result.exit_code == 0
+    assert "--set-default" in result.output
+    assert "--secret" in result.output

--- a/cli/tests/commands/test_team.py
+++ b/cli/tests/commands/test_team.py
@@ -140,3 +140,124 @@ def test_setup_help():
     assert result.exit_code == 0
     assert "--set-default" in result.output
     assert "--secret" in result.output
+
+
+@patch("transformerlab_cli.commands.team.api")
+@patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-3")
+@patch("transformerlab_cli.commands.team.check_configs")
+def test_wizard_normal_secret_merges(_mock_check, mock_create, mock_api):
+    """A non-special --secret is merged into team secrets via GET+PUT."""
+    mock_api.get.return_value = _mock_response(200, {"secrets": {"EXISTING": "v"}})
+    mock_api.put_json.return_value = _mock_response(200, {"status": "success"})
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "team",
+            "setup",
+            "--name",
+            "p",
+            "--type",
+            "local",
+            "--config",
+            "{}",
+            "--no-set-default",
+            "--no-check",
+            "--secret",
+            "MYKEY=val",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["secrets_set"] == ["MYKEY"]
+    saved = [c for c in mock_api.put_json.call_args_list if "MYKEY" in str(c.kwargs.get("json_data"))]
+    assert saved, "expected a put_json saving MYKEY"
+    assert saved[-1].kwargs["json_data"]["secrets"]["MYKEY"] == "val"
+    assert saved[-1].kwargs["json_data"]["secrets"]["EXISTING"] == "v"
+
+
+@patch("transformerlab_cli.commands.team.api")
+@patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-4")
+@patch("transformerlab_cli.commands.team.check_configs")
+def test_wizard_bad_secret_format_errors(_mock_check, mock_create, mock_api):
+    """--secret without '=' errors out."""
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "team",
+            "setup",
+            "--name",
+            "p",
+            "--type",
+            "local",
+            "--config",
+            "{}",
+            "--no-set-default",
+            "--no-check",
+            "--secret",
+            "BADFORMAT",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "KEY=VALUE" in result.output
+
+
+@patch("transformerlab_cli.commands.team.api")
+@patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-5")
+@patch("transformerlab_cli.commands.team.check_configs")
+def test_wizard_set_default_failure_exits(_mock_check, mock_create, mock_api):
+    """A non-200 from set-default surfaces an error and exits non-zero."""
+    mock_api.patch.return_value = _mock_response(500, {})
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "team",
+            "setup",
+            "--name",
+            "p",
+            "--type",
+            "local",
+            "--config",
+            "{}",
+            "--set-default",
+            "--no-check",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "default" in result.output.lower()
+
+
+@patch("transformerlab_cli.commands.provider.api")
+@patch("transformerlab_cli.commands.team.api")
+@patch("transformerlab_cli.commands.team.check_configs")
+@patch("transformerlab_cli.commands.provider.check_configs")
+def test_wizard_json_output_is_clean(_pcheck, _tcheck, team_api, provider_api):
+    """In --format json mode, stdout must be parseable JSON with no console noise."""
+    # create_provider_interactively (real) posts to create the provider:
+    provider_api.post_json.return_value = _mock_response(200, {"id": "prov-clean"})
+    team_api.get.return_value = _mock_response(200, {"status": True})
+    result = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "team",
+            "setup",
+            "--name",
+            "p",
+            "--type",
+            "local",
+            "--config",
+            "{}",
+            "--no-set-default",
+            "--check",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())  # must parse cleanly — no leading console lines
+    assert data["provider_id"] == "prov-clean"

--- a/cli/tests/commands/test_team.py
+++ b/cli/tests/commands/test_team.py
@@ -71,7 +71,7 @@ def test_top_level_secret_removed():
 @patch("transformerlab_cli.commands.team.api")
 @patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-1")
 @patch("transformerlab_cli.commands.team.check_configs")
-def test_wizard_non_interactive_json(_mock_check, mock_create, mock_api):
+def test_wizard_non_interactive_json(_mock_check, _mock_create, mock_api):
     """Non-interactive JSON wizard creates a provider, sets default, sets secrets, checks."""
     mock_api.patch.return_value = _mock_response(200, {"status": "success"})
     mock_api.put_json.return_value = _mock_response(200, {"status": "success"})
@@ -108,7 +108,7 @@ def test_wizard_non_interactive_json(_mock_check, mock_create, mock_api):
 @patch("transformerlab_cli.commands.team.api")
 @patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-2")
 @patch("transformerlab_cli.commands.team.check_configs")
-def test_wizard_no_check_no_default(_mock_check, mock_create, mock_api):
+def test_wizard_no_check_no_default(_mock_check, _mock_create, mock_api):
     """--no-check and --no-set-default skip those steps."""
     mock_api.put_json.return_value = _mock_response(200, {"status": "success"})
     result = runner.invoke(
@@ -136,7 +136,8 @@ def test_wizard_no_check_no_default(_mock_check, mock_create, mock_api):
 
 
 def test_setup_help():
-    result = runner.invoke(app, ["team", "setup", "--help"])
+    # Widen the terminal so rich does not wrap/truncate the option names.
+    result = runner.invoke(app, ["team", "setup", "--help"], env={"COLUMNS": "200"})
     assert result.exit_code == 0
     assert "--set-default" in result.output
     assert "--secret" in result.output
@@ -145,7 +146,7 @@ def test_setup_help():
 @patch("transformerlab_cli.commands.team.api")
 @patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-3")
 @patch("transformerlab_cli.commands.team.check_configs")
-def test_wizard_normal_secret_merges(_mock_check, mock_create, mock_api):
+def test_wizard_normal_secret_merges(_mock_check, _mock_create, mock_api):
     """A non-special --secret is merged into team secrets via GET+PUT."""
     mock_api.get.return_value = _mock_response(200, {"secrets": {"EXISTING": "v"}})
     mock_api.put_json.return_value = _mock_response(200, {"status": "success"})
@@ -180,7 +181,7 @@ def test_wizard_normal_secret_merges(_mock_check, mock_create, mock_api):
 @patch("transformerlab_cli.commands.team.api")
 @patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-4")
 @patch("transformerlab_cli.commands.team.check_configs")
-def test_wizard_bad_secret_format_errors(_mock_check, mock_create, mock_api):
+def test_wizard_bad_secret_format_errors(_mock_check, _mock_create, mock_api):
     """--secret without '=' errors out."""
     result = runner.invoke(
         app,
@@ -208,7 +209,7 @@ def test_wizard_bad_secret_format_errors(_mock_check, mock_create, mock_api):
 @patch("transformerlab_cli.commands.team.api")
 @patch("transformerlab_cli.commands.team.create_provider_interactively", return_value="prov-5")
 @patch("transformerlab_cli.commands.team.check_configs")
-def test_wizard_set_default_failure_exits(_mock_check, mock_create, mock_api):
+def test_wizard_set_default_failure_exits(_mock_check, _mock_create, mock_api):
     """A non-200 from set-default surfaces an error and exits non-zero."""
     mock_api.patch.return_value = _mock_response(500, {})
     result = runner.invoke(

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -557,7 +557,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.55"
+version = "0.0.56"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,6 +60,8 @@ cli/src/transformerlab_cli/
 │   ├── task.py                 # lab task {list,init,add,validate,edit,upload,delete,info,queue,gallery,interactive}
 │   ├── interactive.py          # implementation for `lab task interactive`
 │   ├── provider.py             # lab provider {list,add,info,update,delete,check,enable,disable,set-default,clear-default}
+│   ├── team.py                 # lab team {setup, secret} (onboarding wizard + secret subgroup)
+│   ├── secret.py               # lab team secret {set,list,keys,delete} (registered as a subgroup of `team`)
 │   ├── server.py               # lab server {install,version,start,stop,restart,update}
 │   ├── experiment.py           # lab experiment {list,create,delete,set-default,tag,tags}
 │   ├── notes.py                # lab notes {show,edit,append}
@@ -152,6 +154,28 @@ lab job list --experiment exp-b
 lab task add ./my-task -e exp-c
 lab notes show -e exp-d
 lab job monitor -e exp-z
+```
+
+### Team setup and secrets
+
+Team-scoped configuration lives under `lab team`:
+
+- **`lab team setup`** — an onboarding wizard for a new team. Interactively walks through creating a compute provider (delegating to `create_provider_interactively` in `provider.py`), optionally setting it as the team default, and adding secrets. It is fully scriptable for non-interactive use via flags: `--name`, `--type`, `--config`, `--credentials-file`, `--secret KEY=VALUE` (repeatable), `--set-default` / `--no-set-default`, and `--check` / `--no-check` (run the provider health check at the end).
+- **`lab team secret`** — secret management subgroup with `set`, `list`, `keys`, and `delete`. (`keys` shows the platform-recognized secret key names.) This was previously the top-level `lab secret` group; it now lives under `lab team`.
+
+```bash
+# Interactive onboarding
+lab team setup
+
+# Non-interactive (combine with the global --no-interactive flag)
+lab team setup --no-interactive --name my-provider --type ssh \
+  --credentials-file ./creds.json --set-default --secret HF_TOKEN=hf_xxx --check
+
+# Secrets
+lab team secret set HF_TOKEN hf_xxx
+lab team secret list
+lab team secret keys
+lab team secret delete HF_TOKEN
 ```
 
 ## Adding a New Command

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -161,21 +161,26 @@ lab job monitor -e exp-z
 Team-scoped configuration lives under `lab team`:
 
 - **`lab team setup`** — an onboarding wizard for a new team. Interactively walks through creating a compute provider (delegating to `create_provider_interactively` in `provider.py`), optionally setting it as the team default, and adding secrets. It is fully scriptable for non-interactive use via flags: `--name`, `--type`, `--config`, `--credentials-file`, `--secret KEY=VALUE` (repeatable), `--set-default` / `--no-set-default`, and `--check` / `--no-check` (run the provider health check at the end).
-- **`lab team secret`** — secret management subgroup with `set`, `list`, `keys`, and `delete`. (`keys` shows the platform-recognized secret key names.) This was previously the top-level `lab secret` group; it now lives under `lab team`.
+- **`lab team secret`** — secret management lives under `lab team secret` with `set`, `list`, `keys`, and `delete`. (`keys` shows the platform-recognized secret key names.)
+
+`--no-interactive` and `--format json` are global flags on the root callback, so they must come immediately after `lab`, **before** the `team` subgroup.
 
 ```bash
 # Interactive onboarding
 lab team setup
 
-# Non-interactive (combine with the global --no-interactive flag)
-lab team setup --no-interactive --name my-provider --type ssh \
-  --credentials-file ./creds.json --set-default --secret HF_TOKEN=hf_xxx --check
+# Non-interactive (the global --no-interactive flag comes right after `lab`)
+lab --no-interactive team setup --name my-provider --type ssh \
+  --credentials-file ./creds.json --set-default --secret _HF_TOKEN=hf_xxx --check
 
 # Secrets
-lab team secret set HF_TOKEN hf_xxx
+lab team secret set _HF_TOKEN hf_xxx
 lab team secret list
 lab team secret keys
-lab team secret delete HF_TOKEN
+lab team secret delete _HF_TOKEN
+
+# JSON output (the global --format json flag also comes right after `lab`)
+lab --format json team secret list
 ```
 
 ## Adding a New Command


### PR DESCRIPTION
- Added a new lab team command group for team configuration.
- Added lab team setup — an interactive onboarding wizard that walks a new team through: adding a compute provider → optionally setting it as the team default → setting platform secrets → optionally running a provider health check.
- Moved secret management to lab team secret (set, list, keys, delete) and removed the top-level lab secret entirely.
- lab team secret set with no key now shows a friendly picker of platform secrets (HuggingFace, GitHub PAT, W&B, ngrok) plus a "Custom key…" option — no need to remember raw key names like _HF_TOKEN.
- Added a global --no-interactive flag; --format json now implies non-interactive. The wizard and all secret commands are fully scriptable (flag-driven) and emit clean JSON with no console noise.
- Refactor: extracted shared provider-creation logic (create_provider_interactively) so lab provider add and the wizard reuse the same code path. lab provider itself is unchanged and stays top-level.
- Hardening: the wizard and secret commands now surface API errors (failed set-default / secret-save) instead of silently reporting success, and avoid clobbering existing secrets on a failed fetch.
- Docs: updated docs/cli.md with the new lab team setup / lab team secret commands and examples.