### PR TITLE
Downgrade and peg azure SDK for provider

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -211,6 +211,15 @@ updates:
       # fails immediately on import. Revisit after refactoring the import path. See PR #2083.
       - dependency-name: 'azure-mgmt-resource'
         versions: ['>=25']
+      # azure-mgmt-compute 35+ rebuilt the VM create REST surface around ARM
+      # `ResourceDefinition`, dropping the flat `hardware_profile` / `storage_profile` /
+      # `os_profile` / `network_profile` keys our provider passes to
+      # `begin_create_or_update`. Launching any Azure VM fails with
+      # `Could not find member 'hardware_profile' on object of type 'ResourceDefinition'`.
+      # Hold at 34.x until the payload builder in compute_providers/azure.py is ported
+      # to the new schema. See PR #2087 (the bump we reverted).
+      - dependency-name: 'azure-mgmt-compute'
+        versions: ['>=35']
       # boto3 patches beyond 1.40.70 are uninstallable. Each boto3 patch pins a
       # matching botocore patch, and aiobotocore's compatible window in the 1.40
       # line is botocore>=1.40.37,<1.40.71 — so boto3 1.40.71+ (and all of 1.41.x)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "werkzeug==3.1.8",
   "google-cloud-storage==3.10.1",
   "azure-identity==1.25.3",
-  "azure-mgmt-compute==38.0.0",
+  "azure-mgmt-compute==34.1.0",
   "azure-mgmt-network==30.2.0",
   "azure-mgmt-resource==24.0.0",
   "azure-mgmt-authorization==4.0.0",


### PR DESCRIPTION
I merged a Dependabot update to Azure SDK that broke the format of the data we use to launch.  THis has broken the azure provider...unbreaking that by pegging to a recent working version for now.
