### PR TITLE
Bump nebius to latest patch version

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "fastapi-users[sqlalchemy,oauth]==15.0.5",
   "httpx-oauth==0.16.1",
   "matplotlib==3.10.9",
-  "nebius==0.3.80",
+  "nebius==0.3.83",
   "packaging==26.2",
   "psutil==7.2.2",
   "pydantic>=2.13.4,<3.0",


### PR DESCRIPTION
Breaking out a simple safe bump to deal with current dependabot issue.