### PR TITLE
blog: link 'coming soon' papers to their /papers pages

### DIFF
--- a/transformerlab-docs/blog/2026-06-16-judging-single-image-3d/index.mdx
+++ b/transformerlab-docs/blog/2026-06-16-judging-single-image-3d/index.mdx
@@ -68,4 +68,4 @@ This is a scoped result, not a universal law. We tested two feed-forward generat
 
 ## Links
 
-The full paper is on its way — we'll add the arXiv link here as soon as it's published.
+The full paper is here: [A Cross-Model VLM-Judge Protocol for Single-Image 3D Mesh Quality](/papers/cross-model-vlm-judge).

--- a/transformerlab-docs/blog/2026-06-16-self-verification-codec-tts/index.mdx
+++ b/transformerlab-docs/blog/2026-06-16-self-verification-codec-tts/index.mdx
@@ -93,4 +93,4 @@ The whole study ran on Transformer Lab and cost on the order of 45 GPU-hours end
 
 ## Links
 
-The full paper is on its way — we'll add the arXiv link here as soon as it's published.
+The full paper is here: [Reliable Neural-Codec Text-to-Speech by ASR Self-Verification and Distillation](/papers/reliable-neural-codec-tts).

--- a/transformerlab-docs/blog/2026-06-18-how-i-built-self-driving-ai/index.mdx
+++ b/transformerlab-docs/blog/2026-06-18-how-i-built-self-driving-ai/index.mdx
@@ -142,4 +142,4 @@ For academia and industry this project proves that you CAN use ViT models on sma
 
 ## You can try this too
 
-If people are interested, I can upload the code for the end working project on Github. Full paper is on its way too; I'll add the arXiv link here as soon as it's published.
+If people are interested, I can upload the code for the end working project on Github. The full paper is here: [It's the Adaptation, Not the Architecture](/papers/adaptation-not-architecture).

--- a/transformerlab-docs/blog/2026-06-19-abstain-from-your-own-doubt/index.mdx
+++ b/transformerlab-docs/blog/2026-06-19-abstain-from-your-own-doubt/index.mdx
@@ -86,4 +86,4 @@ The whole study, covering six models across two families (Llama and Qwen3, from 
 
 If you want to try the idea on your own model, the ingredients are: greedily decode answers, record the average log-probability over each answer, pick a cutoff, relabel the low-confidence half to "I'm not sure," and LoRA-fine-tune. That's the whole thing.\_
 
-_arXiv link to the full paper will be shared here as soon as it's published._
+_Full paper: [Can a Model Catch Its Own Hallucinations for Free?](/papers/label-free-doubt-signals)._

--- a/transformerlab-docs/blog/2026-06-22-moe-modularity/index.mdx
+++ b/transformerlab-docs/blog/2026-06-22-moe-modularity/index.mdx
@@ -80,6 +80,6 @@ The whole study reproduces from a public model and public data. We release the e
 
 Repo: [github.com/transformerlab/exp-command-a-plus-moe-modularity](https://github.com/transformerlab/exp-command-a-plus-moe-modularity)
 
-Full paper on arXiv coming soon.
+Full paper: [How Modular Is a Frontier Mixture-of-Experts?](/papers/expert-modularity-dissolves)
 
 _Built on Cohere's Command A+, openly available under Apache-2.0. We do not redistribute the model._


### PR DESCRIPTION
## Summary

Five blog posts in `transformerlab-docs/blog/` promised a paper link that was "coming soon" / "to be shared once published." Each of those papers now exists in the `/papers` section, so this PR replaces the placeholder text with the matching link.

| Blog | Now links to |
|------|--------------|
| `2026-06-22-moe-modularity` | [expert-modularity-dissolves](/papers/expert-modularity-dissolves) |
| `2026-06-16-self-verification-codec-tts` | [reliable-neural-codec-tts](/papers/reliable-neural-codec-tts) |
| `2026-06-18-how-i-built-self-driving-ai` | [adaptation-not-architecture](/papers/adaptation-not-architecture) |
| `2026-06-19-abstain-from-your-own-doubt` | [label-free-doubt-signals](/papers/label-free-doubt-signals) |
| `2026-06-16-judging-single-image-3d` | [cross-model-vlm-judge](/papers/cross-model-vlm-judge) |

## Notes

- Each match was verified against the paper title in `src/data/papers.json`; all five slugs resolve to existing paper pages.
- Linked to internal `/papers/<slug>` pages (matching the existing pattern in the `does-the-prior-pay-off` and `reward-maximization` blogs) since these papers don't have arXiv IDs yet.
- Left untouched the two non-paper "coming soon" mentions (workflows feature in `diffusion-support`, evaluation feature in `codeTuning`).
- Confirmed the two related 3D-judge blogs aren't crossed: the companion `judging-to-improve-3d` blog already links to the `judging-to-improve` paper.