### PR TITLE
Add a limit to the number of teams a user can create

### DIFF
--- a/api/test/test_team_service.py
+++ b/api/test/test_team_service.py
@@ -160,6 +160,170 @@ def test_is_personal_team_falls_back_to_email_prefix():
     assert _is_personal_team(user, team) is True
 
 
+# ==================== Team creation limit ====================
+
+
+def test_max_teams_per_user_unset_is_unlimited(monkeypatch):
+    from transformerlab.services.team_service import _get_max_teams_per_user
+
+    monkeypatch.delenv("TFL_MAX_TEAMS_PER_USER", raising=False)
+    assert _get_max_teams_per_user() is None
+
+
+def test_max_teams_per_user_valid_int(monkeypatch):
+    from transformerlab.services.team_service import _get_max_teams_per_user
+
+    monkeypatch.setenv("TFL_MAX_TEAMS_PER_USER", "3")
+    assert _get_max_teams_per_user() == 3
+
+
+def test_max_teams_per_user_invalid_value_is_unlimited(monkeypatch):
+    from transformerlab.services.team_service import _get_max_teams_per_user
+
+    monkeypatch.setenv("TFL_MAX_TEAMS_PER_USER", "not-a-number")
+    assert _get_max_teams_per_user() is None
+
+
+def test_max_teams_per_user_non_positive_is_unlimited(monkeypatch):
+    from transformerlab.services.team_service import _get_max_teams_per_user
+
+    monkeypatch.setenv("TFL_MAX_TEAMS_PER_USER", "0")
+    assert _get_max_teams_per_user() is None
+    monkeypatch.setenv("TFL_MAX_TEAMS_PER_USER", "-2")
+    assert _get_max_teams_per_user() is None
+
+
+def test_max_teams_per_user_empty_is_unlimited(monkeypatch):
+    from transformerlab.services.team_service import _get_max_teams_per_user
+
+    monkeypatch.setenv("TFL_MAX_TEAMS_PER_USER", "   ")
+    assert _get_max_teams_per_user() is None
+
+
+def _make_user(first_name="Alice", email="alice@example.com", user_id="user-1"):
+    user = MagicMock()
+    user.first_name = first_name
+    user.email = email
+    user.id = user_id
+    return user
+
+
+def _make_user_team(team_id, role):
+    ut = MagicMock()
+    ut.team_id = team_id
+    ut.role = role
+    return ut
+
+
+def _make_team(team_id, name):
+    team = MagicMock()
+    team.id = team_id
+    team.name = name
+    return team
+
+
+async def test_count_owned_non_personal_teams_excludes_personal_and_member(monkeypatch):
+    from transformerlab.services import team_service
+    from transformerlab.shared.models.models import TeamRole
+
+    user = _make_user()
+    session = _make_mock_session()
+
+    user_teams = [
+        _make_user_team("t-personal", TeamRole.OWNER.value),
+        _make_user_team("t-owned-1", TeamRole.OWNER.value),
+        _make_user_team("t-owned-2", TeamRole.OWNER.value),
+        _make_user_team("t-member", TeamRole.MEMBER.value),
+    ]
+    teams = [
+        _make_team("t-personal", "Alice's Team"),
+        _make_team("t-owned-1", "Research Group"),
+        _make_team("t-owned-2", "Side Project"),
+    ]
+
+    monkeypatch.setattr(team_service.db_team, "get_user_teams", AsyncMock(return_value=user_teams))
+    monkeypatch.setattr(team_service.db_team, "get_teams_by_ids", AsyncMock(return_value=teams))
+
+    count = await team_service._count_owned_non_personal_teams(session, user)
+    assert count == 2
+
+
+async def test_count_owned_non_personal_teams_zero_when_only_personal(monkeypatch):
+    from transformerlab.services import team_service
+    from transformerlab.shared.models.models import TeamRole
+
+    user = _make_user()
+    session = _make_mock_session()
+
+    user_teams = [_make_user_team("t-personal", TeamRole.OWNER.value)]
+    teams = [_make_team("t-personal", "Alice's Team")]
+
+    monkeypatch.setattr(team_service.db_team, "get_user_teams", AsyncMock(return_value=user_teams))
+    monkeypatch.setattr(team_service.db_team, "get_teams_by_ids", AsyncMock(return_value=teams))
+
+    assert await team_service._count_owned_non_personal_teams(session, user) == 0
+
+
+async def test_create_team_raises_when_at_limit(monkeypatch):
+    from transformerlab.services import team_service
+
+    monkeypatch.setenv("TFL_MAX_TEAMS_PER_USER", "2")
+    monkeypatch.setattr(team_service, "_count_owned_non_personal_teams", AsyncMock(return_value=2))
+    insert_mock = AsyncMock()
+    monkeypatch.setattr(team_service.db_team, "insert_team", insert_mock)
+
+    user = _make_user()
+    session = _make_mock_session()
+
+    with pytest.raises(HTTPException) as exc:
+        await team_service.create_team(session, "New Team", user)
+    assert exc.value.status_code == 403
+    assert "maximum number of teams" in exc.value.detail
+    insert_mock.assert_not_called()
+
+
+async def test_create_team_allows_when_under_limit(monkeypatch):
+    from transformerlab.services import team_service
+
+    monkeypatch.setenv("TFL_MAX_TEAMS_PER_USER", "5")
+    monkeypatch.setattr(team_service, "_count_owned_non_personal_teams", AsyncMock(return_value=1))
+    monkeypatch.setattr(team_service.db_team, "insert_team", AsyncMock(return_value=_make_team("t-new", "New Team")))
+    monkeypatch.setattr(team_service.db_team, "add_user_to_team", AsyncMock())
+    # Skip storage provisioning and default-experiment creation side effects.
+    monkeypatch.delenv("TFL_REMOTE_STORAGE_ENABLED", raising=False)
+    monkeypatch.delenv("TFL_STORAGE_PROVIDER", raising=False)
+    monkeypatch.setattr(team_service, "set_organization_id", lambda _id: None)
+    monkeypatch.setattr(team_service.Experiment, "create_or_get", AsyncMock())
+
+    user = _make_user()
+    session = _make_mock_session()
+
+    result = await team_service.create_team(session, "New Team", user)
+    assert result == {"id": "t-new", "name": "New Team"}
+
+
+async def test_create_team_unlimited_when_env_unset(monkeypatch):
+    from transformerlab.services import team_service
+
+    monkeypatch.delenv("TFL_MAX_TEAMS_PER_USER", raising=False)
+    count_mock = AsyncMock(return_value=99)
+    monkeypatch.setattr(team_service, "_count_owned_non_personal_teams", count_mock)
+    monkeypatch.setattr(team_service.db_team, "insert_team", AsyncMock(return_value=_make_team("t-new", "New Team")))
+    monkeypatch.setattr(team_service.db_team, "add_user_to_team", AsyncMock())
+    monkeypatch.delenv("TFL_REMOTE_STORAGE_ENABLED", raising=False)
+    monkeypatch.delenv("TFL_STORAGE_PROVIDER", raising=False)
+    monkeypatch.setattr(team_service, "set_organization_id", lambda _id: None)
+    monkeypatch.setattr(team_service.Experiment, "create_or_get", AsyncMock())
+
+    user = _make_user()
+    session = _make_mock_session()
+
+    result = await team_service.create_team(session, "New Team", user)
+    assert result == {"id": "t-new", "name": "New Team"}
+    # Count is never consulted when the limit is unset.
+    count_mock.assert_not_called()
+
+
 # ==================== Member management ====================
 
 

--- a/api/transformerlab/services/team_service.py
+++ b/api/transformerlab/services/team_service.py
@@ -114,6 +114,35 @@ def _is_personal_team(user: User, team: Team) -> bool:
     return team.name == expected
 
 
+def _get_max_teams_per_user() -> Optional[int]:
+    """Read the per-user team-creation cap from TFL_MAX_TEAMS_PER_USER.
+
+    Returns None (unlimited) when the env var is unset, empty, non-positive, or
+    not parseable as an integer. A malformed value is logged as a warning.
+    """
+    raw = getenv("TFL_MAX_TEAMS_PER_USER")
+    if raw is None or not raw.strip():
+        return None
+    try:
+        limit = int(raw.strip())
+    except ValueError:
+        logger.warning("Ignoring invalid TFL_MAX_TEAMS_PER_USER value %r; treating as unlimited", raw)
+        return None
+    if limit <= 0:
+        return None
+    return limit
+
+
+async def _count_owned_non_personal_teams(session: AsyncSession, user: User) -> int:
+    """Count teams the user owns, excluding their personal team."""
+    user_teams = await db_team.get_user_teams(session, str(user.id))
+    owned_team_ids = [ut.team_id for ut in user_teams if ut.role == TeamRole.OWNER.value]
+    if not owned_team_ids:
+        return 0
+    teams = await db_team.get_teams_by_ids(session, owned_team_ids)
+    return sum(1 for team in teams if not _is_personal_team(user, team))
+
+
 async def get_all_team_ids() -> List[str]:
     """Return the IDs of all teams in the database."""
     async with async_session() as session:
@@ -129,6 +158,15 @@ async def create_team(
     logo_filename: Optional[str] = None,
 ) -> dict:
     """Create a team, add the creator as owner, provision storage and default experiment."""
+
+    limit = _get_max_teams_per_user()
+    if limit is not None:
+        owned_count = await _count_owned_non_personal_teams(session, user)
+        if owned_count >= limit:
+            raise HTTPException(
+                status_code=403,
+                detail=f"You have reached the maximum number of teams you can create ({limit}).",
+            )
 
     team = await db_team.insert_team(session, name)
 

--- a/src/renderer/components/Team/NewTeamModal.tsx
+++ b/src/renderer/components/Team/NewTeamModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   Button,
   FormControl,
@@ -26,22 +27,27 @@ export default function NewTeamModal({
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [logoPreview, setLogoPreview] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
 
   function resetAndClose() {
     setName('');
     setLogoFile(null);
     setLogoPreview(null);
+    setError(null);
     onClose();
   }
 
   async function handleSubmit() {
     setSubmitting(true);
+    setError(null);
     try {
       await onCreate(name, logoFile);
       setName('');
       setLogoFile(null);
       setLogoPreview(null);
       onClose();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to create team. Please try again.');
     } finally {
       setSubmitting(false);
     }
@@ -61,6 +67,12 @@ export default function NewTeamModal({
         <Typography id="new-team-title" level="h4">
           New Team
         </Typography>
+
+        {error && (
+          <Alert color="danger" variant="soft" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
 
         <Box sx={{ mt: 2 }}>
           <FormControl>

--- a/src/renderer/components/Team/Team.tsx
+++ b/src/renderer/components/Team/Team.tsx
@@ -402,6 +402,9 @@ export default function UserLoginTest(): JSX.Element {
       }
     } catch (e: any) {
       console.error('Error creating team:', e);
+      // Re-throw so NewTeamModal can surface the error to the user instead of
+      // silently closing as if the team was created.
+      throw e;
     } finally {
       setLoading(false);
     }

--- a/src/renderer/components/Team/Team.tsx
+++ b/src/renderer/components/Team/Team.tsx
@@ -367,7 +367,16 @@ export default function UserLoginTest(): JSX.Element {
       });
 
       if (!res.ok) {
-        return;
+        let detail = 'Failed to create team. Please try again.';
+        try {
+          const errBody = await res.json();
+          if (errBody?.detail) {
+            detail = errBody.detail;
+          }
+        } catch {
+          // Response body was not JSON; fall back to the default message.
+        }
+        throw new Error(detail);
       }
 
       const data = await res.json();


### PR DESCRIPTION
- This also includes the number of teams a user is invited as an owner