### PR TITLE
DStack: Catch ConnectionError and raise without logger.error

### DIFF
--- a/api/test/test_dstack_provider.py
+++ b/api/test/test_dstack_provider.py
@@ -44,13 +44,19 @@ class TestCheck:
         assert call_kwargs[1]["json"] == {"project_name": "test-project", "only_active": False, "limit": 1}
 
     @patch("transformerlab.compute_providers.dstack.requests.request")
-    def test_returns_false_on_connection_error(self, mock_request, provider):
+    def test_returns_false_on_connection_error(self, mock_request, provider, caplog):
+        import logging
         import requests as req_lib
 
         mock_request.side_effect = req_lib.exceptions.ConnectionError("unreachable")
-        status, reason = provider.check()
+        with caplog.at_level(logging.WARNING, logger="transformerlab.compute_providers.dstack"):
+            status, reason = provider.check()
         assert status is False
-        assert "Unable to list dstack runs" in reason
+        assert "unreachable" in reason
+        # A dstack server being down is an expected health-check outcome,
+        # so it should not be logged at ERROR level
+        error_logs = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_logs == []
 
 
 # --- _parse_accelerators() ---

--- a/api/transformerlab/compute_providers/dstack.py
+++ b/api/transformerlab/compute_providers/dstack.py
@@ -198,6 +198,11 @@ class DstackProvider(ComputeProvider):
                 json_data={"project_name": self.project_name, "only_active": False, "limit": limit},
                 timeout=timeout,
             )
+        except ConnectionError:
+            # The dstack server being unreachable is an expected, transient condition
+            # (e.g. the server is temporarily down). Callers such as check() handle this
+            # gracefully, so re-raise without logging at ERROR to avoid noisy Sentry alerts.
+            raise
         except Exception as exc:
             if hasattr(exc, "response") and exc.response.status_code not in [404, 405]:
                 raise

--- a/api/transformerlab/compute_providers/dstack.py
+++ b/api/transformerlab/compute_providers/dstack.py
@@ -201,7 +201,7 @@ class DstackProvider(ComputeProvider):
         except ConnectionError:
             # The dstack server being unreachable is an expected, transient condition
             # (e.g. the server is temporarily down). Callers such as check() handle this
-            # gracefully, so re-raise without logging at ERROR to avoid noisy Sentry alerts.
+            # gracefully, so re-raise without logging at ERROR.
             raise
         except Exception as exc:
             if hasattr(exc, "response") and exc.response.status_code not in [404, 405]:


### PR DESCRIPTION
If a dstack provider is down and you call check() it outputs a logger.error which was creating noise in Sentry.  But this is an expected possible condition so it shouldn't raise an error.  This will hopefully align this with other providers.

I checked and the only other place this gets called is list_clusters() but that has an `except Exception` catch all so this should be fine there as well (and not print two messages).


