### PR TITLE
Expanduser on TFL_STORAGE_URI so setting to ~/something works

### DIFF
--- a/api/localprovider_pyproject.toml
+++ b/api/localprovider_pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "soundfile==0.13.1",
   "tensorboardX==2.6.2.2",
   "timm==1.0.15",
-  "transformerlab==0.1.45",
+  "transformerlab==0.1.46",
   "transformerlab-inference==0.2.52",
   "transformers==4.57.1",
   "wandb==0.23.1",

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "python-dotenv==1.2.2",
   "python-multipart==0.0.32",
   "sqlalchemy[asyncio]==2.0.51",
-  "transformerlab==0.1.45",
+  "transformerlab==0.1.46",
   "transformerlab-inference==0.2.52",
   "uvicorn==0.35.0",
   "watchfiles==1.2.0",

--- a/cli/src/transformerlab_cli/commands/server.py
+++ b/cli/src/transformerlab_cli/commands/server.py
@@ -159,6 +159,9 @@ def _prompt_storage(existing: dict[str, str]) -> dict[str, str]:
     if provider == "localfs":
         default_path = existing.get("TFL_STORAGE_URI", "/data/transformerlab")
         storage_path = typer.prompt("Storage directory path", default=default_path)
+        # Expand ~ and normalize to an absolute path — a literal "~" in TFL_STORAGE_URI
+        # breaks downstream consumers that join/makedirs the raw value.
+        storage_path = os.path.abspath(os.path.expanduser(storage_path.strip()))
         env["TFL_STORAGE_URI"] = storage_path
     else:
         env["TFL_REMOTE_STORAGE_ENABLED"] = "true"

--- a/lab-sdk/pyproject.toml
+++ b/lab-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformerlab"
-version = "0.1.45"
+version = "0.1.46"
 description = "Python SDK for Transformer Lab"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/lab-sdk/src/lab/storage.py
+++ b/lab-sdk/src/lab/storage.py
@@ -123,6 +123,14 @@ _current_tfl_storage_uri: contextvars.ContextVar[str | None] = contextvars.Conte
 
 # Single source: aws | gcp | azure | localfs | juicefs (default aws for backward compatibility)
 STORAGE_PROVIDER = (os.getenv("TFL_STORAGE_PROVIDER") or "aws").strip().lower()
+
+# Normalize TFL_STORAGE_URI once at import: expand "~" for local filesystem paths so the
+# literal "~" never reaches consumers that read os.environ directly (dirs.py,
+# remote_workspace folder creation, launch-template env construction, ...). Remote URIs
+# (s3://, gs://, ...) never start with "~" so this only touches localfs paths.
+_env_storage_uri = os.getenv("TFL_STORAGE_URI")
+if _env_storage_uri and _env_storage_uri.startswith("~"):
+    os.environ["TFL_STORAGE_URI"] = os.path.expanduser(_env_storage_uri)
 _AWS_PROFILE = os.getenv("AWS_PROFILE", "transformerlab-s3")
 _GCP_PROJECT = os.getenv("GCP_PROJECT", "transformerlab-workspace")
 _AZURE_CONNECTION_STRING = os.getenv("AZURE_STORAGE_CONNECTION_STRING")


### PR DESCRIPTION
Currently when you install via the CLI and you intend to use local storage, it defaults to a path of something like `/data`.  This doesn't owrk on Mac (probably shoudl be a separate issue).  Without thinking I often put in something like `~/tlab_workspaces/` which ends up doing weird things because it doesn't expand the ~. 