### PR TITLE
Fix Azure cleanup to always get public IP

### DIFF
--- a/api/test/test_azure_provider.py
+++ b/api/test/test_azure_provider.py
@@ -500,20 +500,25 @@ class TestStopCluster:
             "transformerlab-abc", "transformerlab-pip-my-cluster"
         )
 
-    def test_pip_delete_skipped_when_nic_delete_keeps_failing(self, provider):
-        """If the NIC can't be removed, deleting the PIP would fail anyway; leave it to the sweep."""
+    def test_pip_delete_attempted_even_when_nic_delete_keeps_failing(self, provider):
+        """Regression: a NIC mid cascade-delete stays "in use" past our retries, then vanishes
+        on its own — the PIP must still be attempted or it leaks (seen in production)."""
         mock_cc = MagicMock()
         mock_nc = MagicMock()
         mock_cc.virtual_machines.begin_delete.return_value = MagicMock(result=MagicMock(return_value=None))
         mock_nc.network_interfaces.begin_delete.side_effect = Exception("NicInUse")
+        mock_nc.public_ip_addresses.begin_delete.side_effect = [
+            Exception("PublicIPAddressCannotBeDeleted: still referenced by the NIC"),
+            MagicMock(result=MagicMock(return_value=None)),
+        ]
         with (
             patch.object(provider, "_get_compute_client", return_value=mock_cc),
             patch.object(provider, "_get_network_client", return_value=mock_nc),
             patch("transformerlab.compute_providers.azure.time.sleep"),
         ):
             provider.stop_cluster("my-cluster")
-        assert mock_nc.network_interfaces.begin_delete.call_count == 6
-        mock_nc.public_ip_addresses.begin_delete.assert_not_called()
+        assert mock_nc.network_interfaces.begin_delete.call_count == 8
+        assert mock_nc.public_ip_addresses.begin_delete.call_count == 2
 
     def test_nic_and_pip_not_found_treated_as_success_without_retry(self, provider):
         mock_cc = MagicMock()

--- a/api/transformerlab/compute_providers/azure.py
+++ b/api/transformerlab/compute_providers/azure.py
@@ -88,8 +88,10 @@ _PIP_NAME_PREFIX = "transformerlab-pip-"
 
 # Azure only releases a NIC for deletion once its VM is fully gone, and a public IP
 # once its NIC is gone — both report "in use" errors for a while after the parent's
-# delete has already completed. Sleep this schedule between attempts.
-_NETWORK_DELETE_RETRY_DELAYS_SECONDS: tuple = (5, 10, 15, 30, 30)
+# delete has already completed. Sleep this schedule between attempts. The tail is
+# sized for the slowest observed case: a NIC can stay "in use" for ~3 minutes after
+# its VM's delete has finished.
+_NETWORK_DELETE_RETRY_DELAYS_SECONDS: tuple = (5, 10, 15, 30, 30, 60, 60)
 
 
 def _resolve_gpu_vm_size(accelerators: str) -> str:
@@ -264,9 +266,24 @@ class AzureProvider(ComputeProvider):
         pip_name = f"{_PIP_NAME_PREFIX}{cluster_name}"
         nic_gone = self._delete_network_resource_with_retries(network_client.network_interfaces.begin_delete, nic_name)
         if not nic_gone:
-            logger.warning("Skipping delete of %s because %s still exists and is holding it", pip_name, nic_name)
-            return
-        self._delete_network_resource_with_retries(network_client.public_ip_addresses.begin_delete, pip_name)
+            # Do NOT skip the public IP here. When the VM self-deleted, the NIC is
+            # usually mid cascade-delete (delete_option "Delete") and Azure holds it
+            # "in use" past our retry window — it then disappears on its own, so the
+            # public IP delete below succeeds on a later retry. Returning early in
+            # this state is what used to leak public IPs.
+            logger.warning(
+                "NIC %s still exists after all delete retries (likely mid cascade-delete); "
+                "attempting delete of %s anyway",
+                nic_name,
+                pip_name,
+            )
+        pip_gone = self._delete_network_resource_with_retries(network_client.public_ip_addresses.begin_delete, pip_name)
+        if not pip_gone:
+            logger.error(
+                "Public IP %s could not be deleted and is now orphaned; it will keep billing "
+                "until removed manually or by a later teardown",
+                pip_name,
+            )
 
     def _ensure_vm_self_delete_role(self, vm: Any) -> None:
         """Best-effort: grant VM identity rights to delete itself."""


### PR DESCRIPTION
Basically when a job's VM self-deletes, Azure cascade-deletes the NIC, but holds it "in use" for up to ~3 minutes. The control plane's cleanup would retry the NIC delete for only 90 seconds, give up, and then skip the public IP entirely ("because the NIC is still holding it").

This change no longer skips public IP cleanup when NIC fails, and also stretches out the time limit.
