### PR TITLE
Create env var to set sentry sample rates

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -217,12 +217,12 @@ if os.getenv("SENTRY_DSN"):
             integrations=[FastApiIntegration()],
             # Enable sending logs to Sentry
             enable_logs=True,
-            # Set traces_sample_rate to 1.0 to capture 100%
-            # of transactions for tracing.
-            traces_sample_rate=1.0,
-            # Set profile_session_sample_rate to 1.0 to profile 100%
-            # of profile sessions.
-            profile_session_sample_rate=1.0,
+            traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "1.0")),
+            # The profiler samples frames across threads, which can segfault the
+            # interpreter on Python 3.11 (frame_getback race, e.g.
+            # https://github.com/getsentry/sentry-python/issues/2386), so it is
+            # off unless explicitly enabled.
+            profile_session_sample_rate=float(os.getenv("SENTRY_PROFILE_SESSION_SAMPLE_RATE", "0.0")),
             # Set profile_lifecycle to "trace" to automatically
             # run the profiler on when there is an active transaction
             profile_lifecycle="trace",

--- a/api/run.sh
+++ b/api/run.sh
@@ -127,6 +127,10 @@ fi
 # Temporary: Turn off python buffering or debug output made by print() may not show up in logs
 export PYTHONUNBUFFERED=1
 
+# Print the Python traceback of the crashing thread if the interpreter dies on a
+# fatal signal (e.g. segfault), so crashes are diagnosable from the service logs
+export PYTHONFAULTHANDLER=1
+
 UVICORN_WORKERS=${TFL_UVICORN_WORKERS:-1}
 
 echo "▶️ Running one-time startup tasks before workers"


### PR DESCRIPTION
This also sets PYTHONFAULTHANDLER in run.sh so we get a traceback on crashes.