### PR TITLE
Add `lab job chart` — export the job runs chart as a PNG via the CLI

### DIFF
--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -114,8 +114,9 @@ lab job request-logs JOB_ID --follow   # Provider launch/provisioning logs (e.g.
 lab job artifacts JOB_ID
 lab job download JOB_ID --file "*.csv" -o ./results
 
-# 6. (Optional) Export the experiment's job runs chart as a PNG
+# 6. (Optional) Export the experiment's job runs chart as a PNG, or share it publicly
 lab job chart -o runs.png
+lab job chart --share          # enable public sharing and print the public link
 ```
 
 ## Creating Tasks
@@ -388,9 +389,14 @@ lab notes edit
 
 # Append a single line, non-interactive — best for agents
 lab notes append "2026-05-05: switched provider from local to skypilot; queue depth was >12"
+
+# Enable public sharing for the notes and print the public link (instead of the notes)
+lab notes show --share
 ```
 
-All three commands operate on the **current experiment** (`require_current_experiment` — set it first via `lab experiment set-default`). There is no `--format json` output; `show` returns the raw string and `append`/`edit` write it back.
+All commands operate on the **current experiment** (`require_current_experiment` — set it first via `lab experiment set-default`). There is no `--format json` output for the notes content itself; `show` returns the raw string and `append`/`edit` write it back.
+
+`lab notes show --share` enables **public sharing** for the experiment notes and prints the public link instead of the notes. Anyone with the link can view the live notes (no login). It reuses the experiment's existing active link if one exists; only when sharing is off does it mint a new one, asking for confirmation first unless `--no-interactive` / `--format json` is set. With `--format json` it prints `{"url": ..., "token": ..., "created_at": ...}`. Requires the `/experiment/{id}/share/notes` endpoints — on older servers the CLI reports "This server does not support public sharing".
 
 ### When agents should use it
 
@@ -794,9 +800,9 @@ Run `lab provider list` first to confirm the numbering before piping.
 
 All three accept `--follow` to stream continuously. Start with `task-logs`; escalate to `machine-logs` for crashes outside the SDK, and `request-logs` for cluster/provisioning issues.
 
-### Exporting the job runs chart as a PNG
+### Exporting or publicly sharing the job runs chart
 
-`lab job chart` exports the experiment's job runs chart (the same one shown in the web UI's Jobs Chart view: each run's metric score over time, best-so-far runs highlighted, discarded runs grayed out, with a best-so-far step line) as a PNG image. The PNG is rendered server-side, so this requires a server new enough to have the `/experiment/{id}/jobs/chart.png` endpoint — on older servers the CLI reports "This server does not support chart export".
+`lab job chart` exports the experiment's job runs chart (the same one shown in the web UI's Jobs Chart view: each run's metric score over time, best-so-far runs highlighted, discarded runs grayed out, with a best-so-far step line) as a PNG image, and/or enables **public sharing** of the live chart. The PNG is rendered server-side, so this requires a server new enough to have the `/experiment/{id}/jobs/chart.png` endpoint — on older servers the CLI reports "This server does not support chart export". Public sharing requires the `/experiment/{id}/share/chart` endpoints — on older servers the CLI reports "This server does not support public sharing".
 
 ```bash
 # Chart the current experiment's runs (auto-detects the primary metric)
@@ -804,16 +810,23 @@ lab job chart -o runs.png
 
 # Pick a specific metric and direction; scope to another experiment
 lab job chart -o runs.png --metric eval/loss --lower-is-better -e exp-a
+
+# Enable public sharing and print the public link (no PNG written)
+lab job chart --share
+
+# Both: write the PNG and print the public link
+lab job chart --share -o runs.png
 ```
 
 | Option | Description |
 |---|---|
-| `--output` / `-o <path>` | **Required.** Path to write the PNG file. |
-| `--metric <key>` | Metric key to plot. Default: auto-detected primary metric (prefers a key named `score`, else the first metric key found). |
-| `--lower-is-better` / `--higher-is-better` | Which direction counts as "best" when highlighting best-so-far runs. Default: majority vote over each job's `job_data.lower_is_better`. |
+| `--output` / `-o <path>` | Path to write the PNG file. Required unless `--share` is given. |
+| `--share` | Enable public sharing for the jobs chart and print the public link. Anyone with the link can view the live chart (no login). Reuses the experiment's existing active link if one exists; only mints a new one when sharing is off. Minting asks for confirmation unless `--no-interactive` / `--format json` is set. |
+| `--metric <key>` | Metric key to plot. Default: auto-detected primary metric (prefers a key named `score`, else the first metric key found). Only affects the PNG, not the share link. |
+| `--lower-is-better` / `--higher-is-better` | Which direction counts as "best" when highlighting best-so-far runs. Default: majority vote over each job's `job_data.lower_is_better`. Only affects the PNG. |
 | `--experiment` / `-e <id>` | Per-command experiment override. |
 
-The command exits non-zero with a clear message when the experiment has no scored jobs (404) or the requested `--metric` doesn't exist in any job's scores (400). With `--format json` it prints `{"saved": "<path>"}` on success.
+At least one of `-o` or `--share` is required. The command exits non-zero with a clear message when the experiment has no scored jobs (404) or the requested `--metric` doesn't exist in any job's scores (400). With `--format json` it prints `{"saved": "<path>"}` for the PNG and `{"url": ..., "token": ..., "created_at": ...}` for the share link.
 
 ## Debugging Failed Jobs
 
@@ -947,7 +960,7 @@ This applies to launching jobs, fetching logs, checking cluster status, and ever
 | `lab experiment tag add <experiment> <tags...>` | Add one or more tags to an experiment (by name or id) | No |
 | `lab experiment tag remove <experiment> <tags...>` | Remove one or more tags from an experiment | No |
 | `lab experiment tags` | List all distinct tags across experiments you can read | No |
-| `lab notes show` | Render the current experiment's shared markdown notes (`--raw` for plain markdown) | Yes |
+| `lab notes show` | Render the current experiment's shared markdown notes (`--raw` for plain markdown; `--share` enables public sharing and prints the public link instead) | Yes |
 | `lab notes edit` | Open the current experiment's notes in `$EDITOR` (defaults to nano) | Yes |
 | `lab notes append <text>` | Append a line to the current experiment's notes non-interactively — preferred for agents | Yes |
 | `lab task list` | List tasks in current experiment | Yes |
@@ -967,7 +980,7 @@ This applies to launching jobs, fetching logs, checking cluster status, and ever
 | `lab job request-logs <id>` | Fetch provider launch/provisioning logs | Yes |
 | `lab job artifacts <id>` | List job artifacts | Yes |
 | `lab job download <id>` | Download artifacts (`--file` for glob) | Yes |
-| `lab job chart` | Export the experiment's job runs chart as a PNG (`-o <path>` required; `--metric`, `--lower-is-better`/`--higher-is-better`) | Yes |
+| `lab job chart` | Export the experiment's job runs chart as a PNG (`-o <path>`) and/or enable public sharing and print the public link (`--share`); at least one of `-o`/`--share` required (`--metric`, `--lower-is-better`/`--higher-is-better` affect the PNG) | Yes |
 | `lab job stop <id>` | Stop a running job | Yes |
 | `lab job delete <id>` | Delete a job (`--no-interactive` to skip prompt) | Yes |
 | `lab job delete-all` | Delete all jobs in the current experiment (`--no-interactive` to skip prompt) | Yes |

--- a/.agents/skills/transformerlab-cli/SKILL.md
+++ b/.agents/skills/transformerlab-cli/SKILL.md
@@ -113,6 +113,9 @@ lab job request-logs JOB_ID --follow   # Provider launch/provisioning logs (e.g.
 # 5. Download results
 lab job artifacts JOB_ID
 lab job download JOB_ID --file "*.csv" -o ./results
+
+# 6. (Optional) Export the experiment's job runs chart as a PNG
+lab job chart -o runs.png
 ```
 
 ## Creating Tasks
@@ -791,6 +794,27 @@ Run `lab provider list` first to confirm the numbering before piping.
 
 All three accept `--follow` to stream continuously. Start with `task-logs`; escalate to `machine-logs` for crashes outside the SDK, and `request-logs` for cluster/provisioning issues.
 
+### Exporting the job runs chart as a PNG
+
+`lab job chart` exports the experiment's job runs chart (the same one shown in the web UI's Jobs Chart view: each run's metric score over time, best-so-far runs highlighted, discarded runs grayed out, with a best-so-far step line) as a PNG image. The PNG is rendered server-side, so this requires a server new enough to have the `/experiment/{id}/jobs/chart.png` endpoint — on older servers the CLI reports "This server does not support chart export".
+
+```bash
+# Chart the current experiment's runs (auto-detects the primary metric)
+lab job chart -o runs.png
+
+# Pick a specific metric and direction; scope to another experiment
+lab job chart -o runs.png --metric eval/loss --lower-is-better -e exp-a
+```
+
+| Option | Description |
+|---|---|
+| `--output` / `-o <path>` | **Required.** Path to write the PNG file. |
+| `--metric <key>` | Metric key to plot. Default: auto-detected primary metric (prefers a key named `score`, else the first metric key found). |
+| `--lower-is-better` / `--higher-is-better` | Which direction counts as "best" when highlighting best-so-far runs. Default: majority vote over each job's `job_data.lower_is_better`. |
+| `--experiment` / `-e <id>` | Per-command experiment override. |
+
+The command exits non-zero with a clear message when the experiment has no scored jobs (404) or the requested `--metric` doesn't exist in any job's scores (400). With `--format json` it prints `{"saved": "<path>"}` on success.
+
 ## Debugging Failed Jobs
 
 **Job COMPLETE does not mean the task succeeded.** Always check `completion_status` and `completion_details`:
@@ -943,6 +967,7 @@ This applies to launching jobs, fetching logs, checking cluster status, and ever
 | `lab job request-logs <id>` | Fetch provider launch/provisioning logs | Yes |
 | `lab job artifacts <id>` | List job artifacts | Yes |
 | `lab job download <id>` | Download artifacts (`--file` for glob) | Yes |
+| `lab job chart` | Export the experiment's job runs chart as a PNG (`-o <path>` required; `--metric`, `--lower-is-better`/`--higher-is-better`) | Yes |
 | `lab job stop <id>` | Stop a running job | Yes |
 | `lab job delete <id>` | Delete a job (`--no-interactive` to skip prompt) | Yes |
 | `lab job delete-all` | Delete all jobs in the current experiment (`--no-interactive` to skip prompt) | Yes |

--- a/.agents/skills/transformerlab-cli/references/commands.md
+++ b/.agents/skills/transformerlab-cli/references/commands.md
@@ -339,26 +339,35 @@ Download job artifacts.
 
 ### `job chart`
 
-Export the experiment's job runs chart as a PNG image (each run's metric score over time, best-so-far runs highlighted, discarded runs grayed out, best-so-far step line). Rendered server-side via `GET /experiment/{id}/jobs/chart.png` — requires a server new enough to have that endpoint.
+Export the experiment's job runs chart as a PNG image (each run's metric score over time, best-so-far runs highlighted, discarded runs grayed out, best-so-far step line), and/or enable public sharing of the live chart. The PNG is rendered server-side via `GET /experiment/{id}/jobs/chart.png`; sharing uses the `/experiment/{id}/share/chart` endpoints — both require a server new enough to have them.
 
 | Option | Description |
 |---|---|
-| `--output` / `-o <path>` | **Required.** Path to write the PNG file. |
-| `--metric <key>` | Metric key to plot (default: auto-detected primary metric — prefers a key named `score`, else the first metric key). |
-| `--lower-is-better` / `--higher-is-better` | Direction for "best" run highlighting (default: majority vote over each job's `job_data.lower_is_better`). |
+| `--output` / `-o <path>` | Path to write the PNG file. Required unless `--share` is given. |
+| `--share` | Enable public sharing for the jobs chart and print the public link (anyone with the link can view the live chart, no login). Reuses the existing active link; only mints a new one when sharing is off, with a confirmation prompt unless `--no-interactive` / `--format json` is set. |
+| `--metric <key>` | Metric key to plot (default: auto-detected primary metric — prefers a key named `score`, else the first metric key). PNG only. |
+| `--lower-is-better` / `--higher-is-better` | Direction for "best" run highlighting (default: majority vote over each job's `job_data.lower_is_better`). PNG only. |
 | `--experiment` / `-e <id>` | Per-command experiment override. |
 
 ```bash
 lab job chart -o runs.png
 lab job chart -o runs.png --metric eval/loss --lower-is-better
+lab job chart --share                  # public link only, no PNG
+lab job chart --share -o runs.png      # both
 ```
 
-Errors: exits 1 with the server's message when the experiment has no scored jobs or `--metric` is unknown; on older servers without the endpoint it reports that chart export is unsupported.
+At least one of `-o`/`--share` is required. Errors: exits 1 with the server's message when the experiment has no scored jobs or `--metric` is unknown; on older servers without the endpoints it reports that chart export (or public sharing) is unsupported.
 
 **JSON output (success):**
 ```json
 {"saved": "/absolute/path/to/runs.png"}
 ```
+With `--share` (printed as its own JSON object before the `saved` line when `-o` is also given):
+```json
+{"url": "https://.../#/public/share/<token>", "token": "<token>", "created_at": "..."}
+```
+
+Related: `lab notes show --share` works the same way for the experiment notes (`/experiment/{id}/share/notes`).
 
 ### `job stop <job_id>`
 

--- a/.agents/skills/transformerlab-cli/references/commands.md
+++ b/.agents/skills/transformerlab-cli/references/commands.md
@@ -337,6 +337,29 @@ Download job artifacts.
 | `--file <pattern>` | Glob pattern for specific files (repeatable). Omit to download all as a zip. |
 | `--output` / `-o <dir>` | Output directory (default: current directory) |
 
+### `job chart`
+
+Export the experiment's job runs chart as a PNG image (each run's metric score over time, best-so-far runs highlighted, discarded runs grayed out, best-so-far step line). Rendered server-side via `GET /experiment/{id}/jobs/chart.png` — requires a server new enough to have that endpoint.
+
+| Option | Description |
+|---|---|
+| `--output` / `-o <path>` | **Required.** Path to write the PNG file. |
+| `--metric <key>` | Metric key to plot (default: auto-detected primary metric — prefers a key named `score`, else the first metric key). |
+| `--lower-is-better` / `--higher-is-better` | Direction for "best" run highlighting (default: majority vote over each job's `job_data.lower_is_better`). |
+| `--experiment` / `-e <id>` | Per-command experiment override. |
+
+```bash
+lab job chart -o runs.png
+lab job chart -o runs.png --metric eval/loss --lower-is-better
+```
+
+Errors: exits 1 with the server's message when the experiment has no scored jobs or `--metric` is unknown; on older servers without the endpoint it reports that chart export is unsupported.
+
+**JSON output (success):**
+```json
+{"saved": "/absolute/path/to/runs.png"}
+```
+
 ### `job stop <job_id>`
 
 Stop a running job.

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "fastapi==0.125.0",
   "fastapi-users[sqlalchemy,oauth]==15.0.5",
   "httpx-oauth==0.16.1",
+  "matplotlib==3.10.9",
   "nebius==0.3.73",
   "packaging==26.2",
   "psutil==7.2.2",

--- a/api/test/services/test_job_chart_service.py
+++ b/api/test/services/test_job_chart_service.py
@@ -1,0 +1,155 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from transformerlab.services import job_chart_service
+
+
+def _job(
+    job_id: str,
+    created_at: str,
+    score=None,
+    discard=None,
+    lower_is_better=None,
+):
+    job_data = {}
+    if score is not None:
+        job_data["score"] = score
+    if discard is not None:
+        job_data["discard"] = discard
+    if lower_is_better is not None:
+        job_data["lower_is_better"] = lower_is_better
+    return {"id": job_id, "status": "COMPLETE", "created_at": created_at, "job_data": job_data}
+
+
+SAMPLE_JOBS = [
+    _job("job-1", "2026-01-01T10:00:00", score={"accuracy": 0.5}),
+    _job("job-2", "2026-01-02T10:00:00", score={"accuracy": 0.7}),
+    _job("job-3", "2026-01-03T10:00:00", score={"accuracy": 0.6}),
+    _job("job-4", "2026-01-04T10:00:00", score={"accuracy": 0.9, "discard": True}),
+    _job("job-5", "2026-01-05T10:00:00", score=None),
+]
+
+
+class TestParseNumericScoreFields:
+    def test_dict_score(self):
+        assert job_chart_service._parse_numeric_score_fields({"accuracy": 0.5, "f1": "0.6"}) == {
+            "accuracy": 0.5,
+            "f1": 0.6,
+        }
+
+    def test_scalar_score(self):
+        assert job_chart_service._parse_numeric_score_fields(0.42) == {"score": 0.42}
+        assert job_chart_service._parse_numeric_score_fields("0.42") == {"score": 0.42}
+
+    def test_discard_key_excluded(self):
+        assert job_chart_service._parse_numeric_score_fields({"accuracy": 0.5, "discard": 1}) == {"accuracy": 0.5}
+
+    def test_non_numeric_values_skipped(self):
+        assert job_chart_service._parse_numeric_score_fields({"note": "great", "loss": 1.2}) == {"loss": 1.2}
+
+    def test_invalid_inputs(self):
+        assert job_chart_service._parse_numeric_score_fields(None) == {}
+        assert job_chart_service._parse_numeric_score_fields("not-a-number") == {}
+        assert job_chart_service._parse_numeric_score_fields(True) == {}
+
+
+class TestParseDiscardValue:
+    @pytest.mark.parametrize("value", [True, 1, "1", "true", "True "])
+    def test_truthy(self, value):
+        assert job_chart_service._parse_discard_value(value) is True
+
+    @pytest.mark.parametrize("value", [False, 0, "0", "false", None, "garbage", 2])
+    def test_falsy(self, value):
+        assert job_chart_service._parse_discard_value(value) is False
+
+
+class TestComputePrimaryMetricKey:
+    def test_prefers_score_key(self):
+        jobs = [_job("j", "2026-01-01T00:00:00", score={"accuracy": 0.5, "score": 0.7})]
+        assert job_chart_service.compute_primary_metric_key(jobs) == "score"
+
+    def test_falls_back_to_first_key(self):
+        jobs = [_job("j", "2026-01-01T00:00:00", score={"accuracy": 0.5, "f1": 0.6})]
+        assert job_chart_service.compute_primary_metric_key(jobs) == "accuracy"
+
+    def test_no_metrics(self):
+        assert job_chart_service.compute_primary_metric_key([_job("j", "2026-01-01T00:00:00")]) is None
+
+
+class TestResolveLowerIsBetter:
+    def test_default_false(self):
+        assert job_chart_service.resolve_lower_is_better(SAMPLE_JOBS) is False
+
+    def test_majority_true(self):
+        jobs = [
+            _job("a", "2026-01-01T00:00:00", score={"loss": 1.0}, lower_is_better=True),
+            _job("b", "2026-01-02T00:00:00", score={"loss": 0.9}, lower_is_better=True),
+            _job("c", "2026-01-03T00:00:00", score={"loss": 0.8}, lower_is_better=False),
+        ]
+        assert job_chart_service.resolve_lower_is_better(jobs) is True
+
+
+class TestBuildGraphModel:
+    def test_points_sorted_and_filtered(self):
+        model = job_chart_service.build_graph_model(SAMPLE_JOBS)
+        # job-5 has no score so it is dropped
+        assert [p.job_id for p in model.points] == ["job-1", "job-2", "job-3", "job-4"]
+        assert model.primary_metric == "accuracy"
+        assert model.axis_legend == "Score (accuracy)"
+
+    def test_best_so_far_higher_is_better(self):
+        model = job_chart_service.build_graph_model(SAMPLE_JOBS)
+        best_ids = [p.job_id for p in model.best_for_step_line]
+        # job-3 (0.6 < 0.7) is not best; job-4 is discarded despite 0.9
+        assert best_ids == ["job-1", "job-2"]
+
+    def test_best_so_far_lower_is_better(self):
+        model = job_chart_service.build_graph_model(SAMPLE_JOBS, lower_is_better=True)
+        best_ids = [p.job_id for p in model.best_for_step_line]
+        assert best_ids == ["job-1"]
+
+    def test_discarded_flag_from_score_and_job_data(self):
+        jobs = [
+            _job("a", "2026-01-01T00:00:00", score={"acc": 0.5, "discard": "true"}),
+            _job("b", "2026-01-02T00:00:00", score={"acc": 0.6}, discard=1),
+        ]
+        model = job_chart_service.build_graph_model(jobs)
+        assert all(p.discarded for p in model.points)
+        assert model.best_for_step_line == []
+
+    def test_explicit_metric_key(self):
+        jobs = [_job("a", "2026-01-01T00:00:00", score={"accuracy": 0.5, "f1": 0.6})]
+        model = job_chart_service.build_graph_model(jobs, metric_key="f1")
+        assert model.points[0].y == 0.6
+        assert model.axis_legend == "Score (f1)"
+
+    def test_no_points_when_no_dates(self):
+        jobs = [{"id": "a", "job_data": {"score": {"acc": 0.5}}}]
+        model = job_chart_service.build_graph_model(jobs)
+        assert model.points == []
+
+
+class TestRenderChartPng:
+    def test_returns_png_bytes(self):
+        model = job_chart_service.build_graph_model(SAMPLE_JOBS)
+        png = job_chart_service.render_chart_png(model)
+        assert png.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+@pytest.mark.asyncio
+class TestGenerateExperimentChartPng:
+    async def test_renders_png(self, monkeypatch):
+        monkeypatch.setattr(job_chart_service.job_service, "jobs_get_all", AsyncMock(return_value=SAMPLE_JOBS))
+        png = await job_chart_service.generate_experiment_chart_png("exp-1")
+        assert png.startswith(b"\x89PNG\r\n\x1a\n")
+
+    async def test_no_scored_jobs_raises(self, monkeypatch):
+        monkeypatch.setattr(job_chart_service.job_service, "jobs_get_all", AsyncMock(return_value=[]))
+        with pytest.raises(job_chart_service.ChartDataError):
+            await job_chart_service.generate_experiment_chart_png("exp-1")
+
+    async def test_unknown_metric_raises(self, monkeypatch):
+        monkeypatch.setattr(job_chart_service.job_service, "jobs_get_all", AsyncMock(return_value=SAMPLE_JOBS))
+        with pytest.raises(job_chart_service.MetricNotFoundError):
+            await job_chart_service.generate_experiment_chart_png("exp-1", metric="does-not-exist")

--- a/api/transformerlab/routers/experiment/jobs.py
+++ b/api/transformerlab/routers/experiment/jobs.py
@@ -21,6 +21,7 @@ from transformerlab.compute_providers.runpod import fetch_runpod_provider_logs
 from transformerlab.routers.auth import get_user_and_team
 from transformerlab.routers.serverinfo import watch_file
 from transformerlab.services.job_service import get_artifacts_from_directory, job_update_status
+import transformerlab.services.job_chart_service as job_chart_service
 import transformerlab.services.job_service as job_service
 from transformerlab.services.permission_service import require_permission
 from transformerlab.services.provider_service import get_team_provider, get_provider_instance
@@ -167,6 +168,32 @@ async def jobs_get_all(
         jobs = [_slim_job(job) for job in jobs]
 
     return jobs
+
+
+@router.get("/chart.png")
+async def jobs_chart_png(
+    experimentId: str,
+    metric: str = "",
+    lower_is_better: Optional[bool] = None,
+):
+    """
+    Render the experiment's job runs chart (metric score over time, with
+    best-so-far runs highlighted) as a PNG image.
+
+    ``metric`` defaults to the auto-detected primary metric; ``lower_is_better``
+    defaults to a majority vote over each job's ``job_data.lower_is_better``.
+    """
+    try:
+        png = await job_chart_service.generate_experiment_chart_png(
+            experiment_id=experimentId,
+            metric=metric or None,
+            lower_is_better=lower_is_better,
+        )
+    except job_chart_service.MetricNotFoundError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except job_chart_service.ChartDataError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return Response(content=png, media_type="image/png")
 
 
 async def _job_delete_handler(job_id: str, experimentId: str) -> dict:

--- a/api/transformerlab/services/job_chart_service.py
+++ b/api/transformerlab/services/job_chart_service.py
@@ -1,0 +1,280 @@
+"""Build and render the per-experiment job runs chart as a PNG.
+
+This mirrors the frontend chart in
+``src/renderer/components/Experiment/Tasks/JobsChartShared.ts`` /
+``JobsChartGraphView.tsx``: each job run is plotted as a point (metric score
+over time), best-so-far runs are highlighted, discarded runs are grayed out,
+and a step line traces the best score over time.
+"""
+
+import io
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import transformerlab.services.job_service as job_service
+
+logger = logging.getLogger(__name__)
+
+# Colors mirror JobsChartGraphView.tsx
+_BEST_COLOR = "#22c55e"
+_BEST_BORDER = "#15803d"
+_POINT_COLOR = "#3b82f6"
+_DISCARD_POINT_FILL = "#94a3b8"
+_DISCARD_POINT_STROKE = "#64748b"
+_GRID_COLOR = "#e2e8f0"
+_AXIS_TEXT_COLOR = "#475569"
+
+
+class ChartDataError(ValueError):
+    """Raised when an experiment has no chartable job data."""
+
+
+class MetricNotFoundError(ValueError):
+    """Raised when an explicitly requested metric is missing from all jobs."""
+
+
+@dataclass
+class ChartPoint:
+    x: datetime
+    y: float
+    job_id: str
+    discarded: bool
+    is_best: bool = False
+
+
+@dataclass
+class GraphModel:
+    points: List[ChartPoint]
+    best_for_step_line: List[ChartPoint]
+    primary_metric: Optional[str]
+    axis_legend: str
+
+
+def _parse_discard_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value == 1
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+        try:
+            return int(normalized) == 1
+        except ValueError:
+            return False
+    return False
+
+
+def _parse_numeric_score_fields(score: Any) -> Dict[str, float]:
+    """Extract numeric metric fields from a job's score payload."""
+    if isinstance(score, bool):
+        return {}
+    if isinstance(score, (int, float)):
+        return {"score": float(score)}
+    if isinstance(score, str):
+        try:
+            return {"score": float(score)}
+        except ValueError:
+            return {}
+    if isinstance(score, dict):
+        fields: Dict[str, float] = {}
+        for key, value in score.items():
+            if key.lower() == "discard":
+                continue
+            if isinstance(value, bool):
+                continue
+            try:
+                fields[key] = float(value)
+            except (TypeError, ValueError):
+                continue
+        return fields
+    return {}
+
+
+def compute_primary_metric_key(jobs: List[dict]) -> Optional[str]:
+    """Auto-detect the primary metric: prefer a key named 'score', else the first key."""
+    for job in jobs:
+        fields = _parse_numeric_score_fields((job.get("job_data") or {}).get("score"))
+        keys = list(fields.keys())
+        if keys:
+            return next((k for k in keys if k.lower() == "score"), keys[0])
+    return None
+
+
+def resolve_lower_is_better(jobs: List[dict]) -> bool:
+    """Majority vote over job_data.lower_is_better; defaults to False."""
+    true_count = 0
+    false_count = 0
+    for job in jobs:
+        value = (job.get("job_data") or {}).get("lower_is_better")
+        if value is True:
+            true_count += 1
+        elif value is False:
+            false_count += 1
+    if true_count == 0 and false_count == 0:
+        return False
+    return true_count > false_count
+
+
+def _extract_date(job: dict) -> Optional[datetime]:
+    job_data = job.get("job_data") or {}
+    raw = job.get("created_at") or job_data.get("start_time") or job_data.get("end_time")
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def build_graph_model(
+    jobs: List[dict],
+    metric_key: Optional[str] = None,
+    lower_is_better: Optional[bool] = None,
+) -> GraphModel:
+    """Port of buildGraphModel() from JobsChartShared.ts."""
+    primary_metric = metric_key or compute_primary_metric_key(jobs)
+    if lower_is_better is None:
+        lower_is_better = resolve_lower_is_better(jobs)
+    axis_legend = f"Score ({primary_metric})" if primary_metric else "Score"
+
+    points: List[ChartPoint] = []
+    for job in jobs:
+        date = _extract_date(job)
+        if date is None:
+            continue
+        job_data = job.get("job_data") or {}
+        score = job_data.get("score")
+        fields = _parse_numeric_score_fields(score)
+        if not primary_metric or primary_metric not in fields:
+            continue
+        score_obj = score if isinstance(score, dict) else {}
+        discarded = _parse_discard_value(score_obj.get("discard")) or _parse_discard_value(job_data.get("discard"))
+        points.append(
+            ChartPoint(
+                x=date,
+                y=fields[primary_metric],
+                job_id=str(job.get("id") or ""),
+                discarded=discarded,
+            )
+        )
+    points.sort(key=lambda p: p.x)
+
+    running_extreme = float("inf") if lower_is_better else float("-inf")
+    for point in points:
+        if point.discarded:
+            continue
+        better = point.y < running_extreme if lower_is_better else point.y > running_extreme
+        if better:
+            running_extreme = point.y
+            point.is_best = True
+    best_for_step_line = [p for p in points if not p.discarded and p.is_best]
+
+    return GraphModel(
+        points=points,
+        best_for_step_line=best_for_step_line,
+        primary_metric=primary_metric,
+        axis_legend=axis_legend,
+    )
+
+
+def render_chart_png(model: GraphModel) -> bytes:
+    """Render a GraphModel to PNG bytes with matplotlib (headless)."""
+    # Imported lazily so that importing this service (and the jobs router)
+    # doesn't pay the matplotlib startup cost on every API boot.
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.dates as mdates
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(12, 6), dpi=100)
+    try:
+        scored = [p for p in model.points if not p.discarded and not p.is_best]
+        best = [p for p in model.points if not p.discarded and p.is_best]
+        discarded = [p for p in model.points if p.discarded]
+
+        if len(model.best_for_step_line) >= 2:
+            ax.plot(
+                [p.x for p in model.best_for_step_line],
+                [p.y for p in model.best_for_step_line],
+                drawstyle="steps-post",
+                color=_BEST_COLOR,
+                linewidth=2,
+                zorder=1,
+                label="Best so far",
+            )
+        if discarded:
+            ax.scatter(
+                [p.x for p in discarded],
+                [p.y for p in discarded],
+                s=50,
+                color=_DISCARD_POINT_FILL,
+                edgecolors=_DISCARD_POINT_STROKE,
+                linewidths=1.5,
+                zorder=2,
+                label="Discarded",
+            )
+        if scored:
+            ax.scatter(
+                [p.x for p in scored],
+                [p.y for p in scored],
+                s=40,
+                color=_POINT_COLOR,
+                zorder=3,
+                label="Scored",
+            )
+        if best:
+            ax.scatter(
+                [p.x for p in best],
+                [p.y for p in best],
+                s=60,
+                color=_BEST_COLOR,
+                edgecolors=_BEST_BORDER,
+                linewidths=1,
+                zorder=4,
+                label="Best run",
+            )
+
+        ax.set_xlabel("Date", color=_AXIS_TEXT_COLOR)
+        ax.set_ylabel(model.axis_legend, color=_AXIS_TEXT_COLOR)
+        ax.grid(axis="y", color=_GRID_COLOR, linewidth=1)
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d %H:%M"))
+        ax.tick_params(colors=_AXIS_TEXT_COLOR)
+        fig.autofmt_xdate(rotation=30)
+        ax.set_title("Job Runs", color=_AXIS_TEXT_COLOR)
+        ax.legend(loc="best", fontsize=9)
+        fig.tight_layout()
+
+        buffer = io.BytesIO()
+        fig.savefig(buffer, format="png")
+        return buffer.getvalue()
+    finally:
+        plt.close(fig)
+
+
+async def generate_experiment_chart_png(
+    experiment_id: str,
+    metric: Optional[str] = None,
+    lower_is_better: Optional[bool] = None,
+) -> bytes:
+    """Fetch an experiment's REMOTE jobs and render the job runs chart as PNG bytes."""
+    jobs = await job_service.jobs_get_all(experiment_id=experiment_id, type="REMOTE", status="")
+
+    if metric:
+        has_metric = any(
+            metric in _parse_numeric_score_fields((job.get("job_data") or {}).get("score")) for job in jobs
+        )
+        if not has_metric:
+            raise MetricNotFoundError(f"Metric '{metric}' not found in any job scores for experiment {experiment_id}.")
+
+    model = build_graph_model(jobs, metric_key=metric, lower_is_better=lower_is_better)
+    if not model.points:
+        raise ChartDataError(f"No scored jobs to chart for experiment {experiment_id}.")
+
+    return render_chart_png(model)

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.62"
+version = "0.0.63"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/job.py
+++ b/cli/src/transformerlab_cli/commands/job.py
@@ -718,6 +718,66 @@ def download_artifacts(job_id: str, experiment_id: str, output_dir: str | None =
         console.print(f"[error]Error:[/error] Failed to download artifacts: {e}")
 
 
+def export_job_chart(
+    experiment_id: str,
+    output_path: str,
+    metric: str | None = None,
+    lower_is_better: bool | None = None,
+) -> None:
+    """Download the experiment's job runs chart from the server as a PNG file."""
+    output_format = cli_state.output_format
+
+    params: dict[str, str] = {}
+    if metric:
+        params["metric"] = metric
+    if lower_is_better is not None:
+        params["lower_is_better"] = "true" if lower_is_better else "false"
+    chart_url = f"/experiment/{experiment_id}/jobs/chart.png"
+    if params:
+        chart_url = f"{chart_url}?{urlencode(params)}"
+
+    if output_format != "json":
+        with console.status("[bold success]Rendering job runs chart...[/bold success]", spinner="dots"):
+            response = api.get(chart_url, timeout=60.0)
+    else:
+        response = api.get(chart_url, timeout=60.0)
+
+    if response.status_code == 200:
+        resolved_path = os.path.abspath(output_path)
+        out_dir = os.path.dirname(resolved_path)
+        try:
+            if out_dir:
+                os.makedirs(out_dir, exist_ok=True)
+            with open(resolved_path, "wb") as f:
+                f.write(response.content)
+        except OSError as e:
+            if output_format == "json":
+                print(json.dumps({"error": f"Failed to write chart file: {e}"}))
+            else:
+                console.print(f"[error]Error:[/error] Failed to write chart file: {e}")
+            raise typer.Exit(1)
+        if output_format == "json":
+            print(json.dumps({"saved": resolved_path}))
+        else:
+            console.print(f"[success]✓[/success] Job runs chart saved to: {resolved_path}")
+        return
+
+    detail = _extract_error_detail(response)
+    if response.status_code == 404 and detail.strip() == "Not Found":
+        # FastAPI's default 404 body — the endpoint itself is missing on this server.
+        message = (
+            "This server does not support chart export (missing /jobs/chart.png endpoint). "
+            "Update the Transformer Lab server and try again."
+        )
+    else:
+        message = detail or f"Failed to export chart. Status code: {response.status_code}"
+    if output_format == "json":
+        print(json.dumps({"error": message, "status_code": response.status_code}))
+    else:
+        console.print(f"[error]Error:[/error] {message}")
+    raise typer.Exit(1)
+
+
 def fetch_metrics(experiment_id: str, job_id: str, since: int = 0):
     """Fetch live training metrics for a job."""
     return api.get(f"/experiment/{experiment_id}/jobs/{job_id}/metrics?since={since}", timeout=15.0)
@@ -1046,6 +1106,23 @@ def _print_logs(experiment_id: str, job_id: str, output_format: str, fetch_fn, l
         print(json.dumps({"job_id": job_id, "logs": logs_text, "line_count": len(lines)}))
     else:
         console.print(logs_text)
+
+
+@app.command("chart")
+def command_job_chart(
+    output: str = typer.Option(..., "--output", "-o", help="Path to write the chart PNG (e.g. runs.png)"),
+    metric: str = typer.Option(None, "--metric", help="Metric key to plot (default: auto-detected primary metric)"),
+    lower_is_better: bool | None = typer.Option(
+        None,
+        "--lower-is-better/--higher-is-better",
+        help="Mark best runs assuming lower (or higher) metric values are better (default: auto-detect from job data)",
+    ),
+    experiment: str | None = typer.Option(None, "--experiment", "-e", help="Override experiment for this command"),
+):
+    """Export the experiment's job runs chart as a PNG image."""
+    check_configs(output_format=cli_state.output_format)
+    current_experiment = resolve_experiment_id(experiment)
+    export_job_chart(current_experiment, output, metric=metric, lower_is_better=lower_is_better)
 
 
 @app.command("machine-logs")

--- a/cli/src/transformerlab_cli/commands/job.py
+++ b/cli/src/transformerlab_cli/commands/job.py
@@ -22,6 +22,7 @@ from rich.text import Text
 
 from transformerlab_cli.state import cli_state
 from transformerlab_cli.util import api
+from transformerlab_cli.util import share as share_links
 from transformerlab_cli.util.config import check_configs, resolve_experiment_id
 from transformerlab_cli.util.ui import console, exit_with_no_results
 
@@ -778,6 +779,28 @@ def export_job_chart(
     raise typer.Exit(1)
 
 
+def share_job_chart(experiment_id: str) -> None:
+    """Enable public sharing for the experiment's jobs chart and print the public link."""
+    output_format = cli_state.output_format
+    confirm_message = None
+    if not cli_state.no_interactive:
+        confirm_message = "Enable public sharing for the jobs chart? Anyone with the link can view it."
+
+    try:
+        link = share_links.ensure_share_link(experiment_id, "chart", confirm_message=confirm_message)
+    except share_links.ShareLinkError as e:
+        if output_format == "json":
+            print(json.dumps({"error": e.message, "status_code": e.status_code}))
+        else:
+            console.print(f"[error]Error:[/error] {e.message}")
+        raise typer.Exit(1)
+
+    if output_format == "json":
+        print(json.dumps({"url": link.get("url"), "token": link.get("token"), "created_at": link.get("created_at")}))
+    else:
+        console.print(f"[success]✓[/success] Public sharing enabled for the jobs chart: {link['url']}")
+
+
 def fetch_metrics(experiment_id: str, job_id: str, since: int = 0):
     """Fetch live training metrics for a job."""
     return api.get(f"/experiment/{experiment_id}/jobs/{job_id}/metrics?since={since}", timeout=15.0)
@@ -1110,19 +1133,35 @@ def _print_logs(experiment_id: str, job_id: str, output_format: str, fetch_fn, l
 
 @app.command("chart")
 def command_job_chart(
-    output: str = typer.Option(..., "--output", "-o", help="Path to write the chart PNG (e.g. runs.png)"),
+    output: str | None = typer.Option(None, "--output", "-o", help="Path to write the chart PNG (e.g. runs.png)"),
     metric: str = typer.Option(None, "--metric", help="Metric key to plot (default: auto-detected primary metric)"),
     lower_is_better: bool | None = typer.Option(
         None,
         "--lower-is-better/--higher-is-better",
         help="Mark best runs assuming lower (or higher) metric values are better (default: auto-detect from job data)",
     ),
+    share: bool = typer.Option(
+        False,
+        "--share",
+        help="Enable public sharing for the jobs chart and print the public link (no PNG written unless -o is also given)",
+    ),
     experiment: str | None = typer.Option(None, "--experiment", "-e", help="Override experiment for this command"),
 ):
-    """Export the experiment's job runs chart as a PNG image."""
+    """Export the experiment's job runs chart as a PNG image, or share it publicly with --share."""
     check_configs(output_format=cli_state.output_format)
+    output_format = cli_state.output_format
+    if not output and not share:
+        message = "Provide --output/-o to save a PNG or --share to get a public link."
+        if output_format == "json":
+            print(json.dumps({"error": message}))
+        else:
+            console.print(f"[error]Error:[/error] {message}")
+        raise typer.Exit(1)
     current_experiment = resolve_experiment_id(experiment)
-    export_job_chart(current_experiment, output, metric=metric, lower_is_better=lower_is_better)
+    if share:
+        share_job_chart(current_experiment)
+    if output:
+        export_job_chart(current_experiment, output, metric=metric, lower_is_better=lower_is_better)
 
 
 @app.command("machine-logs")

--- a/cli/src/transformerlab_cli/commands/notes.py
+++ b/cli/src/transformerlab_cli/commands/notes.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import subprocess
@@ -6,6 +7,8 @@ import typer
 from rich.markdown import Markdown
 
 import transformerlab_cli.util.api as api
+from transformerlab_cli.state import cli_state
+from transformerlab_cli.util import share as share_links
 from transformerlab_cli.util.config import resolve_experiment_id
 from transformerlab_cli.util.ui import console
 
@@ -33,10 +36,35 @@ def _save_notes(experiment_id: str, content: str) -> None:
 @app.command("show")
 def command_notes_show(
     raw: bool = typer.Option(False, "--raw", help="Print raw markdown instead of rendered output"),
+    share: bool = typer.Option(
+        False,
+        "--share",
+        help="Enable public sharing for the experiment notes and print the public link instead of the notes",
+    ),
     experiment: str | None = typer.Option(None, "--experiment", "-e", help="Override experiment for this command"),
 ) -> None:
     """Show experiment notes."""
     experiment_id = resolve_experiment_id(experiment)
+    if share:
+        output_format = cli_state.output_format
+        confirm_message = None
+        if not cli_state.no_interactive:
+            confirm_message = "Enable public sharing for the experiment notes? Anyone with the link can view them."
+        try:
+            link = share_links.ensure_share_link(experiment_id, "notes", confirm_message=confirm_message)
+        except share_links.ShareLinkError as e:
+            if output_format == "json":
+                print(json.dumps({"error": e.message, "status_code": e.status_code}))
+            else:
+                console.print(f"[error]Error:[/error] {e.message}")
+            raise typer.Exit(1)
+        if output_format == "json":
+            print(
+                json.dumps({"url": link.get("url"), "token": link.get("token"), "created_at": link.get("created_at")})
+            )
+        else:
+            console.print(f"[success]✓[/success] Public sharing enabled for experiment notes: {link['url']}")
+        return
     content = _get_notes(experiment_id)
     if not content.strip():
         console.print("[dim]No notes yet.[/dim]")

--- a/cli/src/transformerlab_cli/util/share.py
+++ b/cli/src/transformerlab_cli/util/share.py
@@ -1,0 +1,75 @@
+"""Helpers for public share links (experiment notes and jobs chart)."""
+
+import typer
+
+import transformerlab_cli.util.api as api
+
+
+class ShareLinkError(Exception):
+    """Raised when a public share link cannot be fetched or created."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def _extract_error_detail(response) -> str:
+    try:
+        payload = response.json()
+        if isinstance(payload, dict):
+            return str(payload.get("detail") or payload.get("message") or response.text or "")
+    except Exception:
+        pass
+    return response.text or ""
+
+
+def _error_from_response(response) -> ShareLinkError:
+    detail = _extract_error_detail(response)
+    if response.status_code == 404 and detail.strip() == "Not Found":
+        # FastAPI's default 404 body — the share endpoints are missing on this server.
+        message = (
+            "This server does not support public sharing (missing /share endpoints). "
+            "Update the Transformer Lab server and try again."
+        )
+    else:
+        message = detail or f"Failed to create share link. Status code: {response.status_code}"
+    return ShareLinkError(message, response.status_code)
+
+
+def get_active_share_link(experiment_id: str, kind: str) -> dict | None:
+    """Return the active public share link for `kind` ("chart" or "notes"), or None if sharing is off."""
+    response = api.get(f"/experiment/{experiment_id}/share/{kind}")
+    if response.status_code != 200:
+        raise _error_from_response(response)
+    link = response.json()
+    if isinstance(link, dict) and link.get("url"):
+        return link
+    return None
+
+
+def mint_share_link(experiment_id: str, kind: str) -> dict:
+    """Mint a new public share link for `kind`, revoking any previous one server-side."""
+    response = api.post_json(f"/experiment/{experiment_id}/share/{kind}")
+    if response.status_code != 200:
+        raise _error_from_response(response)
+    created = response.json()
+    if not isinstance(created, dict) or not created.get("url"):
+        raise ShareLinkError("Server returned an unexpected share link response.", response.status_code)
+    return created
+
+
+def ensure_share_link(experiment_id: str, kind: str, confirm_message: str | None = None) -> dict:
+    """Return the active public share link for `kind`, minting one if none exists.
+
+    Reuses any existing active link so repeated calls keep returning the same URL
+    instead of rotating it (minting revokes the previous link server-side).
+    If `confirm_message` is given, prompts for confirmation before minting a new
+    link (reusing an existing link never prompts); declining aborts the command.
+    """
+    link = get_active_share_link(experiment_id, kind)
+    if link is not None:
+        return link
+    if confirm_message:
+        typer.confirm(confirm_message, abort=True)
+    return mint_share_link(experiment_id, kind)

--- a/cli/tests/commands/test_job.py
+++ b/cli/tests/commands/test_job.py
@@ -995,3 +995,93 @@ def test_job_metrics_keys_filter(_mock_require, _mock_api):
     assert "loss" in out
     assert "acc" in out
     assert "lr" not in out
+
+
+# A minimal valid PNG header is enough for the CLI, which writes bytes verbatim.
+FAKE_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-png-body"
+
+
+def _mock_png_response():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.content = FAKE_PNG_BYTES
+    return mock_resp
+
+
+def _mock_error_response(status_code, detail):
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = {"detail": detail}
+    mock_resp.text = json.dumps({"detail": detail})
+    return mock_resp
+
+
+@patch("transformerlab_cli.commands.job.api.get", return_value=_mock_png_response())
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_writes_png(_mock_check, _mock_require, mock_api, tmp_path):
+    """`job chart -o file.png` downloads the chart PNG and writes it to disk."""
+    output_path = tmp_path / "runs.png"
+    result = runner.invoke(app, ["job", "chart", "-o", str(output_path)])
+    assert result.exit_code == 0
+    assert output_path.read_bytes() == FAKE_PNG_BYTES
+    assert "Job runs chart saved to" in strip_ansi(result.output)
+    called_path = mock_api.call_args[0][0]
+    assert called_path == "/experiment/exp1/jobs/chart.png"
+
+
+@patch("transformerlab_cli.commands.job.api.get", return_value=_mock_png_response())
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_metric_and_lower_is_better_params(_mock_check, _mock_require, mock_api, tmp_path):
+    """--metric and --lower-is-better are forwarded as query params."""
+    output_path = tmp_path / "runs.png"
+    result = runner.invoke(
+        app,
+        ["job", "chart", "-o", str(output_path), "--metric", "eval/loss", "--lower-is-better"],
+    )
+    assert result.exit_code == 0
+    called_path = mock_api.call_args[0][0]
+    assert called_path.startswith("/experiment/exp1/jobs/chart.png?")
+    assert "metric=eval%2Floss" in called_path
+    assert "lower_is_better=true" in called_path
+
+
+@patch("transformerlab_cli.commands.job.api.get", return_value=_mock_png_response())
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_higher_is_better_param(_mock_check, _mock_require, mock_api, tmp_path):
+    """--higher-is-better sends lower_is_better=false."""
+    output_path = tmp_path / "runs.png"
+    result = runner.invoke(app, ["job", "chart", "-o", str(output_path), "--higher-is-better"])
+    assert result.exit_code == 0
+    assert "lower_is_better=false" in mock_api.call_args[0][0]
+
+
+@patch(
+    "transformerlab_cli.commands.job.api.get",
+    return_value=_mock_error_response(404, "No scored jobs to chart for experiment exp1."),
+)
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_no_scored_jobs(_mock_check, _mock_require, _mock_api, tmp_path):
+    """Server-side 'no data' errors surface their detail message."""
+    output_path = tmp_path / "runs.png"
+    result = runner.invoke(app, ["job", "chart", "-o", str(output_path)])
+    assert result.exit_code == 1
+    assert "No scored jobs to chart" in strip_ansi(result.output)
+    assert not output_path.exists()
+
+
+@patch(
+    "transformerlab_cli.commands.job.api.get",
+    return_value=_mock_error_response(404, "Not Found"),
+)
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_endpoint_missing_on_old_server(_mock_check, _mock_require, _mock_api, tmp_path):
+    """A FastAPI default 404 means the server predates the chart endpoint."""
+    output_path = tmp_path / "runs.png"
+    result = runner.invoke(app, ["job", "chart", "-o", str(output_path)])
+    assert result.exit_code == 1
+    assert "does not support chart export" in strip_ansi(result.output)

--- a/cli/tests/commands/test_job.py
+++ b/cli/tests/commands/test_job.py
@@ -1085,3 +1085,121 @@ def test_job_chart_endpoint_missing_on_old_server(_mock_check, _mock_require, _m
     result = runner.invoke(app, ["job", "chart", "-o", str(output_path)])
     assert result.exit_code == 1
     assert "does not support chart export" in strip_ansi(result.output)
+
+
+SHARE_LINK = {
+    "token": "tok123",
+    "url": "https://lab.cloud/#/public/share/tok123",
+    "created_at": "2026-06-04T00:00:00",
+}
+
+
+def _mock_json_response(payload, status_code=200):
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = payload
+    mock_resp.text = json.dumps(payload)
+    return mock_resp
+
+
+@patch("transformerlab_cli.util.share.api.post_json", return_value=_mock_json_response(SHARE_LINK))
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_response(None))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_share_mints_link_when_none_active(_mock_check, _mock_require, mock_get, mock_post):
+    """`job chart --share` mints a public link when none is active and prints its URL."""
+    result = runner.invoke(app, ["--no-interactive", "job", "chart", "--share"])
+    assert result.exit_code == 0
+    assert SHARE_LINK["url"] in strip_ansi(result.output)
+    assert mock_get.call_args[0][0] == "/experiment/exp1/share/chart"
+    assert mock_post.call_args[0][0] == "/experiment/exp1/share/chart"
+
+
+@patch("transformerlab_cli.util.share.api.post_json", return_value=_mock_json_response(SHARE_LINK))
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_response(None))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_share_prompts_before_minting(_mock_check, _mock_require, _mock_get, mock_post):
+    """Minting a new public link asks for confirmation; declining aborts without minting."""
+    result = runner.invoke(app, ["job", "chart", "--share"], input="n\n")
+    assert result.exit_code == 1
+    mock_post.assert_not_called()
+
+
+@patch("transformerlab_cli.util.share.api.post_json", return_value=_mock_json_response(SHARE_LINK))
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_response(None))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_share_prompt_accepted(_mock_check, _mock_require, _mock_get, mock_post):
+    """Confirming the prompt mints the link."""
+    result = runner.invoke(app, ["job", "chart", "--share"], input="y\n")
+    assert result.exit_code == 0
+    assert SHARE_LINK["url"] in strip_ansi(result.output)
+    mock_post.assert_called_once()
+
+
+@patch("transformerlab_cli.util.share.api.post_json", return_value=_mock_json_response(SHARE_LINK))
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_response(None))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_share_json_format(_mock_check, _mock_require, _mock_get, _mock_post):
+    """`--format json` emits the link as JSON and never prompts (json implies --no-interactive)."""
+    result = runner.invoke(app, ["--format", "json", "job", "chart", "--share"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload == SHARE_LINK
+
+
+@patch("transformerlab_cli.util.share.api.post_json")
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_response(SHARE_LINK))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_share_reuses_existing_link(_mock_check, _mock_require, _mock_get, mock_post):
+    """`job chart --share` reuses the active link instead of rotating it."""
+    result = runner.invoke(app, ["job", "chart", "--share"])
+    assert result.exit_code == 0
+    assert SHARE_LINK["url"] in strip_ansi(result.output)
+    mock_post.assert_not_called()
+
+
+def _share_or_png_get(path, **kwargs):
+    if "/share/chart" in path:
+        return _mock_json_response(SHARE_LINK)
+    return _mock_png_response()
+
+
+@patch("transformerlab_cli.util.share.api.post_json")
+@patch("transformerlab_cli.commands.job.api.get", side_effect=_share_or_png_get)
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_share_with_output_does_both(_mock_check, _mock_require, _mock_get, mock_post, tmp_path):
+    """`job chart --share -o file.png` prints the public link and writes the PNG."""
+    output_path = tmp_path / "runs.png"
+    result = runner.invoke(app, ["job", "chart", "--share", "-o", str(output_path)])
+    assert result.exit_code == 0
+    out = strip_ansi(result.output)
+    assert SHARE_LINK["url"] in out
+    assert "Job runs chart saved to" in out
+    assert output_path.read_bytes() == FAKE_PNG_BYTES
+    mock_post.assert_not_called()
+
+
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_requires_output_or_share(_mock_check):
+    """`job chart` without -o or --share exits with a usage error."""
+    result = runner.invoke(app, ["job", "chart"])
+    assert result.exit_code == 1
+    assert "Provide --output/-o to save a PNG or --share" in strip_ansi(result.output)
+
+
+@patch(
+    "transformerlab_cli.util.share.api.get",
+    return_value=_mock_error_response(404, "Not Found"),
+)
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+@patch("transformerlab_cli.commands.job.check_configs")
+def test_job_chart_share_endpoint_missing_on_old_server(_mock_check, _mock_require, _mock_get):
+    """A FastAPI default 404 on the share endpoint means the server predates public sharing."""
+    result = runner.invoke(app, ["job", "chart", "--share"])
+    assert result.exit_code == 1
+    assert "does not support public sharing" in strip_ansi(result.output)

--- a/cli/tests/commands/test_notes.py
+++ b/cli/tests/commands/test_notes.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -41,6 +42,74 @@ def test_notes_show_raw_flag(_mock_exp, _mock_api):
 def test_notes_show_api_error(_mock_exp, _mock_api):
     result = runner.invoke(app, ["notes", "show"])
     assert result.exit_code != 0
+
+
+# ── show --share ──────────────────────────────────────────────────────────────
+
+
+SHARE_LINK = {
+    "token": "tok123",
+    "url": "https://lab.cloud/#/public/share/tok123",
+    "created_at": "2026-06-04T00:00:00",
+}
+
+
+def _mock_json_resp(payload, status: int = 200):
+    m = MagicMock()
+    m.status_code = status
+    m.json.return_value = payload
+    m.text = ""
+    return m
+
+
+@patch("transformerlab_cli.util.share.api.post_json", return_value=_mock_json_resp(SHARE_LINK))
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_resp(None))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+def test_notes_show_share_mints_link(_mock_exp, mock_get, mock_post):
+    result = runner.invoke(app, ["--no-interactive", "notes", "show", "--share"])
+    assert result.exit_code == 0
+    assert SHARE_LINK["url"] in strip_ansi(result.output)
+    assert mock_get.call_args[0][0] == "/experiment/exp1/share/notes"
+    assert mock_post.call_args[0][0] == "/experiment/exp1/share/notes"
+
+
+@patch("transformerlab_cli.util.share.api.post_json", return_value=_mock_json_resp(SHARE_LINK))
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_resp(None))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+def test_notes_show_share_prompts_before_minting(_mock_exp, _mock_get, mock_post):
+    """Minting a new public link asks for confirmation; declining aborts without minting."""
+    result = runner.invoke(app, ["notes", "show", "--share"], input="n\n")
+    assert result.exit_code == 1
+    mock_post.assert_not_called()
+
+
+@patch("transformerlab_cli.util.share.api.post_json", return_value=_mock_json_resp(SHARE_LINK))
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_resp(None))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+def test_notes_show_share_json_format(_mock_exp, _mock_get, _mock_post):
+    """`--format json` emits the link as JSON and never prompts (json implies --no-interactive)."""
+    result = runner.invoke(app, ["--format", "json", "notes", "show", "--share"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload == SHARE_LINK
+
+
+@patch("transformerlab_cli.util.share.api.post_json")
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_resp(SHARE_LINK))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+def test_notes_show_share_reuses_existing_link(_mock_exp, _mock_get, mock_post):
+    result = runner.invoke(app, ["notes", "show", "--share"])
+    assert result.exit_code == 0
+    assert SHARE_LINK["url"] in strip_ansi(result.output)
+    mock_post.assert_not_called()
+
+
+@patch("transformerlab_cli.util.share.api.get", return_value=_mock_json_resp({"detail": "boom"}, status=500))
+@patch("transformerlab_cli.util.config.require_current_experiment", return_value="exp1")
+def test_notes_show_share_api_error(_mock_exp, _mock_get):
+    result = runner.invoke(app, ["notes", "show", "--share"])
+    assert result.exit_code != 0
+    assert "boom" in strip_ansi(result.output)
 
 
 # ── append ────────────────────────────────────────────────────────────────────

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -557,7 +557,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.62"
+version = "0.0.63"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,6 +86,7 @@ cli/src/transformerlab_cli/
     ├── auth.py                 # API key validation, user/team fetching
     ├── browser_login.py        # loopback browser login flow used by `lab login`
     ├── config.py               # ~/.lab/config.json management
+    ├── share.py                # Public share link helpers (`job chart --share`, `notes show --share`)
     ├── shared.py               # Constants (BASE_URL, credential paths)
     ├── ui.py                   # Rich console, themes, render_table()
     ├── logo.py                 # ASCII logo printed by the root help

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,7 @@ cli/src/transformerlab_cli/
 │   ├── version.py              # lab version
 │   ├── config.py               # lab config
 │   ├── install_agent_skill.py  # lab install-agent-skill
-│   ├── job.py                  # lab job {list,info,machine-logs,task-logs,request-logs,download,metrics,artifacts,discard,stop,delete,delete-all,monitor,publish ...}
+│   ├── job.py                  # lab job {list,info,machine-logs,task-logs,request-logs,download,chart,metrics,artifacts,discard,stop,delete,delete-all,monitor,publish ...}
 │   ├── task.py                 # lab task {list,init,add,validate,edit,upload,delete,info,queue,gallery,interactive}
 │   ├── interactive.py          # implementation for `lab task interactive`
 │   ├── provider.py             # lab provider {list,add,info,update,delete,check,enable,disable,set-default,clear-default}


### PR DESCRIPTION
## Summary

Adds the ability to export an experiment's **job runs chart** (the same chart shown in the web UI's Jobs Chart view) as a PNG from the CLI, and to enable **public sharing** of the live chart or the experiment notes and get the public link directly from the terminal:

```bash
lab job chart -o runs.png
lab job chart -o runs.png --metric eval/loss --lower-is-better -e exp-a
lab job chart --share                # enable public sharing, print the public link (no PNG)
lab job chart --share -o runs.png    # both
lab notes show --share               # public link for the experiment notes
```

The PNG is rendered **server-side** so the CLI stays dependency-light and any client can reuse the endpoint later. Sharing reuses the existing share-link backend (`/experiment/{id}/share/{chart|notes}` + `/public/share/{token}`).

## API

- New endpoint: `GET /experiment/{id}/jobs/chart.png` in `routers/experiment/jobs.py`, with optional `metric` and `lower_is_better` query params. Returns 404 with a clear detail when there are no scored jobs, 400 for an unknown metric.
- New service `services/job_chart_service.py` (router stays thin per the service pattern):
  - Ports the chart-model logic from the frontend's `JobsChartShared.ts` — score/discard parsing, primary-metric auto-detection (prefers a key named `score`), `lower_is_better` majority vote, best-so-far computation.
  - Renders with matplotlib (headless `Agg`, lazily imported so API boot doesn't pay the import cost). Styling mirrors the Nivo chart: blue scored dots, green best-run dots with step line, gray discarded dots.
- Dependency: `matplotlib==3.10.9` added to `api/pyproject.toml` (servers need to re-run `./install.sh`).
- No new endpoints for sharing — the CLI uses the existing `GET/POST /experiment/{id}/share/{kind}` routes.

## CLI

- New `lab job chart` command:
  - `-o/--output <path>` — where to write the PNG (required unless `--share` is given)
  - `--share` — enable public sharing for the jobs chart and print the public link
  - `--metric <key>` — defaults to the auto-detected primary metric (PNG only)
  - `--lower-is-better` / `--higher-is-better` — overrides the direction used to mark best runs (default: auto-detect from `job_data.lower_is_better`; PNG only)
  - `-e/--experiment` — per-command experiment override, like other job commands
  - At least one of `-o`/`--share` is required.
- New `lab notes show --share` — enables public sharing for the experiment notes and prints the public link instead of the notes content.
- New `util/share.py` helper (`ensure_share_link`):
  - **Reuses the active link** — GETs first and only mints (POST) when sharing is off, so repeated `--share` calls return the same URL and never break links already sent to people (minting rotates server-side).
  - **Confirmation before publishing** — minting a *new* public link prompts ("Anyone with the link can view it"), matching the `job delete` pattern. Reusing an existing link never prompts; the global `--no-interactive` flag skips it and `--format json` implies it, so agent workflows stay non-interactive.
  - With `--format json`, share output is `{"url", "token", "created_at"}` (errors: `{"error", "status_code"}`).
- Friendly errors on older servers that lack the chart or share endpoints; surfaces server detail messages for no-data/bad-metric errors; `--format json` prints `{"saved": path}` for the PNG.

## Docs

- Documented both commands in the local `transformerlab-cli` agent skill (`SKILL.md` + `references/commands.md`) and `docs/cli.md`.

## Sample output

The rendered chart mirrors the web UI: best-so-far step line, green best runs, blue scored runs, gray discarded runs, `Score (<metric>)` vs Date axes.

## Testing

- `api/test/services/test_job_chart_service.py`: 32 tests covering score/discard parsing, metric auto-detection, best-so-far in both directions, PNG rendering, and service error cases — all passing.
- `cli/tests/commands/test_job.py` + `test_notes.py`: 15 new tests — chart export (file write, query-param forwarding for both flag directions, no-data error, old-server 404) and sharing (mint when none active, reuse without rotating, prompt declined/accepted, `--share -o` combined, missing both flags, old-server 404, json output for both commands). Full CLI suite passes (395 passed, 4 skipped).
- `ruff check` + `ruff format` clean on all changed Python files.
- Visually verified a rendered sample chart matches the web chart's design.