### PR TITLE
Add support for reservation ID to AWS provider

### DIFF
--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -552,10 +552,33 @@ if [ -x /root/.local/bin/uvx ]; then cp /root/.local/bin/uvx /usr/local/bin/uvx 
                 }
             ]
 
-        # Spot instances: MarketType "spot" with default (one-time, terminate) behavior,
-        # which suits ephemeral job VMs. No SpotOptions => no max price (pay up to on-demand).
-        if config.use_spot:
+        # Capacity reservation targeting. Read from first-class ClusterConfig fields, falling back
+        # to provider_config so callers can set it without a schema change. General across reservation
+        # kinds (ODCR or Capacity Block); see ClusterConfig for semantics.
+        pc = config.provider_config or {}
+        reservation_id = config.capacity_reservation_id or pc.get("capacity_reservation_id")
+        reservation_type = config.capacity_reservation_type or pc.get("capacity_reservation_type") or "on-demand"
+
+        # Spot instances: MarketType "spot" with default (one-time, terminate) behavior, which suits
+        # ephemeral job VMs. No SpotOptions => no max price (pay up to on-demand). Spot and a capacity
+        # reservation are mutually exclusive — a reservation targets guaranteed on-demand/block capacity,
+        # so it takes precedence over use_spot.
+        if config.use_spot and not reservation_id:
             launch_params["InstanceMarketOptions"] = {"MarketType": "spot"}
+
+        if reservation_id:
+            # Target the reserved slot instead of open on-demand capacity. This is what lets a booked
+            # Capacity Block (or ODCR) actually be consumed — an untargeted on-demand launch would ignore
+            # the reservation and can still fail with InsufficientInstanceCapacity.
+            launch_params["CapacityReservationSpecification"] = {
+                "CapacityReservationTarget": {"CapacityReservationId": reservation_id}
+            }
+            if reservation_type == "capacity-block":
+                # Capacity Blocks must be launched with the capacity-block instance-market type.
+                launch_params["InstanceMarketOptions"] = {"MarketType": "capacity-block"}
+            # The instance must launch in the reservation's Availability Zone. Honor an explicit zone.
+            if config.zone:
+                launch_params["Placement"] = {"AvailabilityZone": config.zone}
 
         # IAM instance profiles are eventually consistent. Retry on the specific
         # propagation error so freshly-created profiles don't cause launch failures.

--- a/api/transformerlab/compute_providers/models.py
+++ b/api/transformerlab/compute_providers/models.py
@@ -47,6 +47,18 @@ class ClusterConfig(BaseModel):
     zone: Optional[str] = None
     use_spot: bool = False
 
+    # Capacity reservation targeting (currently honored by the AWS provider). General across
+    # reservation kinds so this works for future reservation use, not just Capacity Blocks:
+    #   - capacity_reservation_id: a reservation id ("cr-..."). Applies to an On-Demand Capacity
+    #     Reservation (ODCR) or a Capacity Block. When set, launches target the *reserved* slot
+    #     instead of open on-demand capacity — i.e. capacity is guaranteed for the reservation's
+    #     lifetime, so repeated ephemeral launches into it don't hit InsufficientInstanceCapacity.
+    #   - capacity_reservation_type: "capacity-block" for a Capacity Block (which additionally
+    #     requires the capacity-block instance-market type); omit/"on-demand" for an ODCR.
+    # NOTE: the instance's AZ must match the reservation's AZ; set `zone` accordingly.
+    capacity_reservation_id: Optional[str] = None
+    capacity_reservation_type: Optional[str] = None  # "capacity-block" | "on-demand" (default)
+
     # Container / VM image override (SkyPilot only).
     # Use "docker:<image>" for Docker containers, e.g. "docker:nvcr.io/nvidia/pytorch:23.10-py3".
     image_id: Optional[str] = None


### PR DESCRIPTION
Naive addition to support reservation ID so I can use a capacity block on AWS.

I am not sure if this is a good way to do this. Setting as draft for now and then I will consider if there is a better generalized pattern to add to the root model before setting to ready.
