### PR TITLE
Terminate AWS VMs on all job finished cases

### DIFF
--- a/api/test/api/test_remote_job_status_service.py
+++ b/api/test/api/test_remote_job_status_service.py
@@ -36,12 +36,15 @@ def _make_job(
     cluster_name: str = "cluster-abc",
     live_status: str | None = None,
     workspace_dir: str | None = None,
+    provider_type: str | None = None,
 ) -> dict:
     job_data: dict = {"provider_id": provider_id, "cluster_name": cluster_name}
     if live_status:
         job_data["live_status"] = live_status
     if workspace_dir:
         job_data["workspace_dir"] = workspace_dir
+    if provider_type:
+        job_data["provider_type"] = provider_type
     return {
         "id": job_id,
         "type": job_type,
@@ -201,6 +204,90 @@ async def test_handle_live_status_crashed_interactive_subtype_transitions_failed
     result = await _handle_live_status(job, "exp-1")
     assert result is True
     assert ("status", "job-1", "FAILED") in calls
+
+
+@pytest.mark.asyncio
+async def test_handle_live_status_finished_vm_per_job_provider_stops_cluster(monkeypatch):
+    """VM-per-job providers (e.g. AWS) must have their VM torn down on normal
+    completion, not only on crash — in-instance self-termination alone can fail
+    silently and leak instances."""
+    job = _make_job(live_status="Remote command finished", provider_type="aws")
+
+    calls = []
+
+    async def fake_update_kv(job_id, key, value, exp_id):
+        calls.append(("kv", job_id, key))
+
+    async def fake_update_status(job_id, status, experiment_id=None):
+        calls.append(("status", job_id, status))
+
+    monkeypatch.setattr(
+        remote_job_status_service.job_service,
+        "job_update_job_data_insert_key_value",
+        fake_update_kv,
+    )
+    monkeypatch.setattr(
+        remote_job_status_service.job_service,
+        "job_update_status",
+        fake_update_status,
+    )
+    stop_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(remote_job_status_service, "_best_effort_stop_cluster_for_job", stop_mock)
+
+    result = await _handle_live_status(job, "exp-1")
+
+    assert result is True
+    assert ("status", "job-1", "COMPLETE") in calls
+    stop_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_live_status_finished_shared_cluster_provider_does_not_stop(monkeypatch):
+    """SkyPilot/SLURM clusters are not per-job VMs; normal completion must not stop them."""
+    job = _make_job(live_status="Remote command finished", provider_type="skypilot")
+
+    monkeypatch.setattr(
+        remote_job_status_service.job_service,
+        "job_update_job_data_insert_key_value",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        remote_job_status_service.job_service,
+        "job_update_status",
+        AsyncMock(return_value=None),
+    )
+    stop_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(remote_job_status_service, "_best_effort_stop_cluster_for_job", stop_mock)
+
+    result = await _handle_live_status(job, "exp-1")
+
+    assert result is True
+    stop_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_live_status_crashed_vm_per_job_provider_stops_cluster_once(monkeypatch):
+    """On crash the cluster is already stopped by the crash path; the VM-per-job
+    teardown must not call stop a second time."""
+    job = _make_job(live_status="Remote command crashed", provider_type="aws")
+
+    monkeypatch.setattr(
+        remote_job_status_service.job_service,
+        "job_update_job_data_insert_key_value",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        remote_job_status_service.job_service,
+        "job_update_status",
+        AsyncMock(return_value=None),
+    )
+    stop_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(remote_job_status_service, "_best_effort_stop_cluster_for_job", stop_mock)
+
+    result = await _handle_live_status(job, "exp-1")
+
+    assert result is True
+    stop_mock.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -332,21 +332,6 @@ class TestLaunchCluster:
         call_kwargs = mock_ec2.run_instances.call_args[1]
         assert call_kwargs["BlockDeviceMappings"][0]["Ebs"]["VolumeSize"] == 200
 
-    def test_shutdown_behavior_is_terminate(self, provider):
-        """An OS shutdown must terminate the instance — the self-terminate trap's
-        fallback path relies on this when the AMI has no aws CLI."""
-        mock_ec2 = self._make_mock_ec2()
-        with (
-            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
-            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
-            patch.object(
-                provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"
-            ),
-        ):
-            provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
-        call_kwargs = mock_ec2.run_instances.call_args[1]
-        assert call_kwargs["InstanceInitiatedShutdownBehavior"] == "terminate"
-
     def test_no_block_device_when_disk_size_not_set(self, provider):
         mock_ec2 = self._make_mock_ec2()
         with (
@@ -569,21 +554,6 @@ class TestUserDataScript:
         term_lines = [line for line in user_data.splitlines() if "terminate-instances" in line]
         assert len(term_lines) == 1
         assert "|| true" in term_lines[0]
-
-    def test_self_termination_guards_on_aws_cli_presence(self):
-        """The terminate call must be gated on the aws CLI existing, not assumed."""
-        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
-        guard_lines = [line for line in user_data.splitlines() if '[ -n "$_iid" ]' in line]
-        assert len(guard_lines) == 1
-        assert "command -v aws" in guard_lines[0]
-
-    def test_self_termination_has_shutdown_fallback(self):
-        """The trap must fall back to an OS shutdown (instance launches with
-        InstanceInitiatedShutdownBehavior=terminate), so termination works even
-        without the aws CLI — the stock Ubuntu CPU AMIs do not ship it."""
-        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
-        trap_body = user_data.split("_tfl_self_terminate()")[1].split("trap _tfl_self_terminate")[0]
-        assert "shutdown -h now" in trap_body
 
     def test_installs_awscli_when_missing(self):
         """CPU-only jobs run on stock Ubuntu AMIs without awscli; user-data must install it."""

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -332,6 +332,21 @@ class TestLaunchCluster:
         call_kwargs = mock_ec2.run_instances.call_args[1]
         assert call_kwargs["BlockDeviceMappings"][0]["Ebs"]["VolumeSize"] == 200
 
+    def test_shutdown_behavior_is_terminate(self, provider):
+        """An OS shutdown must terminate the instance — the self-terminate trap's
+        fallback path relies on this when the AMI has no aws CLI."""
+        mock_ec2 = self._make_mock_ec2()
+        with (
+            patch.object(provider, "_get_ec2_client", return_value=mock_ec2),
+            patch("transformerlab.compute_providers.aws.asyncio.run", return_value="ssh-ed25519 AAAA"),
+            patch.object(
+                provider, "_ensure_iam_instance_profile", return_value="arn:aws:iam::123:instance-profile/tfl"
+            ),
+        ):
+            provider.launch_cluster("my-cluster", ClusterConfig(run="train.py"))
+        call_kwargs = mock_ec2.run_instances.call_args[1]
+        assert call_kwargs["InstanceInitiatedShutdownBehavior"] == "terminate"
+
     def test_no_block_device_when_disk_size_not_set(self, provider):
         mock_ec2 = self._make_mock_ec2()
         with (
@@ -554,6 +569,32 @@ class TestUserDataScript:
         term_lines = [line for line in user_data.splitlines() if "terminate-instances" in line]
         assert len(term_lines) == 1
         assert "|| true" in term_lines[0]
+
+    def test_self_termination_guards_on_aws_cli_presence(self):
+        """The terminate call must be gated on the aws CLI existing, not assumed."""
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
+        guard_lines = [line for line in user_data.splitlines() if '[ -n "$_iid" ]' in line]
+        assert len(guard_lines) == 1
+        assert "command -v aws" in guard_lines[0]
+
+    def test_self_termination_has_shutdown_fallback(self):
+        """The trap must fall back to an OS shutdown (instance launches with
+        InstanceInitiatedShutdownBehavior=terminate), so termination works even
+        without the aws CLI — the stock Ubuntu CPU AMIs do not ship it."""
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
+        trap_body = user_data.split("_tfl_self_terminate()")[1].split("trap _tfl_self_terminate")[0]
+        assert "shutdown -h now" in trap_body
+
+    def test_installs_awscli_when_missing(self):
+        """CPU-only jobs run on stock Ubuntu AMIs without awscli; user-data must install it."""
+        user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
+        install_lines = [line for line in user_data.splitlines() if "pip install -q awscli" in line]
+        assert len(install_lines) == 1
+        # Idempotent: skipped when the AMI (e.g. a DLAMI) already ships the CLI.
+        assert "command -v aws" in install_lines[0]
+        # The install must come after the venv PATH export so pip resolves.
+        venv_idx = user_data.index('export PATH="/opt/transformerlab-venv/bin:$PATH"')
+        assert user_data.index("pip install -q awscli") > venv_idx
 
 
 class TestStopCluster:

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -556,15 +556,17 @@ class TestUserDataScript:
         assert "|| true" in term_lines[0]
 
     def test_installs_awscli_when_missing(self):
-        """CPU-only jobs run on stock Ubuntu AMIs without awscli; user-data must install it."""
+        """CPU-only jobs run on stock Ubuntu AMIs without awscli; user-data must install
+        the official AWS CLI v2 bundle (pip awscli is v1 / maintenance mode)."""
         user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
-        install_lines = [line for line in user_data.splitlines() if "pip install -q awscli" in line]
-        assert len(install_lines) == 1
         # Idempotent: skipped when the AMI (e.g. a DLAMI) already ships the CLI.
-        assert "command -v aws" in install_lines[0]
-        # The install must come after the venv PATH export so pip resolves.
-        venv_idx = user_data.index('export PATH="/opt/transformerlab-venv/bin:$PATH"')
-        assert user_data.index("pip install -q awscli") > venv_idx
+        assert "if ! command -v aws" in user_data
+        # Official v2 bundle, installed via its bundled installer.
+        assert "awscli.amazonaws.com/awscli-exe-linux" in user_data
+        assert "/tmp/aws/install" in user_data
+        # The install must happen before the task's setup/run so the trap works
+        # even when the job command fails early.
+        assert user_data.index("/tmp/aws/install") < user_data.index("tee /workspace/run_logs.txt")
 
 
 class TestStopCluster:

--- a/api/test/test_aws_provider.py
+++ b/api/test/test_aws_provider.py
@@ -558,13 +558,16 @@ class TestUserDataScript:
     def test_installs_awscli_when_missing(self):
         """CPU-only jobs run on stock Ubuntu AMIs without awscli; user-data must install it."""
         user_data = AWSProvider._build_user_data(ClusterConfig(run="echo hello"), region="us-east-1")
-        install_lines = [line for line in user_data.splitlines() if "pip install -q awscli" in line]
-        assert len(install_lines) == 1
+        # Installs AWS CLI v2 via the official bundle, not the deprecated pip `awscli` (v1).
+        assert "pip install -q awscli" not in user_data
+        assert "awscli-exe-linux-x86_64.zip" in user_data
+        assert "awscli-exe-linux-aarch64.zip" in user_data
+        assert "/tmp/aws/install --update" in user_data
         # Idempotent: skipped when the AMI (e.g. a DLAMI) already ships the CLI.
-        assert "command -v aws" in install_lines[0]
-        # The install must come after the venv PATH export so pip resolves.
+        assert "if ! command -v aws >/dev/null 2>&1; then" in user_data
+        # The install must come after the venv PATH export.
         venv_idx = user_data.index('export PATH="/opt/transformerlab-venv/bin:$PATH"')
-        assert user_data.index("pip install -q awscli") > venv_idx
+        assert user_data.index("awscli-exe-linux-x86_64.zip") > venv_idx
 
 
 class TestStopCluster:

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -461,13 +461,9 @@ _tfl_self_terminate() {{
     -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null) || true
   _iid=$(curl -sf -H "X-aws-ec2-metadata-token: $_token" \
     "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null) || true
-  if [ -n "$_iid" ] && command -v aws >/dev/null 2>&1; then
+  if [ -n "$_iid" ]; then
     aws ec2 terminate-instances --instance-ids "$_iid" --region "{region}" >/dev/null 2>&1 || true
   fi
-  # Fallback: the instance launches with InstanceInitiatedShutdownBehavior=terminate,
-  # so an OS shutdown also terminates it even when the aws CLI is unavailable (e.g.
-  # the stock Ubuntu AMIs used for CPU-only jobs) or the API call fails.
-  shutdown -h now >/dev/null 2>&1 || true
   return 0
 }}
 trap _tfl_self_terminate EXIT
@@ -477,9 +473,9 @@ apt-get update -qq
 DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3 python3-venv python3-pip >/dev/null 2>&1
 python3 -m venv /opt/transformerlab-venv
 export PATH="/opt/transformerlab-venv/bin:$PATH"
-# The self-terminate trap prefers the aws CLI. The DLAMIs ship it, but the stock
-# Ubuntu AMIs used for CPU-only jobs do not — install it into the venv so the
-# primary terminate path works there too.
+# The self-terminate trap needs the aws CLI. The DLAMIs ship it, but the stock
+# Ubuntu AMIs used for CPU-only jobs do not — without this, the terminate call
+# fails silently (command-not-found swallowed by || true) and the instance leaks.
 command -v aws >/dev/null 2>&1 || pip install -q awscli >/dev/null 2>&1 || true
 # Install uv for task setups that use `uv pip ...`.
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -540,9 +536,6 @@ if [ -x /root/.local/bin/uvx ]; then cp /root/.local/bin/uvx /usr/local/bin/uvx 
             "SecurityGroupIds": [sg_id],
             "IamInstanceProfile": {"Arn": profile_arn},
             "UserData": user_data,
-            # Make an OS-level shutdown terminate (not stop) the instance. This is the
-            # self-terminate trap's fallback when the aws CLI is unavailable on the AMI.
-            "InstanceInitiatedShutdownBehavior": "terminate",
             "TagSpecifications": [
                 {
                     "ResourceType": "instance",

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -476,7 +476,18 @@ export PATH="/opt/transformerlab-venv/bin:$PATH"
 # The self-terminate trap needs the aws CLI. The DLAMIs ship it, but the stock
 # Ubuntu AMIs used for CPU-only jobs do not — without this, the terminate call
 # fails silently (command-not-found swallowed by || true) and the instance leaks.
-command -v aws >/dev/null 2>&1 || pip install -q awscli >/dev/null 2>&1 || true
+# Install AWS CLI v2 via the official bundle: the pip `awscli` package is v1,
+# which entered maintenance mode and is no longer the recommended install path.
+if ! command -v aws >/dev/null 2>&1; then
+  case "$(uname -m)" in
+    aarch64|arm64) _tfl_awscli_url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" ;;
+    *)             _tfl_awscli_url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" ;;
+  esac
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq unzip >/dev/null 2>&1 || true
+  (curl -sSL "$_tfl_awscli_url" -o /tmp/awscliv2.zip \
+    && unzip -q -o /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install --update) >/dev/null 2>&1 || true
+fi
 # Install uv for task setups that use `uv pip ...`.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$HOME/.local/bin:/root/.local/bin:/home/ubuntu/.local/bin:$PATH"

--- a/api/transformerlab/compute_providers/aws.py
+++ b/api/transformerlab/compute_providers/aws.py
@@ -461,9 +461,13 @@ _tfl_self_terminate() {{
     -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null) || true
   _iid=$(curl -sf -H "X-aws-ec2-metadata-token: $_token" \
     "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null) || true
-  if [ -n "$_iid" ]; then
+  if [ -n "$_iid" ] && command -v aws >/dev/null 2>&1; then
     aws ec2 terminate-instances --instance-ids "$_iid" --region "{region}" >/dev/null 2>&1 || true
   fi
+  # Fallback: the instance launches with InstanceInitiatedShutdownBehavior=terminate,
+  # so an OS shutdown also terminates it even when the aws CLI is unavailable (e.g.
+  # the stock Ubuntu AMIs used for CPU-only jobs) or the API call fails.
+  shutdown -h now >/dev/null 2>&1 || true
   return 0
 }}
 trap _tfl_self_terminate EXIT
@@ -473,6 +477,10 @@ apt-get update -qq
 DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3 python3-venv python3-pip >/dev/null 2>&1
 python3 -m venv /opt/transformerlab-venv
 export PATH="/opt/transformerlab-venv/bin:$PATH"
+# The self-terminate trap prefers the aws CLI. The DLAMIs ship it, but the stock
+# Ubuntu AMIs used for CPU-only jobs do not — install it into the venv so the
+# primary terminate path works there too.
+command -v aws >/dev/null 2>&1 || pip install -q awscli >/dev/null 2>&1 || true
 # Install uv for task setups that use `uv pip ...`.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$HOME/.local/bin:/root/.local/bin:/home/ubuntu/.local/bin:$PATH"
@@ -532,6 +540,9 @@ if [ -x /root/.local/bin/uvx ]; then cp /root/.local/bin/uvx /usr/local/bin/uvx 
             "SecurityGroupIds": [sg_id],
             "IamInstanceProfile": {"Arn": profile_arn},
             "UserData": user_data,
+            # Make an OS-level shutdown terminate (not stop) the instance. This is the
+            # self-terminate trap's fallback when the aws CLI is unavailable on the AMI.
+            "InstanceInitiatedShutdownBehavior": "terminate",
             "TagSpecifications": [
                 {
                     "ResourceType": "instance",

--- a/api/transformerlab/services/remote_job_status_service.py
+++ b/api/transformerlab/services/remote_job_status_service.py
@@ -184,6 +184,28 @@ async def _set_provider_empty_jobs_polls(
         )
 
 
+def _is_vm_per_job_provider(job: Dict[str, Any]) -> bool:
+    """Return True when the job's provider allocates one VM/pod per job.
+
+    For these providers the cluster IS the job's VM, so it must be torn down on
+    every terminal transition — there is no shared cluster to preserve.
+    """
+    from transformerlab.shared.models.models import ProviderType
+
+    job_data = job.get("job_data") or {}
+    if not isinstance(job_data, dict):
+        return False
+    return job_data.get("provider_type") in (
+        ProviderType.AWS.value,
+        ProviderType.AZURE.value,
+        ProviderType.GCP.value,
+        ProviderType.NEBIUS.value,
+        ProviderType.LAMBDA.value,
+        ProviderType.RUNPOD.value,
+        ProviderType.VASTAI.value,
+    )
+
+
 async def _handle_live_status(job: Dict[str, Any], experiment_id: str) -> bool:
     """Check job_data.live_status written by tfl-remote-trap (pure filesystem read).
 
@@ -201,6 +223,8 @@ async def _handle_live_status(job: Dict[str, Any], experiment_id: str) -> bool:
     job_id = str(job.get("id", ""))
     job_status = job.get("status", "")
 
+    stopped_cluster = False
+
     # Interactive sessions:
     # - allow FAILED only when live_status indicates a crash
     # - allow STOPPED when STOPPING (user requested stop)
@@ -208,6 +232,7 @@ async def _handle_live_status(job: Dict[str, Any], experiment_id: str) -> bool:
     if _is_interactive_subtype_job(job):
         if is_crashed:
             await _best_effort_stop_cluster_for_job(job)
+            stopped_cluster = True
             new_status = JobStatus.FAILED.value
         elif job_status == JobStatus.STOPPING.value:
             new_status = JobStatus.STOPPED.value if is_finished else JobStatus.FAILED.value
@@ -219,7 +244,16 @@ async def _handle_live_status(job: Dict[str, Any], experiment_id: str) -> bool:
     else:
         if is_crashed:
             await _best_effort_stop_cluster_for_job(job)
+            stopped_cluster = True
         new_status = JobStatus.COMPLETE.value if is_finished else JobStatus.FAILED.value
+
+    # VM-per-job providers: tear the VM down on every terminal transition, not just
+    # crashes. Normal completion otherwise relies solely on in-instance self-termination,
+    # which can fail silently (e.g. no aws CLI on the stock Ubuntu AMIs used for
+    # CPU-only AWS jobs) and leak instances. stop_cluster is safe to call when the
+    # instance is already gone.
+    if not stopped_cluster and _is_vm_per_job_provider(job):
+        await _best_effort_stop_cluster_for_job(job)
 
     try:
         end_time_str = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())


### PR DESCRIPTION
aws.py — the instance side (fixes 1 & 2):

- launch_cluster now passes InstanceInitiatedShutdownBehavior: "terminate" to run_instances, and the self-terminate trap ends with shutdown -h now. This is the bulletproof path: an OS shutdown terminates the instance with no dependency on the aws CLI, credentials, IMDS, or the IAM profile — it works no matter how broken the instance environment is.
- User-data installs awscli into the venv when the AMI doesn't ship it (command -v aws || pip install -q awscli), so the primary explicit-terminate path now works on the stock Ubuntu CPU AMIs too. The trap's aws call is also now gated on command -v aws rather than assuming it exists.

remote_job_status_service.py — the server side (fix 3):

- New _is_vm_per_job_provider() helper (aws, azure, gcp, nebius, lambda, runpod, vastai — the providers where the "cluster" is the job's VM).
- _handle_live_status now calls _best_effort_stop_cluster_for_job on every terminal transition for those providers — normal finish, lab.error() failures, and user stops — not just wrapper crashes. A stopped_cluster flag prevents double-stopping on the crash path, and SkyPilot/SLURM shared clusters are untouched.