### PR TITLE
Add checks that discord notification fields fit correct format

### DIFF
--- a/api/transformerlab/services/notification_service.py
+++ b/api/transformerlab/services/notification_service.py
@@ -135,16 +135,18 @@ def build_notification_request_body(webhook_url: str, payload: Dict[str, Any]) -
         f"({payload.get('job_type')}) in {payload.get('experiment_name')}"
     )
 
-    # Discord webhooks
+    # Discord webhooks. Discord rejects the whole request with 400 Bad Request
+    # if any embed field `value` is empty or longer than 1024 chars, or if
+    # `content` exceeds 2000 chars — so guard empties with "-"/"None" and slice.
     if host == "discord.com" and path.startswith("/api/webhooks"):
         return {
-            "content": summary,
+            "content": summary[:2000],
             "embeds": [
                 {
                     "title": "Job notification",
                     "fields": [
-                        {"name": "Status", "value": str(payload.get("status")), "inline": True},
-                        {"name": "Type", "value": str(payload.get("job_type")), "inline": True},
+                        {"name": "Status", "value": str(payload.get("status")) or "-", "inline": True},
+                        {"name": "Type", "value": str(payload.get("job_type")) or "-", "inline": True},
                         {"name": "Experiment", "value": str(payload.get("experiment_name")) or "-"},
                         {
                             "name": "Duration (s)",
@@ -155,7 +157,9 @@ def build_notification_request_body(webhook_url: str, payload: Dict[str, Any]) -
                         },
                         {
                             "name": "Error",
-                            "value": str(payload.get("error_message")) if payload.get("error_message") else "None",
+                            "value": str(payload.get("error_message"))[:1024]
+                            if payload.get("error_message")
+                            else "None",
                         },
                     ],
                 },


### PR DESCRIPTION
Fix for https://transformerlab.sentry.io/issues/7522305803/?alert_rule_id=16591847&alert_timestamp=1780429098606&alert_type=email&environment=production&notification_uuid=8445adab-025b-461c-a4f3-9c9a9e768b51&project=4510699247566848&referrer=alert_email