### PR TITLE
blog: clarify parsimony vs the λ dial in symbolic-regression post

### DIFF
--- a/transformerlab-docs/blog/2026-06-23-what-steers-the-search-in-rl-symbolic-regression/index.mdx
+++ b/transformerlab-docs/blog/2026-06-23-what-steers-the-search-in-rl-symbolic-regression/index.mdx
@@ -68,14 +68,16 @@ the model is trained to raise):
 
 - **Fit**: how well the equation predicts held-out data points it was not fit on. Higher is
   better.
-- **Parsimony**: how short and simple the equation is. We penalize size, because a giant
-  tangled formula that happens to fit is not a "law."
+- **Parsimony**: a preference for short, simple equations. A giant tangled formula that
+  happens to fit the numbers is not a "law," so the reward docks points for size.
 
-So the reward is roughly `fit − λ·complexity`. That little `λ` (lambda) is the **simplicity
-penalty**: a single number that says how much we punish a longer equation. Parsimony, the
-simplicity penalty, and λ are three names for this one dial. Crank it up and the model is
-told, in effect, "keep it short." Set it to zero and the model is free to write sprawling
-expressions if they fit.
+So the reward is roughly `fit − λ·complexity`. It helps to keep two things separate here.
+**Parsimony** is the _principle_ — favor the shortest law that explains the data. **λ**
+(lambda), the **simplicity penalty**, is the _dial that enforces it_: a single number setting
+how steeply each extra piece of the equation costs the model. Crank λ up and the model is
+told, in effect, "keep it short," even when a longer formula would fit a little better. Set it
+to zero and the model is free to write sprawling expressions, as long as they match the data.
+That dial is the lever this whole study turns on.
 
 There is no human grader and no learned judge anywhere in this loop. The reward is computed
 exactly, by checking the equation against data and counting its parts. That makes it a clean


### PR DESCRIPTION
## What

Tightens the parsimony explanation in the RL symbolic-regression blog post (`What steers the search…`). The original "How the model gets a score" section read oddly because it flattened three distinct things into one:

> ~~"Parsimony, the simplicity penalty, and λ are three names for this one dial."~~

## Why

Per the paper (*Parsimony, Not the Clip*), these are not synonyms:
- **Parsimony** is the *principle* — favor the shortest law that explains the data.
- **complexity** is the measured *size* of an equation.
- **λ** (the *simplicity penalty*) is the *dial* that sets how steeply size is penalized, via `fit − λ·complexity`.

Calling parsimony "a name for a dial" muddles the principle with the lever — and that principle-vs-dial distinction is the spine of the paper ("λ cleanly and monotonically sets the operating point on the accuracy–parsimony frontier").

## Change
- Reframes the **Parsimony** bullet as a preference/principle rather than the penalty itself.
- Cleanly splits principle from dial, and adds a tradeoff beat (high λ keeps things short "even when a longer formula would fit a little better").
- Closes with "That dial is the lever this whole study turns on" to bring the parsimony point forward as the headline mechanism.

Prose-only change; Prettier clean. Stacked on `blog/symbolreg-braininterp` so the diff shows only the wording change.