### PR TITLE
Fix command to install skill to work on windows

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab-cli"
-version = "0.0.63"
+version = "0.0.64"
 description = "Transformer Lab CLI"
 requires-python = ">=3.10"
 authors = [{ name = "Transformer Lab", email = "hello@transformerlab.ai" }]

--- a/cli/src/transformerlab_cli/commands/install_agent_skill.py
+++ b/cli/src/transformerlab_cli/commands/install_agent_skill.py
@@ -25,7 +25,12 @@ def install_agent_skill() -> None:
     telemetry.init()
     telemetry.incr("install_agent_skill.start")
 
-    if shutil.which("npx") is None:
+    # Resolve the full path to `npx`. On Windows `npx` is a `.cmd` shim, and
+    # `subprocess.run(["npx", ...])` (without shell=True) calls CreateProcess,
+    # which does not honor PATHEXT and fails with WinError 2. Passing the
+    # resolved path (e.g. `...\npx.cmd`) from shutil.which lets it launch.
+    npx_path = shutil.which("npx")
+    if npx_path is None:
         console.print(
             "[error]Error:[/error] `npx` was not found on PATH.\n"
             "[dim]`npx` ships with Node.js. Install Node.js from https://nodejs.org "
@@ -35,12 +40,13 @@ def install_agent_skill() -> None:
         telemetry.flush()
         raise typer.Exit(1)
 
+    command = [npx_path, *SKILL_COMMAND[1:]]
     pretty_command = " ".join(SKILL_COMMAND)
     console.print(f"\n[info]Running:[/info] [bold]{pretty_command}[/bold]\n")
     telemetry.breadcrumb("install_agent_skill_start")
 
     try:
-        process = subprocess.run(SKILL_COMMAND, stdout=sys.stdout, stderr=sys.stderr)
+        process = subprocess.run(command, stdout=sys.stdout, stderr=sys.stderr)
     except KeyboardInterrupt:
         console.print("\n[warning]Installation interrupted.[/warning]")
         telemetry.incr("install_agent_skill.completed", exit_code="130")

--- a/cli/tests/commands/test_install_agent_skill.py
+++ b/cli/tests/commands/test_install_agent_skill.py
@@ -23,10 +23,30 @@ def test_install_agent_skill_success():
     assert result.exit_code == 0
     args, _ = mock_run.call_args
     cmd = args[0]
-    assert cmd[:3] == ["npx", "skills", "add"]
+    # The executable is the resolved path from shutil.which (not the bare "npx"),
+    # so subprocess can launch the npx.cmd shim on Windows.
+    assert cmd[0] == "/usr/local/bin/npx"
+    assert cmd[1:3] == ["skills", "add"]
     assert "transformerlab/transformerlab-app" in cmd
     assert cmd[-2:] == ["--skill", "transformerlab-cli"]
     assert "successfully" in result.output.lower()
+
+
+def test_install_agent_skill_uses_resolved_npx_path():
+    """Regression for Windows WinError 2: subprocess must receive the full path
+    returned by shutil.which (e.g. npx.cmd), not the bare `npx` token, otherwise
+    CreateProcess cannot resolve the .cmd shim via PATHEXT."""
+    resolved = r"C:\Program Files\nodejs\npx.cmd"
+    mock_proc = MagicMock(returncode=0)
+    with (
+        patch(f"{_MODULE}.shutil.which", return_value=resolved),
+        patch(f"{_MODULE}.subprocess.run", return_value=mock_proc) as mock_run,
+    ):
+        result = runner.invoke(app, ["install-agent-skill"])
+
+    assert result.exit_code == 0
+    args, _ = mock_run.call_args
+    assert args[0][0] == resolved
 
 
 def test_install_agent_skill_npx_missing():

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -557,7 +557,7 @@ wheels = [
 
 [[package]]
 name = "transformerlab-cli"
-version = "0.0.63"
+version = "0.0.64"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Alternatively, I could try this (resolving full path) inside the `if npx_path is None:` block if we don't want to mess with the default case.

(I think this fixes the issue one of our users had earlier today trying to install the skill on powershell on windows so he could connect to a remote server)

<img width="1380" height="312" alt="image-1781140519708" src="https://github.com/user-attachments/assets/5d49a029-c363-4612-b43a-8147454df44e" />
