### PR TITLE
Open VS Code interactive sessions in a new tab to bypass vscode.dev CSP

### DIFF
--- a/src/renderer/components/Experiment/Interactive/InteractIframeModal.tsx
+++ b/src/renderer/components/Experiment/Interactive/InteractIframeModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Button,
   CircularProgress,
   DialogContent,
   IconButton,
@@ -16,7 +17,7 @@ import {
   Box,
   Divider,
 } from '@mui/joy';
-import { RefreshCwIcon } from 'lucide-react';
+import { ExternalLinkIcon, RefreshCwIcon } from 'lucide-react';
 import useSWR from 'swr';
 import * as chatAPI from 'renderer/lib/transformerlab-api-sdk';
 import { fetcher } from 'renderer/lib/transformerlab-api-sdk';
@@ -61,6 +62,10 @@ export default function InteractIframeModal({
       url: values[k],
     }));
 
+  // vscode.dev sets `Content-Security-Policy: frame-ancestors 'none'`, so any
+  // iframe embed fails with "refused to connect". Open in a new tab instead.
+  const openInNewTab = data?.interactive_type === 'vscode';
+
   const handleRefresh = () => {
     const iframe = iframeRefs.current.get(activeTab);
     if (iframe) {
@@ -88,7 +93,7 @@ export default function InteractIframeModal({
           sx={{ pr: 4 }}
         >
           <Typography level="title-lg">Interact (Job {jobId})</Typography>
-          {isReady && urls.length > 0 && (
+          {isReady && urls.length > 0 && !openInNewTab && (
             <IconButton
               variant="outlined"
               color="neutral"
@@ -118,6 +123,29 @@ export default function InteractIframeModal({
             <Typography level="body-sm" sx={{ mt: 2, px: 2 }}>
               No service URLs available for this job.
             </Typography>
+          ) : openInNewTab ? (
+            <Stack spacing={2} sx={{ mt: 3, px: 3 }}>
+              <Typography level="body-sm">
+                This service cannot be embedded. Open it in a new browser tab:
+              </Typography>
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                {urls.map(({ label, url: src }) => (
+                  <Button
+                    key={label}
+                    component="a"
+                    href={src}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="solid"
+                    color="primary"
+                    endDecorator={<ExternalLinkIcon size={16} />}
+                    sx={{ textTransform: 'capitalize' }}
+                  >
+                    Open {label}
+                  </Button>
+                ))}
+              </Stack>
+            </Stack>
           ) : (
             <Tabs
               defaultValue={0}

--- a/src/renderer/components/Experiment/Interactive/InteractIframeModal.tsx
+++ b/src/renderer/components/Experiment/Interactive/InteractIframeModal.tsx
@@ -29,6 +29,9 @@ interface InteractModalProps {
   onClose: () => void;
 }
 
+// Hoisted so the icon element isn't re-created on every render of each button.
+const externalLinkIcon = <ExternalLinkIcon size={16} />;
+
 export default function InteractIframeModal({
   jobId,
   open,
@@ -138,7 +141,7 @@ export default function InteractIframeModal({
                     rel="noopener noreferrer"
                     variant="solid"
                     color="primary"
-                    endDecorator={<ExternalLinkIcon size={16} />}
+                    endDecorator={externalLinkIcon}
                     sx={{ textTransform: 'capitalize' }}
                   >
                     Open {label}

--- a/src/renderer/components/Experiment/Interactive/InteractIframeModal.tsx
+++ b/src/renderer/components/Experiment/Interactive/InteractIframeModal.tsx
@@ -38,7 +38,8 @@ export default function InteractIframeModal({
   onClose,
 }: InteractModalProps) {
   const iframeRefs = React.useRef<Map<number, HTMLIFrameElement>>(new Map());
-  const [activeTab, setActiveTab] = React.useState(0);
+  // Only read inside handleRefresh, never in render, so a ref avoids needless re-renders on tab change.
+  const activeTabRef = React.useRef(0);
   const { experimentInfo } = useExperimentInfo();
 
   const url = React.useMemo(() => {
@@ -56,21 +57,25 @@ export default function InteractIframeModal({
   const isReady = Boolean(data?.is_ready);
   const values: Record<string, string> = data || {};
 
-  const urls = Object.keys(values)
-    .filter(
-      (k) => k.endsWith('_url') && typeof values[k] === 'string' && values[k],
-    )
-    .map((k) => ({
-      label: k.replace(/_url$/, '').replace(/_/g, ' '),
-      url: values[k],
-    }));
+  const urls = Object.keys(values).reduce<{ label: string; url: string }[]>(
+    (acc, k) => {
+      if (k.endsWith('_url') && typeof values[k] === 'string' && values[k]) {
+        acc.push({
+          label: k.replace(/_url$/, '').replace(/_/g, ' '),
+          url: values[k],
+        });
+      }
+      return acc;
+    },
+    [],
+  );
 
   // vscode.dev sets `Content-Security-Policy: frame-ancestors 'none'`, so any
   // iframe embed fails with "refused to connect". Open in a new tab instead.
   const openInNewTab = data?.interactive_type === 'vscode';
 
   const handleRefresh = () => {
-    const iframe = iframeRefs.current.get(activeTab);
+    const iframe = iframeRefs.current.get(activeTabRef.current);
     if (iframe) {
       // eslint-disable-next-line no-self-assign
       iframe.src = iframe.src;
@@ -152,7 +157,9 @@ export default function InteractIframeModal({
           ) : (
             <Tabs
               defaultValue={0}
-              onChange={(_, val) => setActiveTab(val as number)}
+              onChange={(_, val) => {
+                activeTabRef.current = val as number;
+              }}
               sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}
             >
               <TabList>


### PR DESCRIPTION
`vscode.dev` sends `Content-Security-Policy: frame-ancestors 'none'`, so embedding a
VS Code interactive session in an iframe fails with "refused to connect". When the
job's `interactive_type` is `vscode`, the Interact modal now renders an
"Open <service>" button that launches the URL in a new browser tab instead of
attempting the iframe embed (and hides the now-irrelevant refresh control).

## Test plan
- [ ] Start a VS Code interactive session and open the Interact modal — verify the
      "Open" button appears and launches vscode.dev in a new tab.
- [ ] Verify non-vscode interactive sessions still embed via iframe as before.
