### PR TITLE
Add more commands to lab team in CLI

### DIFF
--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -833,6 +833,24 @@ This applies to launching jobs, fetching logs, checking cluster status, and ever
 | `lab server install` | Interactive server setup wizard | No |
 | `lab server version` | Show installed server version | No |
 | `lab server update` | Update server to latest | No |
+| `lab team info` | Show current team: name, your role, member count, quota | No |
+| `lab team rename <name>` | Rename the current team (team owners only) | No |
+| `lab team setup` | Onboarding wizard: add a provider, set defaults/secrets, health-check | No |
+| `lab team secret list` | List secrets (`--user`/`-u` for user-level, `--show-values`) | No |
+| `lab team secret set [name] [value]` | Set a secret (`--user`/`-u` for user-level) | No |
+| `lab team secret delete <name>` | Delete a secret (`--user`/`-u`, `--no-interactive`) | No |
+| `lab team secret keys` | Show platform-recognized secret key names | No |
+| `lab team quota show` | Show the current team's monthly quota (minutes; shows hours too) | No |
+| `lab team quota set <minutes>` | Set team monthly quota in minutes (team owners only) | No |
+| `lab team quota usage` | Per-user quota usage for the team (team owners only) | No |
+| `lab team quota set-user <email\|uuid> <minutes>` | Set a per-user quota override (team owners only) | No |
+| `lab team quota me` | Show your own quota status in the current team | No |
+| `lab team members list` | List members of the current team | No |
+| `lab team members invite <email>` | Invite a member by email (`--role member\|owner`, team owners only) | No |
+| `lab team members remove <email\|uuid>` | Remove a member (`--no-interactive`; team owners only) | No |
+| `lab team members set-role <email\|uuid> <role>` | Change a member's role to `member`/`owner` (team owners only) | No |
+| `lab team invitations list` | List pending invitations for the team (team owners only) | No |
+| `lab team invitations cancel <invitation_id>` | Cancel a pending invitation (`--no-interactive`; team owners only) | No |
 
 ## JSON Output Shapes
 

--- a/api/transformerlab/routers/auth.py
+++ b/api/transformerlab/routers/auth.py
@@ -648,9 +648,19 @@ async def set_user_secrets(
         # Ensure workspace directory exists
         await storage.makedirs(workspace_dir, exist_ok=True)
 
+        # Special secrets live in the same file but are only mutable via the
+        # special secrets endpoint. Preserve them so a regular-secrets PUT
+        # (which overwrites the whole file) does not silently wipe them.
+        preserved_special = {}
+        if await storage.exists(secrets_path):
+            async with await storage.open(secrets_path, "r") as f:
+                existing = json.loads(await f.read())
+            preserved_special = {k: v for k, v in existing.items() if k in SPECIAL_SECRET_KEYS}
+        merged = {**secrets_data.secrets, **preserved_special}
+
         # Write secrets to file
         async with await storage.open(secrets_path, "w") as f:
-            await f.write(json.dumps(secrets_data.secrets, indent=2))
+            await f.write(json.dumps(merged, indent=2))
 
         return {
             "status": "success",

--- a/api/transformerlab/services/team_service.py
+++ b/api/transformerlab/services/team_service.py
@@ -735,8 +735,17 @@ async def set_team_secrets(workspace_dir: str, secrets: dict) -> dict:
     secrets_path = storage.join(workspace_dir, "team_secrets.json")
     try:
         await storage.makedirs(workspace_dir, exist_ok=True)
+        # Special secrets live in the same file but are only mutable via the
+        # special secrets endpoint. Preserve them so a regular-secrets PUT
+        # (which overwrites the whole file) does not silently wipe them.
+        preserved_special = {}
+        if await storage.exists(secrets_path):
+            async with await storage.open(secrets_path, "r") as f:
+                existing = json.loads(await f.read())
+            preserved_special = {k: v for k, v in existing.items() if k in SPECIAL_SECRET_KEYS}
+        merged = {**secrets, **preserved_special}
         async with await storage.open(secrets_path, "w") as f:
-            await f.write(json.dumps(secrets, indent=2))
+            await f.write(json.dumps(merged, indent=2))
         return {"status": "success", "message": "Team secrets saved successfully", "secret_keys": list(secrets.keys())}
     except HTTPException:
         raise

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.56"
+version = "0.0.57"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/secret.py
+++ b/cli/src/transformerlab_cli/commands/secret.py
@@ -71,7 +71,7 @@ def _prompt_special_secret_key() -> str:
 
 @app.command("list")
 def command_secret_list(
-    user: bool = typer.Option(False, "--user", help="List user-level secrets instead of team secrets"),
+    user: bool = typer.Option(False, "--user", "-u", help="List user-level secrets instead of team secrets"),
     show_values: bool = typer.Option(False, "--show-values", help="Show actual secret values (owner only for team)"),
 ):
     """List secrets."""
@@ -117,7 +117,7 @@ def command_secret_keys():
 def command_secret_set(
     name: str = typer.Argument(None, help="Secret name (omit to choose from a menu interactively)"),
     value: str = typer.Argument(None, help="Secret value (omit to be prompted with hidden input)"),
-    user: bool = typer.Option(False, "--user", help="Set as a user-level secret instead of team secret"),
+    user: bool = typer.Option(False, "--user", "-u", help="Set as a user-level secret instead of team secret"),
 ):
     """Set a secret. Overwrites if the name already exists."""
     if name is None:
@@ -168,7 +168,7 @@ def command_secret_set(
 @app.command("delete")
 def command_secret_delete(
     name: str = typer.Argument(..., help="Secret name to delete"),
-    user: bool = typer.Option(False, "--user", help="Delete a user-level secret instead of team secret"),
+    user: bool = typer.Option(False, "--user", "-u", help="Delete a user-level secret instead of team secret"),
     no_interactive: bool = typer.Option(False, "--no-interactive", help="Skip confirmation prompt"),
 ):
     """Delete a secret."""

--- a/cli/src/transformerlab_cli/commands/secret.py
+++ b/cli/src/transformerlab_cli/commands/secret.py
@@ -149,7 +149,9 @@ def command_secret_set(
             console.print(f"[error]Error:[/error] Failed to fetch secrets. {_extract_error_detail(get_response)}")
             raise typer.Exit(1)
 
-        secrets = get_response.json().get("secrets", {})
+        # Exclude special secrets: they share this file but are rejected by the
+        # regular secrets endpoint and are managed via the special secrets path.
+        secrets = {k: v for k, v in get_response.json().get("secrets", {}).items() if k not in SPECIAL_SECRET_KEYS}
         secrets[name] = value
 
         with console.status("[bold success]Saving secret...[/bold success]", spinner="dots"):
@@ -190,7 +192,9 @@ def command_secret_delete(
             console.print(f"[error]Error:[/error] Failed to fetch secrets. {_extract_error_detail(get_response)}")
             raise typer.Exit(1)
 
-        secrets = get_response.json().get("secrets", {})
+        # Exclude special secrets: they share this file but are rejected by the
+        # regular secrets endpoint and are managed via the special secrets path.
+        secrets = {k: v for k, v in get_response.json().get("secrets", {}).items() if k not in SPECIAL_SECRET_KEYS}
         if name not in secrets:
             console.print(f"[error]Error:[/error] Secret [bold]{name}[/bold] not found.")
             raise typer.Exit(1)

--- a/cli/src/transformerlab_cli/commands/team.py
+++ b/cli/src/transformerlab_cli/commands/team.py
@@ -41,7 +41,9 @@ def _save_secret(name: str, value: str) -> None:
                 f"[error]Error:[/error] Failed to fetch current secrets. {_extract_error_detail(get_response)}"
             )
             raise typer.Exit(1)
-        secrets = get_response.json().get("secrets", {})
+        # Exclude special secrets: they share this file but are rejected by the
+        # regular secrets endpoint and are managed via the special secrets path.
+        secrets = {k: v for k, v in get_response.json().get("secrets", {}).items() if k not in SPECIAL_SECRET_KEYS}
         secrets[name] = value
         response = api.put_json(path, json_data={"secrets": secrets})
     if response.status_code != 200:

--- a/cli/src/transformerlab_cli/commands/team.py
+++ b/cli/src/transformerlab_cli/commands/team.py
@@ -15,8 +15,15 @@ from transformerlab_cli.commands.secret import (
     _prompt_special_secret_key,
     app as secret_app,
 )
+from transformerlab_cli.commands.team_members import (
+    _extract_error_detail as _member_error_detail,
+    invitations_app,
+    members_app,
+)
+from transformerlab_cli.commands.team_quota import app as quota_app
 from transformerlab_cli.state import cli_state
-from transformerlab_cli.util.config import check_configs
+from transformerlab_cli.util.auth import fetch_user_teams, get_api_key
+from transformerlab_cli.util.config import check_configs, get_config
 from transformerlab_cli.util.ui import console
 
 app = typer.Typer()
@@ -150,5 +157,71 @@ def command_team_setup(
         console.print(f"  Check:    {status}")
 
 
+@app.command("info")
+def command_team_info():
+    """Show the current team: name, your role, member count, and quota."""
+    check_configs(output_format=cli_state.output_format)
+    team_id = get_config("team_id")
+
+    teams_info = fetch_user_teams(get_api_key()) or {}
+    teams = teams_info.get("teams", [])
+    current = next((t for t in teams if t.get("id") == team_id), None)
+
+    member_count = None
+    members_response = api.get(f"/teams/{team_id}/members")
+    if members_response.status_code == 200:
+        member_count = len(members_response.json().get("members", []))
+
+    monthly_quota = None
+    quota_response = api.get(f"/quota/team/{team_id}")
+    if quota_response.status_code == 200:
+        monthly_quota = quota_response.json().get("monthly_quota_minutes")
+
+    info = {
+        "team_id": team_id,
+        "name": current.get("name") if current else None,
+        "role": current.get("role") if current else None,
+        "member_count": member_count,
+        "monthly_quota_minutes": monthly_quota,
+    }
+
+    if cli_state.output_format == "json":
+        print(json.dumps(info))
+        return
+
+    console.print("\n[bold label]Team Info[/bold label]")
+    console.print(f"  Name:    [bold]{info['name'] or 'N/A'}[/bold]")
+    console.print(f"  Team ID: {info['team_id']}")
+    console.print(f"  Role:    {info['role'] or 'N/A'}")
+    console.print(f"  Members: {info['member_count'] if info['member_count'] is not None else 'N/A'}")
+    if monthly_quota is not None:
+        hours, mins = divmod(int(monthly_quota), 60)
+        console.print(f"  Quota:   {monthly_quota} min ({hours}h {mins}m)")
+
+
+@app.command("rename")
+def command_team_rename(
+    name: str = typer.Argument(..., help="New team name"),
+):
+    """Rename the current team. Team owners only."""
+    check_configs(output_format=cli_state.output_format)
+    team_id = get_config("team_id")
+
+    with console.status("[bold success]Renaming team...[/bold success]", spinner="dots"):
+        response = api.put_json(f"/teams/{team_id}", json_data={"name": name})
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to rename team. {_member_error_detail(response)}")
+        raise typer.Exit(1)
+
+    if cli_state.output_format == "json":
+        print(json.dumps(response.json()))
+    else:
+        console.print(f"[success]✓[/success] Team renamed to [bold]{name}[/bold].")
+
+
 app.add_typer(setup_app, name="setup", help="Onboarding wizard for a new team")
 app.add_typer(secret_app, name="secret", help="Secret management commands", no_args_is_help=True)
+app.add_typer(quota_app, name="quota", help="Team quota management", no_args_is_help=True)
+app.add_typer(members_app, name="members", help="Team member management", no_args_is_help=True)
+app.add_typer(invitations_app, name="invitations", help="Team invitation management", no_args_is_help=True)

--- a/cli/src/transformerlab_cli/commands/team_members.py
+++ b/cli/src/transformerlab_cli/commands/team_members.py
@@ -168,7 +168,7 @@ def command_invitations_list():
         console.print(f"[error]Error:[/error] Failed to fetch invitations. {_extract_error_detail(response)}")
         raise typer.Exit(1)
 
-    invitations = response.json()
+    invitations = response.json().get("invitations", [])
     if not invitations:
         exit_with_no_results(format_type, "No pending invitations")
 

--- a/cli/src/transformerlab_cli/commands/team_members.py
+++ b/cli/src/transformerlab_cli/commands/team_members.py
@@ -1,0 +1,206 @@
+"""Team member and invitation management commands (`lab team members`, `lab team invitations`)."""
+
+import json
+import uuid
+
+import typer
+
+import transformerlab_cli.util.api as api
+from transformerlab_cli.state import cli_state
+from transformerlab_cli.util.config import check_configs, get_config
+from transformerlab_cli.util.ui import console, exit_with_no_results, render_table
+
+VALID_ROLES = {"member", "owner"}
+
+
+def _extract_error_detail(response) -> str:
+    """Extract error detail from an API response."""
+    try:
+        return response.json().get("detail", response.text)
+    except (ValueError, KeyError):
+        return response.text
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(str(value))
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def _fetch_members(team_id: str) -> list[dict]:
+    """Return the list of member dicts ({user_id, email, role}) for a team."""
+    response = api.get(f"/teams/{team_id}/members")
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to fetch members. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+    return response.json().get("members", [])
+
+
+def _resolve_user(team_id: str, ref: str) -> str:
+    """Resolve an email or UUID to a user UUID. UUIDs pass through; emails are looked up."""
+    if _is_uuid(ref):
+        return ref
+    members = _fetch_members(team_id)
+    for member in members:
+        if member.get("email", "").lower() == ref.lower():
+            return member["user_id"]
+    console.print(f"[error]Error:[/error] No member found with email [bold]{ref}[/bold] in this team.")
+    raise typer.Exit(1)
+
+
+members_app = typer.Typer()
+invitations_app = typer.Typer()
+
+
+@members_app.command("list")
+def command_members_list():
+    """List members of the current team."""
+    check_configs(output_format=cli_state.output_format)
+    format_type = cli_state.output_format
+    team_id = get_config("team_id")
+
+    with console.status("[bold success]Fetching members...[/bold success]", spinner="dots"):
+        members = _fetch_members(team_id)
+
+    if not members:
+        exit_with_no_results(format_type, "No members found")
+
+    render_table(
+        data=members,
+        format_type=format_type,
+        table_columns=["email", "role", "user_id"],
+        title="Team Members",
+    )
+
+
+@members_app.command("invite")
+def command_members_invite(
+    email: str = typer.Argument(..., help="Email address to invite"),
+    role: str = typer.Option("member", "--role", help="Role for the invited member: member or owner"),
+):
+    """Invite a new member to the current team by email."""
+    check_configs(output_format=cli_state.output_format)
+    if role not in VALID_ROLES:
+        console.print(f"[error]Error:[/error] --role must be one of {sorted(VALID_ROLES)}, got '{role}'")
+        raise typer.Exit(1)
+
+    team_id = get_config("team_id")
+    with console.status("[bold success]Sending invitation...[/bold success]", spinner="dots"):
+        response = api.post_json(f"/teams/{team_id}/members", json_data={"email": email, "role": role})
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to invite member. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    if cli_state.output_format == "json":
+        print(json.dumps(response.json()))
+    else:
+        console.print(f"[success]✓[/success] Invited [bold]{email}[/bold] as [bold]{role}[/bold].")
+
+
+@members_app.command("remove")
+def command_members_remove(
+    user: str = typer.Argument(..., help="Email or user UUID of the member to remove"),
+    no_interactive: bool = typer.Option(False, "--no-interactive", help="Skip confirmation prompt"),
+):
+    """Remove a member from the current team."""
+    check_configs(output_format=cli_state.output_format)
+    skip_confirm = no_interactive or cli_state.no_interactive
+    team_id = get_config("team_id")
+    user_id = _resolve_user(team_id, user)
+
+    if not skip_confirm:
+        typer.confirm(f"Remove member {user} from the team?", abort=True)
+
+    with console.status("[bold success]Removing member...[/bold success]", spinner="dots"):
+        response = api.delete(f"/teams/{team_id}/members/{user_id}")
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to remove member. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    if cli_state.output_format == "json":
+        print(json.dumps(response.json()))
+    else:
+        console.print(f"[success]✓[/success] Removed [bold]{user}[/bold] from the team.")
+
+
+@members_app.command("set-role")
+def command_members_set_role(
+    user: str = typer.Argument(..., help="Email or user UUID of the member"),
+    role: str = typer.Argument(..., help="New role: member or owner"),
+):
+    """Change a member's role in the current team."""
+    check_configs(output_format=cli_state.output_format)
+    if role not in VALID_ROLES:
+        console.print(f"[error]Error:[/error] role must be one of {sorted(VALID_ROLES)}, got '{role}'")
+        raise typer.Exit(1)
+
+    team_id = get_config("team_id")
+    user_id = _resolve_user(team_id, user)
+
+    with console.status("[bold success]Updating role...[/bold success]", spinner="dots"):
+        response = api.put_json(f"/teams/{team_id}/members/{user_id}/role", json_data={"role": role})
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to update role. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    if cli_state.output_format == "json":
+        print(json.dumps(response.json()))
+    else:
+        console.print(f"[success]✓[/success] Set [bold]{user}[/bold] role to [bold]{role}[/bold].")
+
+
+@invitations_app.command("list")
+def command_invitations_list():
+    """List pending invitations for the current team."""
+    check_configs(output_format=cli_state.output_format)
+    format_type = cli_state.output_format
+    team_id = get_config("team_id")
+
+    with console.status("[bold success]Fetching invitations...[/bold success]", spinner="dots"):
+        response = api.get(f"/teams/{team_id}/invitations")
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to fetch invitations. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    invitations = response.json()
+    if not invitations:
+        exit_with_no_results(format_type, "No pending invitations")
+
+    render_table(
+        data=invitations,
+        format_type=format_type,
+        table_columns=["id", "email", "role", "status", "invited_by_email", "expires_at"],
+        title="Team Invitations",
+    )
+
+
+@invitations_app.command("cancel")
+def command_invitations_cancel(
+    invitation_id: str = typer.Argument(..., help="Invitation ID to cancel"),
+    no_interactive: bool = typer.Option(False, "--no-interactive", help="Skip confirmation prompt"),
+):
+    """Cancel a pending invitation."""
+    check_configs(output_format=cli_state.output_format)
+    skip_confirm = no_interactive or cli_state.no_interactive
+    team_id = get_config("team_id")
+
+    if not skip_confirm:
+        typer.confirm(f"Cancel invitation {invitation_id}?", abort=True)
+
+    with console.status("[bold success]Cancelling invitation...[/bold success]", spinner="dots"):
+        response = api.delete(f"/teams/{team_id}/invitations/{invitation_id}")
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to cancel invitation. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    if cli_state.output_format == "json":
+        print(json.dumps(response.json()))
+    else:
+        console.print(f"[success]✓[/success] Cancelled invitation [bold]{invitation_id}[/bold].")

--- a/cli/src/transformerlab_cli/commands/team_quota.py
+++ b/cli/src/transformerlab_cli/commands/team_quota.py
@@ -1,0 +1,150 @@
+"""Team quota management commands (`lab team quota`)."""
+
+import json
+
+import typer
+
+import transformerlab_cli.util.api as api
+from transformerlab_cli.commands.team_members import _extract_error_detail, _resolve_user
+from transformerlab_cli.state import cli_state
+from transformerlab_cli.util.config import check_configs, get_config
+from transformerlab_cli.util.ui import console, exit_with_no_results, render_table
+
+app = typer.Typer()
+
+
+def _fmt_minutes(minutes) -> str:
+    """Render a minute count as 'N min (Hh Mm)' for pretty output."""
+    try:
+        total = int(round(float(minutes)))
+    except (ValueError, TypeError):
+        return str(minutes)
+    hours, mins = divmod(total, 60)
+    return f"{total} min ({hours}h {mins}m)"
+
+
+@app.command("show")
+def command_quota_show():
+    """Show the current team's quota configuration."""
+    check_configs(output_format=cli_state.output_format)
+    team_id = get_config("team_id")
+
+    with console.status("[bold success]Fetching team quota...[/bold success]", spinner="dots"):
+        response = api.get(f"/quota/team/{team_id}")
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to fetch team quota. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    data = response.json()
+    if cli_state.output_format == "json":
+        print(json.dumps(data))
+        return
+
+    console.print("\n[bold label]Team Quota[/bold label]")
+    console.print(f"  Team:          [bold]{data.get('team_id')}[/bold]")
+    console.print(f"  Monthly quota: {_fmt_minutes(data.get('monthly_quota_minutes', 0))}")
+    console.print(f"  Period start:  {data.get('current_period_start', 'N/A')}")
+
+
+@app.command("set")
+def command_quota_set(
+    minutes: int = typer.Argument(..., help="Monthly quota in minutes (>= 0)"),
+):
+    """Set the current team's monthly quota (minutes). Team owners only."""
+    check_configs(output_format=cli_state.output_format)
+    if minutes < 0:
+        console.print("[error]Error:[/error] minutes must be >= 0")
+        raise typer.Exit(1)
+    team_id = get_config("team_id")
+
+    with console.status("[bold success]Updating team quota...[/bold success]", spinner="dots"):
+        response = api.patch(f"/quota/team/{team_id}", json_data={"monthly_quota_minutes": minutes})
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to update team quota. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    if cli_state.output_format == "json":
+        print(json.dumps(response.json()))
+    else:
+        console.print(f"[success]✓[/success] Team monthly quota set to {_fmt_minutes(minutes)}.")
+
+
+@app.command("usage")
+def command_quota_usage():
+    """Show per-user quota usage for the current team. Team owners only."""
+    check_configs(output_format=cli_state.output_format)
+    format_type = cli_state.output_format
+    team_id = get_config("team_id")
+
+    with console.status("[bold success]Fetching quota usage...[/bold success]", spinner="dots"):
+        response = api.get(f"/quota/team/{team_id}/users")
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to fetch quota usage. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    users = response.json()
+    if not users:
+        exit_with_no_results(format_type, "No quota usage found")
+
+    if format_type == "json":
+        print(json.dumps(users))
+        return
+
+    render_table(
+        data=users,
+        format_type=format_type,
+        table_columns=["email", "total_quota", "used_quota", "available_quota", "overused_quota"],
+        title="Quota Usage (minutes)",
+    )
+
+
+@app.command("set-user")
+def command_quota_set_user(
+    user: str = typer.Argument(..., help="Email or user UUID to override"),
+    minutes: int = typer.Argument(..., help="Additional minutes beyond the team quota (>= 0)"),
+):
+    """Set a per-user quota override (extra minutes beyond team quota). Team owners only."""
+    check_configs(output_format=cli_state.output_format)
+    if minutes < 0:
+        console.print("[error]Error:[/error] minutes must be >= 0")
+        raise typer.Exit(1)
+    team_id = get_config("team_id")
+    user_id = _resolve_user(team_id, user)
+
+    with console.status("[bold success]Updating user quota override...[/bold success]", spinner="dots"):
+        response = api.patch(f"/quota/user/{user_id}/team/{team_id}", json_data={"monthly_quota_minutes": minutes})
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to update user quota. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    if cli_state.output_format == "json":
+        print(json.dumps(response.json()))
+    else:
+        console.print(f"[success]✓[/success] Set override for [bold]{user}[/bold] to {_fmt_minutes(minutes)}.")
+
+
+@app.command("me")
+def command_quota_me():
+    """Show your own quota status in the current team."""
+    check_configs(output_format=cli_state.output_format)
+
+    with console.status("[bold success]Fetching your quota...[/bold success]", spinner="dots"):
+        response = api.get("/quota/me")
+
+    if response.status_code != 200:
+        console.print(f"[error]Error:[/error] Failed to fetch quota. {_extract_error_detail(response)}")
+        raise typer.Exit(1)
+
+    data = response.json()
+    if cli_state.output_format == "json":
+        print(json.dumps(data))
+        return
+
+    console.print("\n[bold label]My Quota[/bold label]")
+    for key in ("total_quota", "team_quota", "user_override", "used_quota", "held_quota", "available_quota"):
+        if key in data:
+            console.print(f"  {key.replace('_', ' ').title():16} {_fmt_minutes(data[key])}")

--- a/cli/tests/commands/test_secret.py
+++ b/cli/tests/commands/test_secret.py
@@ -38,6 +38,14 @@ SAMPLE_EMPTY_SECRETS = {
     "secret_keys": [],
 }
 
+# Special secrets share the same backing file and are returned by the regular
+# GET endpoint, but the regular PUT endpoint rejects them.
+SAMPLE_SECRETS_WITH_SPECIAL = {
+    "status": "success",
+    "secrets": {"API_KEY": "sk-123", "_HF_TOKEN": "hf_existing"},
+    "secret_keys": ["API_KEY", "_HF_TOKEN"],
+}
+
 
 def _mock_response(status_code: int = 200, json_data=None):
     mock = MagicMock()
@@ -150,6 +158,37 @@ def test_secret_set(_mock_config, _mock_check, mock_get, mock_put):
     payload = put_call.kwargs["json_data"]
     assert payload["secrets"]["NEW_KEY"] == "new-value"
     assert payload["secrets"]["API_KEY"] == "sk-123"
+
+
+@patch("transformerlab_cli.commands.secret.api.put_json")
+@patch("transformerlab_cli.commands.secret.api.get", return_value=_mock_response(200, SAMPLE_SECRETS_WITH_SPECIAL))
+@patch("transformerlab_cli.commands.secret.check_configs")
+@patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
+def test_secret_set_excludes_special_from_put(_mock_config, _mock_check, mock_get, mock_put):
+    """A non-special set must not echo special secrets back to the regular endpoint."""
+    mock_put.return_value = _mock_response(200, {"status": "success"})
+    result = runner.invoke(app, ["team", "secret", "set", "NEW_KEY", "new-value"])
+    assert result.exit_code == 0
+
+    payload = mock_put.call_args.kwargs["json_data"]
+    assert payload["secrets"]["NEW_KEY"] == "new-value"
+    assert payload["secrets"]["API_KEY"] == "sk-123"
+    assert "_HF_TOKEN" not in payload["secrets"]
+
+
+@patch("transformerlab_cli.commands.secret.api.put_json")
+@patch("transformerlab_cli.commands.secret.api.get", return_value=_mock_response(200, SAMPLE_SECRETS_WITH_SPECIAL))
+@patch("transformerlab_cli.commands.secret.check_configs")
+@patch("transformerlab_cli.commands.secret.get_config", return_value="team-123")
+def test_secret_delete_excludes_special_from_put(_mock_config, _mock_check, mock_get, mock_put):
+    """A non-special delete must not echo special secrets back to the regular endpoint."""
+    mock_put.return_value = _mock_response(200, {"status": "success"})
+    result = runner.invoke(app, ["team", "secret", "delete", "API_KEY", "--no-interactive"])
+    assert result.exit_code == 0
+
+    payload = mock_put.call_args.kwargs["json_data"]
+    assert "API_KEY" not in payload["secrets"]
+    assert "_HF_TOKEN" not in payload["secrets"]
 
 
 @patch("transformerlab_cli.commands.secret.api.put_json")

--- a/cli/tests/commands/test_secret.py
+++ b/cli/tests/commands/test_secret.py
@@ -219,6 +219,15 @@ def test_secret_list_user(_mock_check, mock_get):
     assert "/users/me/secrets" in mock_get.call_args.args[0]
 
 
+@patch("transformerlab_cli.commands.secret.api.get", return_value=_mock_response(200, SAMPLE_SECRETS_RESPONSE))
+@patch("transformerlab_cli.commands.secret.check_configs")
+def test_secret_list_user_short_flag(_mock_check, mock_get):
+    """The -u short alias behaves like --user for listing."""
+    result = runner.invoke(app, ["team", "secret", "list", "-u"])
+    assert result.exit_code == 0
+    assert "/users/me/secrets" in mock_get.call_args.args[0]
+
+
 @patch("transformerlab_cli.commands.secret.api.put_json")
 @patch("transformerlab_cli.commands.secret.api.get", return_value=_mock_response(200, SAMPLE_EMPTY_SECRETS))
 @patch("transformerlab_cli.commands.secret.check_configs")

--- a/cli/tests/commands/test_team_members.py
+++ b/cli/tests/commands/test_team_members.py
@@ -1,0 +1,157 @@
+"""Tests for `lab team members` and `lab team invitations` commands."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from transformerlab_cli.main import app
+from transformerlab_cli.state import cli_state
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_state():
+    cli_state.output_format = "pretty"
+    cli_state.no_interactive = False
+    yield
+    cli_state.output_format = "pretty"
+    cli_state.no_interactive = False
+
+
+def _mock_response(status_code: int = 200, json_data=None):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data if json_data is not None else {}
+    mock.text = ""
+    return mock
+
+
+MEMBERS = {
+    "team_id": "team-1",
+    "members": [
+        {"user_id": "11111111-1111-1111-1111-111111111111", "email": "alice@example.com", "role": "owner"},
+        {"user_id": "22222222-2222-2222-2222-222222222222", "email": "bob@example.com", "role": "member"},
+    ],
+}
+
+
+@patch("transformerlab_cli.commands.team_members.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_members.check_configs")
+@patch("transformerlab_cli.commands.team_members.api")
+def test_members_list_json(mock_api, _check, _cfg):
+    mock_api.get.return_value = _mock_response(200, MEMBERS)
+    result = runner.invoke(app, ["--format", "json", "team", "members", "list"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert {m["email"] for m in data} == {"alice@example.com", "bob@example.com"}
+
+
+@patch("transformerlab_cli.commands.team_members.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_members.check_configs")
+@patch("transformerlab_cli.commands.team_members.api")
+def test_members_invite(mock_api, _check, _cfg):
+    mock_api.post_json.return_value = _mock_response(200, {"status": "invited"})
+    result = runner.invoke(
+        app, ["--format", "json", "team", "members", "invite", "new@example.com", "--role", "member"]
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_api.post_json.call_args[0][0] == "/teams/team-1/members"
+    assert mock_api.post_json.call_args.kwargs["json_data"] == {"email": "new@example.com", "role": "member"}
+
+
+@patch("transformerlab_cli.commands.team_members.check_configs")
+def test_members_invite_bad_role(_check):
+    result = runner.invoke(app, ["team", "members", "invite", "new@example.com", "--role", "boss"])
+    assert result.exit_code == 1
+    assert "role" in result.output.lower()
+
+
+@patch("transformerlab_cli.commands.team_members.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_members.check_configs")
+@patch("transformerlab_cli.commands.team_members.api")
+def test_members_remove_resolves_email(mock_api, _check, _cfg):
+    mock_api.get.return_value = _mock_response(200, MEMBERS)
+    mock_api.delete.return_value = _mock_response(200, {"status": "removed"})
+    result = runner.invoke(
+        app, ["--format", "json", "--no-interactive", "team", "members", "remove", "bob@example.com"]
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_api.delete.call_args[0][0] == "/teams/team-1/members/22222222-2222-2222-2222-222222222222"
+
+
+@patch("transformerlab_cli.commands.team_members.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_members.check_configs")
+@patch("transformerlab_cli.commands.team_members.api")
+def test_members_remove_passes_uuid_through(mock_api, _check, _cfg):
+    mock_api.delete.return_value = _mock_response(200, {"status": "removed"})
+    uid = "33333333-3333-3333-3333-333333333333"
+    result = runner.invoke(app, ["--format", "json", "--no-interactive", "team", "members", "remove", uid])
+    assert result.exit_code == 0, result.output
+    # UUID should pass through without a members lookup
+    mock_api.get.assert_not_called()
+    assert mock_api.delete.call_args[0][0] == f"/teams/team-1/members/{uid}"
+
+
+@patch("transformerlab_cli.commands.team_members.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_members.check_configs")
+@patch("transformerlab_cli.commands.team_members.api")
+def test_members_remove_unknown_email_errors(mock_api, _check, _cfg):
+    mock_api.get.return_value = _mock_response(200, MEMBERS)
+    result = runner.invoke(app, ["--no-interactive", "team", "members", "remove", "ghost@example.com"])
+    assert result.exit_code == 1
+    assert "No member found" in result.output
+
+
+@patch("transformerlab_cli.commands.team_members.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_members.check_configs")
+@patch("transformerlab_cli.commands.team_members.api")
+def test_members_set_role(mock_api, _check, _cfg):
+    mock_api.get.return_value = _mock_response(200, MEMBERS)
+    mock_api.put_json.return_value = _mock_response(200, {"status": "ok"})
+    result = runner.invoke(app, ["--format", "json", "team", "members", "set-role", "bob@example.com", "owner"])
+    assert result.exit_code == 0, result.output
+    assert mock_api.put_json.call_args[0][0] == "/teams/team-1/members/22222222-2222-2222-2222-222222222222/role"
+    assert mock_api.put_json.call_args.kwargs["json_data"] == {"role": "owner"}
+
+
+@patch("transformerlab_cli.commands.team_members.check_configs")
+def test_members_set_role_bad_role(_check):
+    result = runner.invoke(app, ["team", "members", "set-role", "bob@example.com", "boss"])
+    assert result.exit_code == 1
+
+
+@patch("transformerlab_cli.commands.team_members.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_members.check_configs")
+@patch("transformerlab_cli.commands.team_members.api")
+def test_invitations_list_json(mock_api, _check, _cfg):
+    mock_api.get.return_value = _mock_response(
+        200,
+        [
+            {
+                "id": "inv-1",
+                "email": "x@example.com",
+                "role": "member",
+                "status": "pending",
+                "invited_by_email": "alice@example.com",
+                "expires_at": "2026-06-01",
+            }
+        ],
+    )
+    result = runner.invoke(app, ["--format", "json", "team", "invitations", "list"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data[0]["id"] == "inv-1"
+    assert mock_api.get.call_args[0][0] == "/teams/team-1/invitations"
+
+
+@patch("transformerlab_cli.commands.team_members.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_members.check_configs")
+@patch("transformerlab_cli.commands.team_members.api")
+def test_invitations_cancel(mock_api, _check, _cfg):
+    mock_api.delete.return_value = _mock_response(200, {"status": "cancelled"})
+    result = runner.invoke(app, ["--format", "json", "--no-interactive", "team", "invitations", "cancel", "inv-1"])
+    assert result.exit_code == 0, result.output
+    assert mock_api.delete.call_args[0][0] == "/teams/team-1/invitations/inv-1"

--- a/cli/tests/commands/test_team_members.py
+++ b/cli/tests/commands/test_team_members.py
@@ -129,16 +129,19 @@ def test_members_set_role_bad_role(_check):
 def test_invitations_list_json(mock_api, _check, _cfg):
     mock_api.get.return_value = _mock_response(
         200,
-        [
-            {
-                "id": "inv-1",
-                "email": "x@example.com",
-                "role": "member",
-                "status": "pending",
-                "invited_by_email": "alice@example.com",
-                "expires_at": "2026-06-01",
-            }
-        ],
+        {
+            "team_id": "team-1",
+            "invitations": [
+                {
+                    "id": "inv-1",
+                    "email": "x@example.com",
+                    "role": "member",
+                    "status": "pending",
+                    "invited_by_email": "alice@example.com",
+                    "expires_at": "2026-06-01",
+                }
+            ],
+        },
     )
     result = runner.invoke(app, ["--format", "json", "team", "invitations", "list"])
     assert result.exit_code == 0, result.output

--- a/cli/tests/commands/test_team_quota.py
+++ b/cli/tests/commands/test_team_quota.py
@@ -1,0 +1,116 @@
+"""Tests for `lab team quota` commands."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from transformerlab_cli.main import app
+from transformerlab_cli.state import cli_state
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_state():
+    cli_state.output_format = "pretty"
+    cli_state.no_interactive = False
+    yield
+    cli_state.output_format = "pretty"
+    cli_state.no_interactive = False
+
+
+def _mock_response(status_code: int = 200, json_data=None):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data if json_data is not None else {}
+    mock.text = ""
+    return mock
+
+
+@patch("transformerlab_cli.commands.team_quota.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_quota.check_configs")
+@patch("transformerlab_cli.commands.team_quota.api")
+def test_quota_show_json(mock_api, _check, _cfg):
+    mock_api.get.return_value = _mock_response(
+        200, {"team_id": "team-1", "monthly_quota_minutes": 600, "current_period_start": "2026-05-01"}
+    )
+    result = runner.invoke(app, ["--format", "json", "team", "quota", "show"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["monthly_quota_minutes"] == 600
+    assert mock_api.get.call_args[0][0] == "/quota/team/team-1"
+
+
+@patch("transformerlab_cli.commands.team_quota.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_quota.check_configs")
+@patch("transformerlab_cli.commands.team_quota.api")
+def test_quota_show_pretty_shows_hours(mock_api, _check, _cfg):
+    mock_api.get.return_value = _mock_response(200, {"team_id": "team-1", "monthly_quota_minutes": 90})
+    result = runner.invoke(app, ["team", "quota", "show"])
+    assert result.exit_code == 0, result.output
+    assert "90 min (1h 30m)" in result.output
+
+
+@patch("transformerlab_cli.commands.team_quota.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_quota.check_configs")
+@patch("transformerlab_cli.commands.team_quota.api")
+def test_quota_set_patches_minutes(mock_api, _check, _cfg):
+    mock_api.patch.return_value = _mock_response(200, {"monthly_quota_minutes": 1200})
+    result = runner.invoke(app, ["--format", "json", "team", "quota", "set", "1200"])
+    assert result.exit_code == 0, result.output
+    assert mock_api.patch.call_args[0][0] == "/quota/team/team-1"
+    assert mock_api.patch.call_args.kwargs["json_data"] == {"monthly_quota_minutes": 1200}
+
+
+@patch("transformerlab_cli.commands.team_quota.check_configs")
+def test_quota_set_negative_errors(_check):
+    result = runner.invoke(app, ["team", "quota", "set", "-5"])
+    assert result.exit_code != 0
+
+
+@patch("transformerlab_cli.commands.team_quota.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_quota.check_configs")
+@patch("transformerlab_cli.commands.team_quota.api")
+def test_quota_usage_json(mock_api, _check, _cfg):
+    mock_api.get.return_value = _mock_response(
+        200, [{"email": "a@b.com", "total_quota": 600, "used_quota": 100, "available_quota": 500, "overused_quota": 0}]
+    )
+    result = runner.invoke(app, ["--format", "json", "team", "quota", "usage"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data[0]["email"] == "a@b.com"
+    assert mock_api.get.call_args[0][0] == "/quota/team/team-1/users"
+
+
+@patch("transformerlab_cli.commands.team_quota._resolve_user", return_value="uuid-9")
+@patch("transformerlab_cli.commands.team_quota.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_quota.check_configs")
+@patch("transformerlab_cli.commands.team_quota.api")
+def test_quota_set_user_resolves_email(mock_api, _check, _cfg, _resolve):
+    mock_api.patch.return_value = _mock_response(200, {"monthly_quota_minutes": 60})
+    result = runner.invoke(app, ["--format", "json", "team", "quota", "set-user", "a@b.com", "60"])
+    assert result.exit_code == 0, result.output
+    assert mock_api.patch.call_args[0][0] == "/quota/user/uuid-9/team/team-1"
+
+
+@patch("transformerlab_cli.commands.team_quota.check_configs")
+@patch("transformerlab_cli.commands.team_quota.api")
+def test_quota_me_json(mock_api, _check):
+    mock_api.get.return_value = _mock_response(200, {"total_quota": 600, "used_quota": 50, "available_quota": 550})
+    result = runner.invoke(app, ["--format", "json", "team", "quota", "me"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["total_quota"] == 600
+    assert mock_api.get.call_args[0][0] == "/quota/me"
+
+
+@patch("transformerlab_cli.commands.team_quota.get_config", return_value="team-1")
+@patch("transformerlab_cli.commands.team_quota.check_configs")
+@patch("transformerlab_cli.commands.team_quota.api")
+def test_quota_show_error_exits(mock_api, _check, _cfg):
+    mock_api.get.return_value = _mock_response(403, {"detail": "Only team owners can access this"})
+    result = runner.invoke(app, ["team", "quota", "show"])
+    assert result.exit_code == 1
+    assert "Only team owners" in result.output

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -557,7 +557,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.56"
+version = "0.0.57"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/src/renderer/components/Team/TeamSecretsSection.tsx
+++ b/src/renderer/components/Team/TeamSecretsSection.tsx
@@ -40,6 +40,16 @@ interface SecretEntry {
   isViewing?: boolean;
 }
 
+// Special secrets share the same backing file but are managed via the Special
+// Secrets section. They must be excluded from the regular secrets endpoint,
+// which rejects them and overwrites the whole file.
+const SPECIAL_SECRET_KEYS = new Set([
+  '_GITHUB_PAT_TOKEN',
+  '_HF_TOKEN',
+  '_WANDB_API_KEY',
+  '_NGROK_AUTH_TOKEN',
+]);
+
 export default function TeamSecretsSection({ teamId }: { teamId: string }) {
   const { fetchWithAuth } = useAuth();
   const [secrets, setSecrets] = useState<SecretEntry[]>([]);
@@ -68,12 +78,12 @@ export default function TeamSecretsSection({ teamId }: { teamId: string }) {
         if (res.ok) {
           const data = await res.json();
           // Convert secret keys to entries (values are masked)
-          const secretEntries: SecretEntry[] = (data.secret_keys || []).map(
-            (key: string) => ({
+          const secretEntries: SecretEntry[] = (data.secret_keys || [])
+            .filter((key: string) => !SPECIAL_SECRET_KEYS.has(key))
+            .map((key: string) => ({
               key,
               value: '', // Values are masked, so we don't show them
-            }),
-          );
+            }));
           setSecrets(secretEntries);
         } else {
           const errorData = await res.json();
@@ -206,7 +216,13 @@ export default function TeamSecretsSection({ teamId }: { teamId: string }) {
         );
         if (getRes.ok) {
           const getData = await getRes.json();
-          currentSecrets = getData.secrets || {};
+          // Drop special secrets: the regular endpoint rejects them and
+          // overwrites the whole file, so they must not be echoed back.
+          currentSecrets = Object.fromEntries(
+            Object.entries(
+              (getData.secrets || {}) as Record<string, string>,
+            ).filter(([key]) => !SPECIAL_SECRET_KEYS.has(key)),
+          );
         }
       } catch (err) {
         // If we can't fetch, start with empty object
@@ -244,14 +260,14 @@ export default function TeamSecretsSection({ teamId }: { teamId: string }) {
         );
         if (getRes.ok) {
           const getData = await getRes.json();
-          const updatedSecrets: SecretEntry[] = (getData.secret_keys || []).map(
-            (key: string) => ({
+          const updatedSecrets: SecretEntry[] = (getData.secret_keys || [])
+            .filter((key: string) => !SPECIAL_SECRET_KEYS.has(key))
+            .map((key: string) => ({
               key,
               value: '', // Don't show values after saving
               isEditing: false,
               isNew: false,
-            }),
-          );
+            }));
           setSecrets(updatedSecrets);
         } else {
           // Fallback: just update the current secret


### PR DESCRIPTION
  | Command | Description | Requires Experiment |
  |---|---|---|
  | `lab team info` | Show current team: name, your role, member count, quota | No |
  | `lab team rename <name>` | Rename the current team (team owners only) | No |
  | `lab team secret list` | List secrets (`--user`/`-u` for user-level, `--show-values`) | No |
  | `lab team secret set [name] [value]` | Set a secret (`--user`/`-u` for user-level) | No |
  | `lab team secret delete <name>` | Delete a secret (`--user`/`-u`, `--no-interactive`) | No |
  | `lab team quota show` | Show the current team's monthly quota (minutes; shows hours too) | No |
  | `lab team quota set <minutes>` | Set team monthly quota in minutes (team owners only) | No |
  | `lab team quota usage` | Per-user quota usage for the team (team owners only) | No |
  | `lab team quota set-user <email\|uuid> <minutes>` | Set a per-user quota override (team owners only) | No |
  | `lab team quota me` | Show your own quota status in the current team | No |
  | `lab team members list` | List members of the current team | No |
  | `lab team members invite <email>` | Invite a member by email (`--role member\|owner`, team owners only) | No |
  | `lab team members remove <email\|uuid>` | Remove a member (`--no-interactive`; team owners only) | No |
  | `lab team members set-role <email\|uuid> <role>` | Change a member's role to `member`/`owner` (team owners only) | No |
  | `lab team invitations list` | List pending invitations for the team (team owners only) | No |
  | `lab team invitations cancel <invitation_id>` | Cancel a pending invitation (`--no-interactive`; team owners only) | No |