### PR TITLE
Add missing await to job service

### DIFF
--- a/api/transformerlab/services/job_service.py
+++ b/api/transformerlab/services/job_service.py
@@ -842,7 +842,7 @@ async def get_artifacts_from_sdk(job_id: str, experiment_id: str) -> Optional[Li
             return None
 
         sdk_job = Job(job_id, experiment_id)
-        artifact_paths = sdk_job.get_artifact_paths()
+        artifact_paths = await sdk_job.get_artifact_paths()
 
         if not artifact_paths:
             return None


### PR DESCRIPTION
Was causing an error in transformerlab.log on beta.lab.cloud:

```
SDK artifact method failed for job 4043e4a8-4f2f-4f69-9cc0-6b893ec5e130: 'coroutine' object is not iterable
/home/transformerlab/transformerlab-app/api/transformerlab/services/job_service.py:912: RuntimeWarning: coroutine 'Job.get_artifact_paths' was never a
waited
  sdk_artifacts = await get_artifacts_from_sdk(job_id, experiment_id)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```