### PR TITLE
Recover RunPod pods when create-pod returns a 5xx

### DIFF
--- a/api/test/test_runpod_provider.py
+++ b/api/test/test_runpod_provider.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from transformerlab.compute_providers.runpod import RunpodProvider
 from transformerlab.compute_providers.models import ClusterConfig
@@ -35,3 +36,47 @@ class TestSpot:
             provider.launch_cluster("my-cluster", ClusterConfig(run="train.py", accelerators="RTX3090:1"))
         pod_data = mock_req.call_args.kwargs["json_data"]
         assert "interruptible" not in pod_data
+
+
+def _http_error(status_code):
+    """Build an HTTPError whose response carries the given status code (as raise_for_status does)."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = "Internal Server Error"
+    return requests.exceptions.HTTPError(f"{status_code} Server Error", response=response)
+
+
+class TestCreateRecovery:
+    """RunPod's create-pod endpoint can return a 5xx even though the pod was created (broken
+    server-side read-back). We recover by looking the pod up by name."""
+
+    def test_recovers_pod_on_500(self, provider):
+        with (
+            patch.object(provider, "_make_request", side_effect=_http_error(500)),
+            patch.object(provider, "_find_pod_by_name", return_value={"id": "pod-recovered"}) as mock_find,
+        ):
+            result = provider.launch_cluster("my-cluster", ClusterConfig(run="train.py", accelerators="H100:8"))
+
+        assert result["pod_id"] == "pod-recovered"
+        assert result["request_id"] == "pod-recovered"
+        mock_find.assert_called_with("my-cluster")
+        # Recovered pod should be cached for later lookups.
+        assert provider._cluster_name_to_pod_id["my-cluster"] == "pod-recovered"
+
+    def test_raises_on_500_when_pod_not_found(self, provider):
+        with (
+            patch.object(provider, "_make_request", side_effect=_http_error(500)),
+            patch.object(provider, "_find_pod_by_name", return_value=None),
+            patch("transformerlab.compute_providers.runpod.time.sleep"),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to create pod"):
+                provider.launch_cluster("my-cluster", ClusterConfig(run="train.py", accelerators="H100:8"))
+
+    def test_does_not_attempt_recovery_on_4xx(self, provider):
+        with (
+            patch.object(provider, "_make_request", side_effect=_http_error(400)),
+            patch.object(provider, "_find_pod_by_name") as mock_find,
+        ):
+            with pytest.raises(RuntimeError, match="Failed to create pod"):
+                provider.launch_cluster("my-cluster", ClusterConfig(run="train.py", accelerators="H100:8"))
+        mock_find.assert_not_called()

--- a/api/transformerlab/compute_providers/runpod.py
+++ b/api/transformerlab/compute_providers/runpod.py
@@ -3,6 +3,7 @@
 import asyncio
 import io
 import logging
+import time
 from typing import Dict, Any, Optional, Union, List
 
 import requests
@@ -486,10 +487,49 @@ class RunpodProvider(ComputeProvider):
             else:
                 return {"pod_id": None, "request_id": None, "response": result}
         except requests.exceptions.HTTPError as e:
+            # RunPod's create-pod endpoint has a known server-side bug: it creates the pod, then
+            # fails on its own read-back query (a broken SQL join referencing a non-existent
+            # `NetworkVolume.userId` column), returning a 500 even though the pod now exists. When we
+            # get a 5xx, the pod may well be running and billing, so look it up by name before giving
+            # up. See https://github.com/runpod/runpodctl/issues/172.
+            status_code = getattr(e.response, "status_code", None)
+            if status_code is not None and status_code >= 500:
+                recovered = self._recover_pod_after_error(cluster_name)
+                if recovered:
+                    pod_id = recovered.get("id")
+                    logger.warning(
+                        "RunPod create-pod returned %s but pod '%s' (%s) was created; recovered via lookup.",
+                        status_code,
+                        cluster_name,
+                        pod_id,
+                    )
+                    self._cluster_name_to_pod_id[cluster_name] = pod_id
+                    return {"pod_id": pod_id, "request_id": pod_id}
+
             error_msg = f"Failed to create pod: {e}"
             if hasattr(e.response, "text"):
                 error_msg += f" - {e.response.text}"
             raise RuntimeError(error_msg) from e
+
+    def _recover_pod_after_error(
+        self, cluster_name: str, attempts: int = 3, delay_seconds: float = 2.0
+    ) -> Optional[Dict[str, Any]]:
+        """
+        After a 5xx from create-pod, RunPod may have created the pod despite the error response.
+        Poll the pod list by name (with a few retries to absorb listing lag) and return the pod
+        dict if one with a usable ID shows up, else None.
+        """
+        for attempt in range(attempts):
+            try:
+                pod = self._find_pod_by_name(cluster_name)
+            except Exception as lookup_error:  # noqa: BLE001 - best-effort recovery, never mask original error
+                logger.warning("Error looking up pod '%s' during recovery: %s", cluster_name, lookup_error)
+                pod = None
+            if pod and pod.get("id"):
+                return pod
+            if attempt < attempts - 1:
+                time.sleep(delay_seconds)
+        return None
 
     def stop_cluster(self, cluster_name: str) -> Dict[str, Any]:
         """Stop/terminate a pod."""


### PR DESCRIPTION
RunPod's POST /v1/pods has a server-side bug: it creates the pod, then
fails on its own read-back query (a broken SQL join referencing a
non-existent NetworkVolume.userId column) and returns a 500 even though
the pod is now running and billing. This left launches failing while
leaving orphaned pods behind.

When create-pod returns a 5xx, look the pod up by name before giving up
(retrying a few times to absorb listing lag). If it exists, cache the
mapping and return it as a normal success. 4xx errors still raise
immediately without attempting recovery.

Adds TestCreateRecovery covering the 500-recovered, 500-not-found, and
4xx-no-recovery paths.
